### PR TITLE
fix: remove upper limit on API key length validation

### DIFF
--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -28,7 +28,7 @@ const (
 	// queue API responses. Both strings must be present so that torrents are
 	// always processed regardless of which Starr app version is in use.
 	defaultProtocol = "torrent,TorrentDownloadProtocol"
-	apiKeyLength    = 32
+	apiKeyMinLength = 32
 )
 
 // These are the names used to identify each app.
@@ -39,7 +39,7 @@ const (
 // Application validation errors.
 var (
 	ErrInvalidURL = errors.New("provided application URL is invalid")
-	ErrInvalidKey = fmt.Errorf("provided application API Key is invalid, must be %d characters", apiKeyLength)
+	ErrInvalidKey = fmt.Errorf("provided application API Key is invalid, must be at least %d characters", apiKeyMinLength)
 )
 
 // Config defines the configuration data used to start the application.

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -288,7 +288,7 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 		return fmt.Errorf("%w: (%s) %s", ErrInvalidURL, app, conf.URL)
 	}
 
-	if len(conf.APIKey) != apiKeyLength {
+	if len(conf.APIKey) < apiKeyMinLength {
 		return fmt.Errorf("%s (%s) %w, your key length: %d",
 			app, conf.URL, ErrInvalidKey, len(conf.APIKey))
 	}


### PR DESCRIPTION
*Arr apps (Lidarr, Sonarr, Radarr) support API keys longer than 32 characters. A longer API key is inherently more secure and there is no reason to artificially cap it at exactly 32 as the key is simply passed through to the *Arr API as-is. This PR removes the upper limit so Unpackerr accepts any key that is at least 32 characters long.

The minimum of 32 is preserved as a sanity check to catch obviously invalid or truncated keys.