### PR TITLE
ignore log file, add minimum poll interval, print config file age

### DIFF
--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -79,9 +79,9 @@ func (f *Flags) ConfigFileWithAge() string {
 		return f.ConfigFile + ", unknown age"
 	}
 
-	age := durafmt.Parse(time.Since(stat.ModTime()))
+	age := durafmt.Parse(time.Since(stat.ModTime())).LimitFirstN(2) //nolint:mnd
 
-	return f.ConfigFile + ", age: " + age.LimitFirstN(2).String()
+	return f.ConfigFile + ", age: " + age.String()
 }
 
 func configFileLocactions() (string, []string) {

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -18,7 +18,10 @@ import (
 )
 
 // defaultPollInterval is used if Docker is detected.
-const defaultPollInterval = time.Second
+const (
+	defaultPollInterval = time.Second
+	minimumPollInterval = time.Millisecond
+)
 
 // FolderConfig defines the input data for a watched folder.
 //
@@ -119,7 +122,9 @@ func (u *Unpackerr) PollFolders() {
 	go u.folders.watchFSNotify()
 	u.Printf("[Folder] Watching (fsnotify): %s", strings.Join(flist, ", "))
 
-	if u.Folder.Interval.Duration == 0 {
+	// Setting an interval of any value less than a millisecond
+	// (except zero in docker) allows disabling the poller.
+	if u.Folder.Interval.Duration < minimumPollInterval {
 		return
 	}
 
@@ -175,7 +180,7 @@ func (u *Unpackerr) newFolderWatcher() error {
 
 // Add uses either fsnotify or watcher.
 func (f *Folders) Add(folder string) error {
-	if f.Interval != 0 {
+	if f.Interval >= minimumPollInterval {
 		if err := f.Watcher.Add(folder); err != nil {
 			return fmt.Errorf("watcher: %w", err)
 		}
@@ -366,6 +371,15 @@ func (f *Folders) handleFileEvent(name, operation string) {
 	}
 
 	f.Debugf("Folder: Ignored event from non-configured path: %v", name)
+}
+
+func (u *Unpackerr) processEvent(event *eventData) {
+	// Do not watch our own log file.
+	if event.file == u.Config.LogFile || event.file == u.Config.Webserver.LogFile {
+		return
+	}
+
+	u.folders.processEvent(event)
 }
 
 // processEvent processes the event that was received.

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -20,7 +20,7 @@ import (
 // defaultPollInterval is used if Docker is detected.
 const (
 	defaultPollInterval = time.Second
-	minimumPollInterval = time.Millisecond
+	minimumPollInterval = 5 * time.Millisecond
 )
 
 // FolderConfig defines the input data for a watched folder.

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -273,7 +273,7 @@ func (u *Unpackerr) Run() {
 			u.folderXtractrCallback(resp)
 		case event := <-u.folders.Events:
 			// file system event for watched folder.
-			u.folders.processEvent(event)
+			u.processEvent(event)
 		case <-logger.C:
 			// Log/print current queue counts once in a while.
 			u.logCurrentQueue()


### PR DESCRIPTION
- Closes #419 
- Closes #413 
- Closes #396
- Adds a minimum poll interval. If you wish to disable it while in docker, set the interval to "1ms"
- Ignores log files in the watch folder.
- Prints the config file age on startup.