### PR TITLE
Update linter, fix some bugs

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.59'
+          version: 'v1.62'
 
   golangci-linux:
     # description: "Runs golangci-lint on linux against linux and windows."
@@ -60,4 +60,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.59'
+          version: 'v1.62'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,7 @@ linters:
   enable-all: true
   disable:
     # deprecated
-    - execinquery
-    - gomnd
+    - exportloopref
     # unused
     - exhaustruct
     - exhaustive

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -135,4 +135,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 02 AUG 2024 22:38 UTC
+## => Content Auto Generated, 15 NOV 2024 21:29 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -301,4 +301,4 @@ dir_mode = "0755"
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 02 AUG 2024 22:38 UTC
+## => Content Auto Generated, 15 NOV 2024 21:29 UTC

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	}()
 
 	if err := unpackerr.Start(); err != nil {
-		_, _ = ui.Error("Unpackerr Error", err.Error())
+		_, _ = ui.Error("Unpackerr Error", "%v", err)
 		log.Fatalln("[ERROR]", err) //nolint:gocritic
 	}
 }

--- a/pkg/ui/dlgs_other.go
+++ b/pkg/ui/dlgs_other.go
@@ -8,12 +8,12 @@ func Warning(_, _ string) (bool, error) {
 }
 
 // Error wraps dlgs.Error.
-func Error(_, _ string) (bool, error) {
+func Error(_, _ string, _ any) (bool, error) {
 	return true, nil
 }
 
 // Info wraps dlgs.Info.
-func Info(_, _ string) (bool, error) {
+func Info(_, _ string, _ any) (bool, error) {
 	return true, nil
 }
 
@@ -23,6 +23,6 @@ func Entry(_, _, val string) (string, bool, error) {
 }
 
 // Question wraps dlgs.Question.
-func Question(_, _ string, _ bool) (bool, error) {
+func Question(_ string, _ bool, _ string, _ any) (bool, error) {
 	return true, nil
 }

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -189,8 +189,8 @@ func (slice *StringSlice) UnmarshalENV(_, envval string) error {
 	return nil
 }
 
-func (slice StringSlice) MarshalENV(tag string) (map[string]string, error) {
-	return map[string]string{tag: strings.Join(slice, ",")}, nil
+func (slice *StringSlice) MarshalENV(tag string) (map[string]string, error) {
+	return map[string]string{tag: strings.Join(*slice, ",")}, nil
 }
 
 func buildStatusReason(status string, messages []*starr.StatusMessage) string {

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -126,6 +126,7 @@ func (u *Unpackerr) logCurrentQueue(now time.Time) {
 		len(u.folders.Events)+len(u.updates)+len(u.folders.Updates), len(u.hookChan), len(u.delChan),
 		durafmt.Parse(now.Sub(version.Started)).LimitFirstN(3).Format(durafmtUnits)) //nolint:mnd
 
+	//nolint:gosec
 	u.updateTray(stats, uint(len(u.folders.Events)+len(u.updates)+len(u.folders.Updates)+len(u.delChan)+len(u.hookChan)))
 }
 

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -125,6 +125,8 @@ func New() *Unpackerr {
 }
 
 // Start runs the app.
+//
+//nolint:gosec // not too concerned with possible integer overflows reading user-provided config files.
 func Start() error {
 	log.SetFlags(log.LstdFlags) // in case we throw an error for main.go before logging is setup.
 
@@ -146,7 +148,7 @@ func Start() error {
 	unpackerr.Printf("Unpackerr v%s-%s Starting! PID: %v, UID: %d, GID: %d, Umask: %d, Now: %v",
 		version.Version, version.Revision, os.Getpid(),
 		os.Getuid(), os.Getgid(), getUmask(), version.Started.Round(time.Second))
-	unpackerr.Debugf(strings.Join(strings.Fields(strings.ReplaceAll(version.Print("unpackerr"), "\n", ", ")), " "))
+	unpackerr.Debugf("%s", strings.Join(strings.Fields(strings.ReplaceAll(version.Print("unpackerr"), "\n", ", ")), " "))
 	// Parse filepath: strings from the config and read in extra config files.
 	output, err := cnfgfile.Parse(unpackerr.Config, &cnfgfile.Opts{
 		Name:          "Unpackerr",

--- a/pkg/unpackerr/tray.go
+++ b/pkg/unpackerr/tray.go
@@ -140,10 +140,10 @@ func (u *Unpackerr) makeHistoryChannels() {
 		u.menu[histNone].SetTooltip("history is disabled in the config")
 	}
 
-	for i := range int(u.KeepHistory) {
-		u.menu[hist+strconv.Itoa(i)] = ui.WrapMenu(history.AddSubMenuItem("", ""))
-		u.menu[hist+strconv.Itoa(i)].Disable()
-		u.menu[hist+strconv.Itoa(i)].Hide()
+	for i := range u.KeepHistory {
+		u.menu[hist+strconv.FormatUint(uint64(i), 10)] = ui.WrapMenu(history.AddSubMenuItem("", ""))
+		u.menu[hist+strconv.FormatUint(uint64(i), 10)].Disable()
+		u.menu[hist+strconv.FormatUint(uint64(i), 10)].Hide()
 	}
 }
 
@@ -227,7 +227,7 @@ func (u *Unpackerr) checkForUpdate() {
 	update, err := update.Check("Unpackerr/unpackerr", version.Version)
 	if err != nil {
 		u.Errorf("Update Check: %v", err)
-		_, _ = ui.Error("Unpackerr", "Failure checking version on GitHub: "+err.Error())
+		_, _ = ui.Error("Unpackerr", "Failure checking version on GitHub: %v", err)
 
 		return
 	}

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -78,10 +78,10 @@ func (statuses *ExtractStatuses) UnmarshalENV(tag, envval string) error {
 	return nil
 }
 
-func (statuses ExtractStatuses) MarshalENV(tag string) (map[string]string, error) {
-	vals := make([]string, len(statuses))
+func (statuses *ExtractStatuses) MarshalENV(tag string) (map[string]string, error) {
+	vals := make([]string, len(*statuses))
 
-	for idx, status := range statuses {
+	for idx, status := range *statuses {
 		vals[idx] = status.String()
 	}
 

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -113,7 +113,7 @@ func (u *Unpackerr) runWebServer() {
 		err = u.Webserver.server.ListenAndServe()
 	}
 
-	if err != nil && !errors.Is(http.ErrServerClosed, err) {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		u.Errorf("Web Server Failed: %v", err)
 	}
 }


### PR DESCRIPTION
Updates golang ci linter to latest version and addresses all the lint problems it found.

Fixes a bug where I broke the freebsd and linux builds.