### PR TITLE
Use carbon instead of durafmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters:
             - github.com/lestrrat-go/apache-logformat
             - github.com/ncruces/zenity
             - github.com/energye/systray
-            - github.com/hako/durafmt
+            - github.com/dromara/carbon/v2
             - github.com/mitchellh/go-homedir
             - github.com/fsnotify/fsnotify
             - github.com/radovskyb/watcher

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26.4
 require (
 	code.cloudfoundry.org/bytefmt v0.76.0
 	github.com/BurntSushi/toml v1.6.0
+	github.com/dromara/carbon/v2 v2.6.16
 	github.com/energye/systray v1.0.3
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lestrrat-go/apache-logformat/v2 v2.0.6
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/jsmin v1.0.0 h1:Y2hWXmGZiRxtl+VcTksyucgTlYxnhPzTozCwx9gy9zI=
 github.com/dchest/jsmin v1.0.0/go.mod h1:AVBIund7Mr7lKXT70hKT2YgL3XEXUaUk5iw9DZ8b0Uc=
+github.com/dromara/carbon/v2 v2.6.16 h1:AbxrnW1kJhR3KHdS8G96NFmxDwPFyre+t+xSiJIUD1I=
+github.com/dromara/carbon/v2 v2.6.16/go.mod h1:NGo3reeV5vhWCYWcSqbJRZm46MEwyfYI5EJRdVFoLJo=
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/energye/systray v1.0.3 h1:XnyjJCeRU5z00bpNOic2fGTKz/7yHZMZjWiGIVXDS+4=
@@ -49,8 +51,6 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20260604005048-7023385849c0 h1:h1QTMDl6q9wDvDCJVpKQSjgleGFYnd2fOxmg2K+6BGE=
 github.com/google/pprof v0.0.0-20260604005048-7023385849c0/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
-github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
-github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/icza/bitio v1.1.0 h1:ysX4vtldjdi3Ygai5m1cWy4oLkhWTAi+SyO6HC8L9T0=

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -9,11 +9,10 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Unpackerr/unpackerr/examples"
 	"github.com/Unpackerr/unpackerr/pkg/ui"
-	"github.com/hako/durafmt"
+	"github.com/dromara/carbon/v2"
 	homedir "github.com/mitchellh/go-homedir"
 	"golift.io/cnfg"
 	"golift.io/cnfgfile"
@@ -78,9 +77,9 @@ func (f *Flags) ConfigFileWithAge() string {
 		return f.ConfigFile + ", unknown age"
 	}
 
-	age := durafmt.Parse(time.Since(stat.ModTime())).LimitFirstN(3) //nolint:mnd
+	age := carbon.CreateFromStdTime(stat.ModTime()).DiffAbsInString()
 
-	return f.ConfigFile + ", age: " + age.Format(durafmtUnits)
+	return f.ConfigFile + ", age: " + age
 }
 
 func configFileLocactions() (string, []string) {

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/ui"
-	"github.com/hako/durafmt"
+	"github.com/dromara/carbon/v2"
 	homedir "github.com/mitchellh/go-homedir"
 	"golift.io/rotatorr"
 	"golift.io/rotatorr/timerotator"
@@ -126,7 +126,7 @@ func (u *Unpackerr) logCurrentQueue(now time.Time) {
 		" %d|%d cmdhooks, stacks; event:%d, hook:%d, del:%d, up %s",
 		u.Retries, u.Finished, stats.HookOK, stats.HookFail, stats.CmdOK, stats.CmdFail,
 		len(u.folders.Events)+len(u.updates)+len(u.folders.Updates), len(u.hookChan), len(u.delChan),
-		durafmt.Parse(now.Sub(version.Started)).LimitFirstN(3).Format(durafmtUnits)) //nolint:mnd
+		carbon.CreateFromStdTime(version.Started).DiffAbsInString(carbon.CreateFromStdTime(now)))
 	u.updateTray(stats, uint(len(u.folders.Events)+len(u.updates)+len(u.folders.Updates)+len(u.delChan)+len(u.hookChan)))
 }
 

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/ui"
-	"github.com/hako/durafmt"
 	flag "github.com/spf13/pflag"
 	"golift.io/cnfg"
 	"golift.io/cnfgfile"
@@ -46,9 +45,6 @@ const (
 	bits8              = 8
 	base32             = 32
 )
-
-//nolint:gochecknoglobals
-var durafmtUnits, _ = durafmt.DefaultUnitsCoder.Decode("year,week,day,hour,min,sec,ms:ms,µs:µs")
 
 // Unpackerr stores all the running data.
 type Unpackerr struct {

--- a/pkg/unpackerr/tray.go
+++ b/pkg/unpackerr/tray.go
@@ -8,13 +8,12 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/bindata"
 	"github.com/Unpackerr/unpackerr/pkg/ui"
 	"github.com/Unpackerr/unpackerr/pkg/update"
+	"github.com/dromara/carbon/v2"
 	"github.com/energye/systray"
-	"github.com/hako/durafmt"
 	"golift.io/version"
 )
 
@@ -231,9 +230,7 @@ func (u *Unpackerr) checkForUpdate() {
 		return
 	}
 
-	const limitUnit = 3
-
-	ago := durafmt.Parse(time.Since(update.RelDate)).LimitFirstN(limitUnit).Format(durafmtUnits)
+	ago := carbon.CreateFromStdTime(update.RelDate).DiffAbsInString()
 
 	if !update.Outdate {
 		_, _ = ui.Info("Unpackerr", "You're up to date! Version: %s\nUpdated: %s (%s ago)",

--- a/pkg/unpackerr/tray_other.go
+++ b/pkg/unpackerr/tray_other.go
@@ -10,7 +10,8 @@ import (
 
 func (u *Unpackerr) startTray() {
 	go u.Run()
-	defer u.Xtractr.Stop() // stop and wait for extractions to finish.
+	defer u.Stop() // stop and wait for extractions to finish.
+
 	signal.Notify(u.sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	u.Printf("[unpackerr] Need help? %s\n=====> Exiting! Caught Signal: %v", helpLink, <-u.sigChan)
 }


### PR DESCRIPTION
Switch time formatter from durafmt to carbon. Mostly a no-op, just a dependency change. Also a couple lint fixes.

- Closes #607