### PR TITLE
fix docs

### DIFF
--- a/init/config/docusaurus.go
+++ b/init/config/docusaurus.go
@@ -121,7 +121,7 @@ func (h *Header) makeDocsTable(prefix string) string {
 
 	hSuffix := ""
 	if h.Kind == list {
-		hSuffix = "_0_"
+		hSuffix = "0_"
 	}
 
 	for _, param := range h.Params {

--- a/init/config/docusaurus.go
+++ b/init/config/docusaurus.go
@@ -119,8 +119,13 @@ func (h *Header) makeDocsTable(prefix string) string {
 	buf := bytes.Buffer{}
 	buf.WriteString(tableHeader)
 
+	hSuffix := ""
+	if h.Kind == list {
+		hSuffix = "_0_"
+	}
+
 	for _, param := range h.Params {
-		envVar := prefix + h.Prefix + param.EnvVar
+		envVar := prefix + h.Prefix + hSuffix + param.EnvVar
 		if param.Kind == list {
 			envVar += "0"
 		}


### PR DESCRIPTION
adds the missing `0_` to all the list parameters.