### PR TITLE
Suppress systemd warning

### DIFF
--- a/init/systemd/unpackerr.service
+++ b/init/systemd/unpackerr.service
@@ -15,6 +15,7 @@ EnvironmentFile=-/etc/sysconfig/unpackerr
 Environment=UN_LOG_FILE=/var/log/unpackerr/unpackerr.log
 Environment=UN_WEBSERVER_LOG_FILE=/var/log/unpackerr/http.log
 Environment=UN_QUIET=true
+Environment=DAEMON_OPTS=
 Restart=always
 RestartSec=10
 SyslogIdentifier=unpackerr


### PR DESCRIPTION
Remove this warning:
> unpackerr.service: Referenced but unset environment variable evaluates to an empty string: DAEMON_OPTS

Thanks to @fryfrog for figuring this out.