### PR TITLE
make log file on linux auto. allow dir instead of file for log file

### DIFF
--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -11,12 +11,18 @@ if [ "${OS}" = "Linux" ]; then
     useradd --system --user-group --no-create-home --home-dir /tmp --shell /bin/false unpackerr
 elif [ "${OS}" = "OpenBSD" ]; then
   id unpackerr >/dev/null 2>&1  || \
-    useradd  -g =uid -d /tmp -s /bin/false unpackerr
+    useradd -g =uid -d /tmp -s /bin/false unpackerr
 elif [ "${OS}" = "FreeBSD" ]; then
   id unpackerr >/dev/null 2>&1  || \
     pw useradd unpackerr -d /tmp -w no -s /bin/false
 else
   echo "Unknown OS: ${OS}, please add system user unpackerr manually."
+fi
+
+if [ ! -d "/var/log/unpackerr" ]; then
+  mkdir /var/log/unpackerr
+  chown unpackerr: /var/log/unapckerr
+  chmod 0755 /var/log/unpackerr
 fi
 
 if [ -x "/bin/systemctl" ]; then

--- a/init/systemd/unpackerr.service
+++ b/init/systemd/unpackerr.service
@@ -12,6 +12,8 @@ After=network-online.target
 ExecStart=/usr/bin/unpackerr $DAEMON_OPTS
 EnvironmentFile=-/etc/default/unpackerr
 EnvironmentFile=-/etc/sysconfig/unpackerr
+Environment=UN_LOG_FILE=/var/log/unpackerr/unpackerr.log
+Environment=UN_WEBSERVER_LOG_FILE=/var/log/unpackerr/http.log
 Restart=always
 RestartSec=10
 SyslogIdentifier=unpackerr
@@ -19,6 +21,7 @@ Type=simple
 WorkingDirectory=/tmp
 
 # These should be set correctly for your environment.
+# If you change User, fix ownership on /var/log/unpackerr too.
 UMask=0002
 User=unpackerr
 Group=unpackerr


### PR DESCRIPTION
- Closes #526
- Creates log folder on Linux automatically.
- Allows passing in a log file path that is a directory.
  - The file name is auto-appended now.