### PR TITLE
docs: clarify password file usage and env var format

### DIFF
--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -73,6 +73,10 @@ dir_mode = "0755"
 ## List of passwords to use for encrypted archives. Must be a list of strings.
 ## Use this special format as a password to read more passwords from a file:
 ## passwords = [ "filepath:/path/to/passwords.txt" ]
+## Environment variable format uses an index per item:
+## UN_PASSWORD_0=filepath:/path/to/passwords.txt
+## Password files should contain one password per line.
+## Password files are read once at startup.
 passwords = []
 
 [webserver]
@@ -311,4 +315,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 14 FEB 2026 03:44 UTC
+## => Content Auto Generated, 16 FEB 2026 17:37 UTC

--- a/init/config/definitions.yml
+++ b/init/config/definitions.yml
@@ -380,6 +380,10 @@ sections:
           List of passwords to use for encrypted archives. Must be a list of strings.
           Use this special format as a password to read more passwords from a file:
           passwords = [ "filepath:/path/to/passwords.txt" ]
+          Environment variable format uses an index per item:
+          UN_PASSWORD_0=filepath:/path/to/passwords.txt
+          Password files should contain one password per line.
+          Password files are read once at startup.
   webserver:
     title: Web Server
     docs: |


### PR DESCRIPTION
Fixes #568

## Summary
- Clarify `passwords` file-based loading docs in generated config docs.
- Add explicit environment variable example for file-based passwords:
  - `UN_PASSWORD_0=filepath:/path/to/passwords.txt`
- Document password file expectations:
  - one password per line
  - files are read once at startup

## Files Changed
- `init/config/definitions.yml`
- `examples/unpackerr.conf.example`

## Validation
- `go generate ./...`
- `go test ./pkg/...`