### PR TITLE
Adds the extractednothing ExtractStatus

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+*.go text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Change this line.
 /unpackerr
 
+# JetBrains IDEs: GoLand, IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+.idea/*
+
 # The rest is probably fine.
 /init/macos/*.app/Contents/MacOS/*
 /rsrc*.syso

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -33,11 +33,12 @@ const (
 	DELETING
 	DELETEFAILED // unused
 	DELETED
+	EXTRACTEDNOTHING
 )
 
 // Desc makes ExtractStatus human readable.
 func (status ExtractStatus) Desc() string {
-	if status > DELETED {
+	if status > EXTRACTEDNOTHING {
 		return "Unknown"
 	}
 
@@ -52,6 +53,7 @@ func (status ExtractStatus) Desc() string {
 		"Deleting",
 		"Delete Failed",
 		"Deleted",
+		"extractednothing",
 	}[status]
 }
 
@@ -62,7 +64,7 @@ func (status ExtractStatus) MarshalText() ([]byte, error) {
 
 // String turns a status into a short string.
 func (status ExtractStatus) String() string {
-	if status > DELETED {
+	if status > EXTRACTEDNOTHING {
 		return "unknown"
 	}
 
@@ -77,6 +79,7 @@ func (status ExtractStatus) String() string {
 		"deleting",
 		"deletefailed",
 		"deleted",
+		"extractednothing",
 	}[status]
 }
 


### PR DESCRIPTION
This will allow the `cmdhook`s and `webhook`s to trigger when there is nothing to extract.
Previously just a log message was output into the logs and then the item was removed from further processing.
This will allow users to react with `cmdhook`s and/or `webhook`s to an item being processed that has nothing to extract.