### PR TITLE
docker: set `unpackerr` as entrypoint

### DIFF
--- a/init/docker/Dockerfile
+++ b/init/docker/Dockerfile
@@ -56,11 +56,11 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.licenses="${LICENSE}" \
       org.opencontainers.image.version="${VERSION}-${ITERATION}"
 
-COPY --from=builder /tmp/image /image
+COPY --from=builder /tmp/image /unpackerr
 # Make sure we have an ssl cert chain and timezone data.
 COPY --from=builder /etc/ssl /etc/ssl
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 ENV TZ=UTC
 
-ENTRYPOINT [ "/image" ]
+ENTRYPOINT [ "/unpackerr" ]


### PR DESCRIPTION
This avoids trying to figure out what's eating CPU in htop and related applications:

<img width="261" alt="Screenshot 2023-04-26 at 4 10 21 PM" src="https://user-images.githubusercontent.com/19761269/234551571-2235af6b-d3fd-427a-b94e-0aee89e813fb.png">
