### PR TITLE
Include both torrent and usenet in default protocols

### DIFF
--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -23,7 +23,12 @@ import (
 const DefaultQueuePageSize = 2000
 
 const (
-	defaultProtocol = "torrent"
+	// defaultProtocol includes both torrent and usenet so that the common cases
+	// work out of the box without requiring users to set the protocols field.
+	// Lidarr (and other Starr apps) may return either value depending on the
+	// download client configured; omitting either one silently causes all
+	// completed downloads of that protocol to be skipped.
+	defaultProtocol = "torrent,usenet"
 	apiKeyLength    = 32
 )
 


### PR DESCRIPTION
Previously the defaultProtocol was only 'torrent', so users who did not explicitly set protocols in their config would silently have all usenet downloads ignored by Lidarr (and every other Starr app). Since the common case is to have both torrent and usenet download clients, the default should cover both.

Users who genuinely want to restrict to one protocol can still do so by setting protocols explicitly in their config file.

Refs: https://github.com/Unpackerr/unpackerr/issues/141