### PR TITLE
Fixes a bug where no API Key prevents the app from starting

### DIFF
--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -30,6 +30,11 @@ func (u *Unpackerr) validateLidarr() error {
 			continue
 		}
 
+		if u.Lidarr[i].APIKey == "" {
+			u.Errorf("Missing Lidarr API Key in one of your configurations, skipped and ignored.")
+			continue
+		}
+
 		if !strings.HasPrefix(u.Lidarr[i].URL, "http://") && !strings.HasPrefix(u.Lidarr[i].URL, "https://") {
 			return fmt.Errorf("%w: (lidarr) %s", ErrInvalidURL, u.Lidarr[i].URL)
 		}

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -30,6 +30,11 @@ func (u *Unpackerr) validateRadarr() error {
 			continue
 		}
 
+		if u.Radarr[i].APIKey == "" {
+			u.Errorf("Missing Radarr API Key in one of your configurations, skipped and ignored.")
+			continue
+		}
+
 		if !strings.HasPrefix(u.Radarr[i].URL, "http://") && !strings.HasPrefix(u.Radarr[i].URL, "https://") {
 			return fmt.Errorf("%w: (radarr) %s", ErrInvalidURL, u.Radarr[i].URL)
 		}

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -30,6 +30,11 @@ func (u *Unpackerr) validateReadarr() error {
 			continue
 		}
 
+		if u.Readarr[i].APIKey == "" {
+			u.Errorf("Missing Readarr API Key in one of your configurations, skipped and ignored.")
+			continue
+		}
+
 		if !strings.HasPrefix(u.Readarr[i].URL, "http://") && !strings.HasPrefix(u.Readarr[i].URL, "https://") {
 			return fmt.Errorf("%w: (readarr) %s", ErrInvalidURL, u.Readarr[i].URL)
 		}

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -30,6 +30,11 @@ func (u *Unpackerr) validateSonarr() error {
 			continue
 		}
 
+		if u.Sonarr[i].APIKey == "" {
+			u.Errorf("Missing Sonarr API Key in one of your configurations, skipped and ignored.")
+			continue
+		}
+
 		if !strings.HasPrefix(u.Sonarr[i].URL, "http://") && !strings.HasPrefix(u.Sonarr[i].URL, "https://") {
 			return fmt.Errorf("%w: (sonarr) %s", ErrInvalidURL, u.Sonarr[i].URL)
 		}

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -34,6 +34,11 @@ func (u *Unpackerr) validateWhisparr() error {
 			continue
 		}
 
+		if u.Whisparr[i].APIKey == "" {
+			u.Errorf("Missing Whisparr API Key in one of your configurations, skipped and ignored.")
+			continue
+		}
+
 		if !strings.HasPrefix(u.Whisparr[i].URL, "http://") && !strings.HasPrefix(u.Whisparr[i].URL, "https://") {
 			return fmt.Errorf("%w: (whisparr) %s", ErrInvalidURL, u.Whisparr[i].URL)
 		}


### PR DESCRIPTION
At some point we added an API Key length check and that began disallowing zero-length keys. The unraid template relies on zero-length keys and the app won't start by default. 
- Allows configurations with no API Key (zero length).
- Apps with zero length keys are ignored and skipped.
- Fixes #408.