### PR TITLE
feat(starr): add mTLS client certificate support for all starr apps

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       # You need at least this one volume mapped so Unpackerr can find your files to extract.
       # Make sure this matches your Starr apps; the folder mount (/downloads or /data) should be identical.
       - /mnt/HostDownloads:/downloads
+      # OPTIONAL: If using mTLS certificates, mount the certificate directory.
+      # - /path/to/certs:/certs:ro
     restart: always
     # Get the user:group correct so unpackerr can read and write to your files.
     user: ${PUID}:${PGID}
@@ -62,6 +64,9 @@ services:
     - UN_SONARR_0_DELETE_DELAY=5m
     - UN_SONARR_0_DELETE_ORIG=false
     - UN_SONARR_0_SYNCTHING=false
+    - UN_SONARR_0_TLS_CLIENT_CERT=/path/to/client.crt
+    - UN_SONARR_0_TLS_CLIENT_KEY=/path/to/client.key
+    - UN_SONARR_0_TLS_CA_CERT=/path/to/ca-bundle.crt
     ## Radarr Settings
     - UN_RADARR_0_URL=http://radarr:7878
     - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
@@ -71,6 +76,9 @@ services:
     - UN_RADARR_0_DELETE_DELAY=5m
     - UN_RADARR_0_DELETE_ORIG=false
     - UN_RADARR_0_SYNCTHING=false
+    - UN_RADARR_0_TLS_CLIENT_CERT=/path/to/client.crt
+    - UN_RADARR_0_TLS_CLIENT_KEY=/path/to/client.key
+    - UN_RADARR_0_TLS_CA_CERT=/path/to/ca-bundle.crt
     ## Lidarr Settings
     - UN_LIDARR_0_URL=http://lidarr:8686
     - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
@@ -80,6 +88,9 @@ services:
     - UN_LIDARR_0_DELETE_DELAY=5m
     - UN_LIDARR_0_DELETE_ORIG=false
     - UN_LIDARR_0_SYNCTHING=false
+    - UN_LIDARR_0_TLS_CLIENT_CERT=/path/to/client.crt
+    - UN_LIDARR_0_TLS_CLIENT_KEY=/path/to/client.key
+    - UN_LIDARR_0_TLS_CA_CERT=/path/to/ca-bundle.crt
     ## Readarr Settings
     - UN_READARR_0_URL=http://readarr:8787
     - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
@@ -89,6 +100,9 @@ services:
     - UN_READARR_0_DELETE_DELAY=5m
     - UN_READARR_0_DELETE_ORIG=false
     - UN_READARR_0_SYNCTHING=false
+    - UN_READARR_0_TLS_CLIENT_CERT=/path/to/client.crt
+    - UN_READARR_0_TLS_CLIENT_KEY=/path/to/client.key
+    - UN_READARR_0_TLS_CA_CERT=/path/to/ca-bundle.crt
     ## Whisparr Settings
     - UN_WHISPARR_0_URL=http://whisparr:6969
     - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
@@ -98,6 +112,9 @@ services:
     - UN_WHISPARR_0_DELETE_DELAY=5m
     - UN_WHISPARR_0_DELETE_ORIG=false
     - UN_WHISPARR_0_SYNCTHING=false
+    - UN_WHISPARR_0_TLS_CLIENT_CERT=/path/to/client.crt
+    - UN_WHISPARR_0_TLS_CLIENT_KEY=/path/to/client.key
+    - UN_WHISPARR_0_TLS_CA_CERT=/path/to/ca-bundle.crt
     ## Watch Folders
     - UN_FOLDER_0_PATH=/downloads/auto_extract
     - UN_FOLDER_0_EXTRACT_PATH=
@@ -136,4 +153,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 12 APR 2025 04:54 UTC
+## => Content Auto Generated, 28 AUG 2025 18:38 UTC

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -153,4 +153,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 28 AUG 2025 18:38 UTC
+## => Content Auto Generated, 28 AUG 2025 20:00 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -132,6 +132,18 @@ dir_mode = "0755"
 # delete_orig = false
 ## If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
 # syncthing = false
+## Path to TLS client certificate file for mutual TLS authentication.
+## Required when your Starr app is behind a reverse proxy with mTLS enabled.
+## Must be paired with tls_client_key. Leave empty for standard TLS connections.
+# tls_client_cert = "/path/to/client.crt"
+## Path to TLS client private key file for mutual TLS authentication.
+## This key must match the tls_client_cert certificate.
+## Both cert and key are required for mTLS to work.
+# tls_client_key = "/path/to/client.key"
+## Path to custom Certificate Authority bundle to verify server certificate.
+## Use this when your Starr app uses a certificate signed by a private CA.
+## If not set, system default CA bundle is used.
+# tls_ca_cert = "/path/to/ca-bundle.crt"
 
 ## Leaving the [[radarr]] header uncommented (no leading hash #) without also
 ## uncommenting the api_key (remove the hash #) will produce a startup warning.
@@ -153,6 +165,18 @@ dir_mode = "0755"
 # delete_orig = false
 ## If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
 # syncthing = false
+## Path to TLS client certificate file for mutual TLS authentication.
+## Required when your Starr app is behind a reverse proxy with mTLS enabled.
+## Must be paired with tls_client_key. Leave empty for standard TLS connections.
+# tls_client_cert = "/path/to/client.crt"
+## Path to TLS client private key file for mutual TLS authentication.
+## This key must match the tls_client_cert certificate.
+## Both cert and key are required for mTLS to work.
+# tls_client_key = "/path/to/client.key"
+## Path to custom Certificate Authority bundle to verify server certificate.
+## Use this when your Starr app uses a certificate signed by a private CA.
+## If not set, system default CA bundle is used.
+# tls_ca_cert = "/path/to/ca-bundle.crt"
 
 #[[lidarr]]
 # url = "http://127.0.0.1:8686"
@@ -172,6 +196,18 @@ dir_mode = "0755"
 # delete_orig = false
 ## If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
 # syncthing = false
+## Path to TLS client certificate file for mutual TLS authentication.
+## Required when your Starr app is behind a reverse proxy with mTLS enabled.
+## Must be paired with tls_client_key. Leave empty for standard TLS connections.
+# tls_client_cert = "/path/to/client.crt"
+## Path to TLS client private key file for mutual TLS authentication.
+## This key must match the tls_client_cert certificate.
+## Both cert and key are required for mTLS to work.
+# tls_client_key = "/path/to/client.key"
+## Path to custom Certificate Authority bundle to verify server certificate.
+## Use this when your Starr app uses a certificate signed by a private CA.
+## If not set, system default CA bundle is used.
+# tls_ca_cert = "/path/to/ca-bundle.crt"
 
 #[[readarr]]
 # url = "http://127.0.0.1:8787"
@@ -191,6 +227,18 @@ dir_mode = "0755"
 # delete_orig = false
 ## If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
 # syncthing = false
+## Path to TLS client certificate file for mutual TLS authentication.
+## Required when your Starr app is behind a reverse proxy with mTLS enabled.
+## Must be paired with tls_client_key. Leave empty for standard TLS connections.
+# tls_client_cert = "/path/to/client.crt"
+## Path to TLS client private key file for mutual TLS authentication.
+## This key must match the tls_client_cert certificate.
+## Both cert and key are required for mTLS to work.
+# tls_client_key = "/path/to/client.key"
+## Path to custom Certificate Authority bundle to verify server certificate.
+## Use this when your Starr app uses a certificate signed by a private CA.
+## If not set, system default CA bundle is used.
+# tls_ca_cert = "/path/to/ca-bundle.crt"
 
 #[[whisparr]]
 # url = "http://127.0.0.1:6969"
@@ -210,6 +258,18 @@ dir_mode = "0755"
 # delete_orig = false
 ## If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
 # syncthing = false
+## Path to TLS client certificate file for mutual TLS authentication.
+## Required when your Starr app is behind a reverse proxy with mTLS enabled.
+## Must be paired with tls_client_key. Leave empty for standard TLS connections.
+# tls_client_cert = "/path/to/client.crt"
+## Path to TLS client private key file for mutual TLS authentication.
+## This key must match the tls_client_cert certificate.
+## Both cert and key are required for mTLS to work.
+# tls_client_key = "/path/to/client.key"
+## Path to custom Certificate Authority bundle to verify server certificate.
+## Use this when your Starr app uses a certificate signed by a private CA.
+## If not set, system default CA bundle is used.
+# tls_ca_cert = "/path/to/ca-bundle.crt"
 
 ##################################################################################
 ### ###  STOP HERE ### STOP HERE ### STOP HERE ### STOP HERE #### STOP HERE  ### #
@@ -302,4 +362,4 @@ dir_mode = "0755"
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 12 APR 2025 04:54 UTC
+## => Content Auto Generated, 28 AUG 2025 18:38 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -362,4 +362,4 @@ dir_mode = "0755"
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 28 AUG 2025 18:38 UTC
+## => Content Auto Generated, 28 AUG 2025 20:00 UTC

--- a/init/config/compose.go
+++ b/init/config/compose.go
@@ -25,6 +25,8 @@ services:
       # You need at least this one volume mapped so Unpackerr can find your files to extract.
       # Make sure this matches your Starr apps; the folder mount (/downloads or /data) should be identical.
       - /mnt/HostDownloads:/downloads
+      # OPTIONAL: If using mTLS certificates, mount the certificate directory.
+      # - /path/to/certs:/certs:ro
     restart: always
     # Get the user:group correct so unpackerr can read and write to your files.
     user: ${PUID}:${PGID}

--- a/init/config/definitions.yml
+++ b/init/config/definitions.yml
@@ -493,6 +493,33 @@ sections:
       recommend: *BOOLEAN
       short: Setting this to true makes unpackerr wait for syncthing to finish.
       desc: If you use Syncthing, setting this to true will make unpackerr wait for syncs to finish.
+    - name: tls_client_cert
+      envvar: TLS_CLIENT_CERT
+      default: ''
+      example: /path/to/client.crt
+      short: Path to TLS client certificate for mTLS.
+      desc: |
+        Path to TLS client certificate file for mutual TLS authentication.
+        Required when your Starr app is behind a reverse proxy with mTLS enabled.
+        Must be paired with tls_client_key. Leave empty for standard TLS connections.
+    - name: tls_client_key
+      envvar: TLS_CLIENT_KEY
+      default: ''
+      example: /path/to/client.key
+      short: Path to TLS client private key for mTLS.
+      desc: |
+        Path to TLS client private key file for mutual TLS authentication.
+        This key must match the tls_client_cert certificate.
+        Both cert and key are required for mTLS to work.
+    - name: tls_ca_cert
+      envvar: TLS_CA_CERT
+      default: ''
+      example: /path/to/ca-bundle.crt
+      short: Path to custom CA certificate.
+      desc: |
+        Path to custom Certificate Authority bundle to verify server certificate.
+        Use this when your Starr app uses a certificate signed by a private CA.
+        If not set, system default CA bundle is used.
 
   # Global folder configuration.
   folders:

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -36,6 +36,7 @@ const (
 var (
 	ErrInvalidURL = errors.New("provided application URL is invalid")
 	ErrInvalidKey = fmt.Errorf("provided application API Key is invalid, must be %d characters", apiKeyLength)
+	ErrInvalidCA  = errors.New("failed parsing CA certificate")
 )
 
 // Config defines the configuration data used to start the application.

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -345,6 +345,7 @@ func (u *Unpackerr) configureTLS(conf *StarrConfig, app starr.App) (*tls.Config,
 		}
 
 		tlsConfig.Certificates = []tls.Certificate{cert}
+
 		u.Debugf("%s (%s): Loaded mTLS client certificate", app, conf.URL)
 	}
 
@@ -352,6 +353,7 @@ func (u *Unpackerr) configureTLS(conf *StarrConfig, app starr.App) (*tls.Config,
 	if conf.TLSCACert != "" {
 		caPath := expandHomedir(conf.TLSCACert)
 		caCert, err := os.ReadFile(caPath)
+
 		if err != nil {
 			return nil, fmt.Errorf("%s (%s) failed reading CA cert from %s: %w",
 				app, conf.URL, caPath, err)
@@ -363,6 +365,7 @@ func (u *Unpackerr) configureTLS(conf *StarrConfig, app starr.App) (*tls.Config,
 		}
 
 		tlsConfig.RootCAs = caCertPool
+
 		u.Debugf("%s (%s): Loaded custom CA certificate", app, conf.URL)
 	}
 

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -351,16 +351,15 @@ func (u *Unpackerr) configureTLS(conf *StarrConfig, app starr.App) (*tls.Config,
 
 	// Add custom CA if configured
 	if conf.TLSCACert != "" {
-		caPath := expandHomedir(conf.TLSCACert)
-		caCert, err := os.ReadFile(caPath)
+		caCert, err := os.ReadFile(expandHomedir(conf.TLSCACert))
 		if err != nil {
 			return nil, fmt.Errorf("%s (%s) failed reading CA cert from %s: %w",
-				app, conf.URL, caPath, err)
+				app, conf.URL, expandHomedir(conf.TLSCACert), err)
 		}
 
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("%w: %s (%s) from %s", ErrInvalidCA, app, conf.URL, caPath)
+			return nil, fmt.Errorf("%w: %s (%s) from %s", ErrInvalidCA, app, conf.URL, expandHomedir(conf.TLSCACert))
 		}
 
 		tlsConfig.RootCAs = caCertPool

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -353,7 +353,6 @@ func (u *Unpackerr) configureTLS(conf *StarrConfig, app starr.App) (*tls.Config,
 	if conf.TLSCACert != "" {
 		caPath := expandHomedir(conf.TLSCACert)
 		caCert, err := os.ReadFile(caPath)
-
 		if err != nil {
 			return nil, fmt.Errorf("%s (%s) failed reading CA cert from %s: %w",
 				app, conf.URL, caPath, err)

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -29,18 +29,19 @@ type Extract struct {
 
 // Shared config items for all starr apps.
 type StarrConfig struct {
-	Path          string        `json:"path"         toml:"path"         xml:"path"         yaml:"path"`
-	Paths         StringSlice   `json:"paths"        toml:"paths"        xml:"paths"        yaml:"paths"`
-	Protocols     string        `json:"protocols"    toml:"protocols"    xml:"protocols"    yaml:"protocols"`
-	DeleteOrig    bool          `json:"delete_orig"  toml:"delete_orig"  xml:"delete_orig"  yaml:"delete_orig"`
-	DeleteDelay   cnfg.Duration `json:"delete_delay" toml:"delete_delay" xml:"delete_delay" yaml:"delete_delay"`
-	Syncthing     bool          `json:"syncthing"    toml:"syncthing"    xml:"syncthing"    yaml:"syncthing"`
-	ValidSSL      bool          `json:"valid_ssl"      toml:"valid_ssl"      xml:"valid_ssl"      yaml:"valid_ssl"`
-	Timeout       cnfg.Duration `json:"timeout"        toml:"timeout"        xml:"timeout"        yaml:"timeout"`
-	TLSClientCert string        `json:"tls_client_cert" toml:"tls_client_cert" xml:"tls_client_cert" yaml:"tls_client_cert"`
+	starr.Config
+
+	Path          string        `json:"path"            toml:"path"            xml:"path"            yaml:"path"`
+	Paths         StringSlice   `json:"paths"           toml:"paths"           xml:"paths"           yaml:"paths"`
+	Protocols     string        `json:"protocols"       toml:"protocols"       xml:"protocols"       yaml:"protocols"`
+	DeleteOrig    bool          `json:"delete_orig"     toml:"delete_orig"     xml:"delete_orig"     yaml:"delete_orig"`
+	DeleteDelay   cnfg.Duration `json:"delete_delay"    toml:"delete_delay"    xml:"delete_delay"    yaml:"delete_delay"`
+	Syncthing     bool          `json:"syncthing"       toml:"syncthing"       xml:"syncthing"       yaml:"syncthing"`
+	ValidSSL      bool          `json:"valid_ssl"       toml:"valid_ssl"       xml:"valid_ssl"       yaml:"valid_ssl"`
+	Timeout       cnfg.Duration `json:"timeout"         toml:"timeout"         xml:"timeout"         yaml:"timeout"`
+	TLSClientCert string        `json:"tls_client_cert" toml:"tls_client_cert" xml:"tls_client_cert" yaml:"tls_client_cert"` //nolint:lll
 	TLSClientKey  string        `json:"tls_client_key"  toml:"tls_client_key"  xml:"tls_client_key"  yaml:"tls_client_key"`
 	TLSCACert     string        `json:"tls_ca_cert"     toml:"tls_ca_cert"     xml:"tls_ca_cert"     yaml:"tls_ca_cert"`
-	starr.Config
 }
 
 // checkQueueChanges checks each item for state changes from the app queues.

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -29,14 +29,17 @@ type Extract struct {
 
 // Shared config items for all starr apps.
 type StarrConfig struct {
-	Path        string        `json:"path"         toml:"path"         xml:"path"         yaml:"path"`
-	Paths       StringSlice   `json:"paths"        toml:"paths"        xml:"paths"        yaml:"paths"`
-	Protocols   string        `json:"protocols"    toml:"protocols"    xml:"protocols"    yaml:"protocols"`
-	DeleteOrig  bool          `json:"delete_orig"  toml:"delete_orig"  xml:"delete_orig"  yaml:"delete_orig"`
-	DeleteDelay cnfg.Duration `json:"delete_delay" toml:"delete_delay" xml:"delete_delay" yaml:"delete_delay"`
-	Syncthing   bool          `json:"syncthing"    toml:"syncthing"    xml:"syncthing"    yaml:"syncthing"`
-	ValidSSL    bool          `json:"valid_ssl"    toml:"valid_ssl"    xml:"valid_ssl"    yaml:"valid_ssl"`
-	Timeout     cnfg.Duration `json:"timeout"      toml:"timeout"      xml:"timeout"      yaml:"timeout"`
+	Path          string        `json:"path"         toml:"path"         xml:"path"         yaml:"path"`
+	Paths         StringSlice   `json:"paths"        toml:"paths"        xml:"paths"        yaml:"paths"`
+	Protocols     string        `json:"protocols"    toml:"protocols"    xml:"protocols"    yaml:"protocols"`
+	DeleteOrig    bool          `json:"delete_orig"  toml:"delete_orig"  xml:"delete_orig"  yaml:"delete_orig"`
+	DeleteDelay   cnfg.Duration `json:"delete_delay" toml:"delete_delay" xml:"delete_delay" yaml:"delete_delay"`
+	Syncthing     bool          `json:"syncthing"    toml:"syncthing"    xml:"syncthing"    yaml:"syncthing"`
+	ValidSSL      bool          `json:"valid_ssl"      toml:"valid_ssl"      xml:"valid_ssl"      yaml:"valid_ssl"`
+	Timeout       cnfg.Duration `json:"timeout"        toml:"timeout"        xml:"timeout"        yaml:"timeout"`
+	TLSClientCert string        `json:"tls_client_cert" toml:"tls_client_cert" xml:"tls_client_cert" yaml:"tls_client_cert"`
+	TLSClientKey  string        `json:"tls_client_key"  toml:"tls_client_key"  xml:"tls_client_key"  yaml:"tls_client_key"`
+	TLSCACert     string        `json:"tls_ca_cert"     toml:"tls_ca_cert"     xml:"tls_ca_cert"     yaml:"tls_ca_cert"`
 	starr.Config
 }
 


### PR DESCRIPTION
## Summary

This PR adds mutual TLS (mTLS) client certificate authentication support to Unpackerr, enabling secure communication with Starr applications (Sonarr, Radarr, Lidarr, Readarr, Whisparr) that are protected behind reverse proxies requiring client certificates.

## Testing

- Tested with real mTLS-protected Sonarr and Radarr instances
- Verified successful extraction and queue monitoring
- Confirmed backward compatibility with non-mTLS instances
- Validated error handling with invalid certificates

## Configuration Example

### TOML Configuration

```toml
[[sonarr]]
url = "https://sonarr.example.com"
api_key = "your-api-key"
tls_client_cert = "/path/to/client.crt"
tls_client_key = "/path/to/client.key"
tls_ca_cert = "/path/to/ca.crt"  # Optional
```

### Docker Compose

```yaml
volumes:
  - /path/to/certs:/certs:ro
environment:
  - UN_SONARR_0_TLS_CLIENT_CERT=/certs/client.crt
  - UN_SONARR_0_TLS_CLIENT_KEY=/certs/client.key
  - UN_SONARR_0_TLS_CA_CERT=/certs/ca.crt
```

## Implementation Details

The implementation modifies the HTTP transport configuration to include TLS client certificates when provided:

1. If tls_client_cert and tls_client_key are configured, they are loaded as an X.509 key pair
2. If tls_ca_cert is provided, it's added to the root CA pool for server certificate verification
3. The existing valid_ssl flag continues to control certificate validation