### PR TITLE
Fix log file path for viewing

### DIFF
--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -28,7 +28,9 @@ log_queues = "1m"
 ## Write messages to a log file. This is the same data that is normally output to stdout.
 ## This setting is great for Docker users that want to export their logs to a file.
 ## The alternative is to use syslog to log the output of the application to a file.
-## Default is no log file; this is unset. log_files=0 turns off auto-rotation.
+## Default is no log file; this is unset.
+## Except on macOS and Windows, the log file gets set to "~/.unpackerr/unpackerr.log"
+## log_files=0 turns off auto-rotation.
 ## Default files is 10 and size(mb) is 10 Megabytes; both doubled if debug is true.
 #log_file = '/downloads/unpackerr.log'
 log_files = 10

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -130,7 +130,7 @@ func (u *Unpackerr) setupLogging() {
 		u.Logger.Info.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
 		u.Logger.Error.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
 	}
-	log.Println(u.Config.LogFile)
+
 	if logFile, err := homedir.Expand(u.Config.LogFile); err == nil {
 		u.Config.LogFile = logFile
 	}


### PR DESCRIPTION
- Closes #434 

Turns out there's no need to add a message since a log file is always set on operating systems with a tray menu. While looking into it, I realized home folder (~) was not being taken into account when viewing the log file, so I fixed that. Also updated the comment in the example config file.