### PR TITLE
Remove expanding of URL previews

### DIFF
--- a/pkg/unpackerr/webhooks_templates.go
+++ b/pkg/unpackerr/webhooks_templates.go
@@ -78,6 +78,7 @@ const WebhookTemplateNotifiarr = `{
 const WebhookTemplateTelegram = `{
   "chat_id": "{{nickname}}",
   "parse_mode": "HTML",
+  "disable_web_page_preview": true,
   "text": "<b><a href=\"https://github.com/Unpackerr/unpackerr/releases\">Unpackerr</a></b>: {{.Event.Desc -}}
     \n<b>Title</b>: {{rawencode (index .IDs "title") -}}
     \n<b>App</b>: {{.App -}}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/a1d72d52-13ee-4387-84a3-6130666578a8)

After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b8120c00-0458-46d0-afee-58eec902936d">

- Closes #493 
