### PR TITLE
fix: default protocol covers both legacy and class-name torrent strings

### DIFF
--- a/init/config/definitions.yml
+++ b/init/config/definitions.yml
@@ -483,13 +483,22 @@ sections:
           Used as fallback if the path the Starr app reports does not exist or is not accessible.
       - name: protocols
         envvar: PROTOCOLS
-        default: torrent
+        default: torrent,TorrentDownloadProtocol
         recommend:
+          - value: torrent,TorrentDownloadProtocol
+          - value: torrent,TorrentDownloadProtocol,usenet,UsenetDownloadProtocol
           - value: torrent
           - value: torrent,usenet
           - value: usenet
-        short: 'Protocols to process. Alt: `torrent,usenet`'
-        desc: 'Default protocols is torrent. Alternative: "torrent,usenet"'
+          - value: UsenetDownloadProtocol
+        short: 'Protocols to process. Newer Starr apps use class-name strings.'
+        desc: |
+          Protocols to process from the download queue. Starr apps historically
+          used "torrent" and "usenet" as the protocol strings, but newer versions
+          emit the full class names "TorrentDownloadProtocol" and
+          "UsenetDownloadProtocol" instead. List every string your app may return,
+          separated by commas. The default covers both the legacy and new torrent
+          strings. Add "usenet,UsenetDownloadProtocol" if you use a Usenet client.
       - name: timeout
         envvar: TIMEOUT
         default: 10s

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -23,7 +23,11 @@ import (
 const DefaultQueuePageSize = 2000
 
 const (
-	defaultProtocol = "torrent"
+	// defaultProtocol covers both the legacy "torrent" string and the newer
+	// "TorrentDownloadProtocol" class name that Starr apps now emit in their
+	// queue API responses. Both strings must be present so that torrents are
+	// always processed regardless of which Starr app version is in use.
+	defaultProtocol = "torrent,TorrentDownloadProtocol"
 	apiKeyLength    = 32
 )
 


### PR DESCRIPTION
## Problem

Starr apps are migrating from short protocol strings (`torrent`, `usenet`) to full class names (`TorrentDownloadProtocol`, `UsenetDownloadProtocol`). Users on newer Starr versions see completed torrent downloads silently skipped because the old default `torrent` no longer matches what the app returns in its queue API response.

This was reported in #141 — davidnewhall noted *"someone changed the protocol from 'torrent' and 'usenet' to some other string"*.

- Closes #589 

## Fix

- Change `defaultProtocol` from `"torrent"` to `"torrent,TorrentDownloadProtocol"` so torrents are always processed regardless of which Starr version is running.
- Update `definitions.yml` recommendations and description to document all four valid strings (`torrent`, `TorrentDownloadProtocol`, `usenet`, `UsenetDownloadProtocol`) and explain that both the legacy and class-name forms should be listed together for Usenet users.

## Test plan

- [ ] Build passes, linter clean (`golangci-lint run ./...` → 0 issues)
- [ ] Verify on a Starr app returning `TorrentDownloadProtocol` that completed downloads are now picked up without setting `protocols` manually
- [ ] Verify existing users with explicit `protocols = torrent` are unaffected (their explicit config overrides the default)