### PR TITLE
Fix config generator copy in definitions.yml

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     - UN_FOLDER_0_DISABLE_LOG=false
     - UN_FOLDER_0_MOVE_BACK=false
     - UN_FOLDER_0_EXTRACT_ISOS=false
-    ## Web Hooks
+    ## Webhooks
     - UN_WEBHOOK_0_URL=https://notifiarr.com/api/v1/notification/unpackerr/api_key_from_notifiarr_com
     - UN_WEBHOOK_0_NAME=
     - UN_WEBHOOK_0_SILENT=false
@@ -138,4 +138,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 08 MAR 2026 18:55 UTC
+## => Content Auto Generated, 26 AUG 2026 08:51 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -268,7 +268,8 @@ passwords = []
 ## Path to extract files to. The default (leaving this blank) is the same as `path` (above).
 # extract_path = ''
 ## Delete extracted or original files this long after extraction.
-## The default is 0. Set to 0 to disable all deletes. Uncomment it to enable deletes. Uses Go Duration.
+## The default is 10m. Set to 0 to disable all deletes. Deletes also
+## require `delete_files` and/or `delete_original`. Uses Go Duration.
 # delete_after = "10m"
 ## Unpackerr extracts archives inside archives. Set this to true to disable recursive extractions.
 # disable_recursion = false
@@ -343,4 +344,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 08 MAR 2026 18:55 UTC
+## => Content Auto Generated, 26 AUG 2026 08:51 UTC

--- a/init/config/definitions.yml
+++ b/init/config/definitions.yml
@@ -383,7 +383,7 @@ sections:
   webserver:
     title: Web Server
     docs: |
-      :::note Metrics
+      :::note[Metrics]
       The web server currently only provides prometheus metrics, which you can display in
       [Grafana](https://grafana.com/grafana/dashboards/18817-unpackerr/).
       It provides no UI. This may change in the future. The web server was added in v0.12.0.
@@ -394,7 +394,7 @@ sections:
         envvar: METRICS
         default: false
         recommend: *BOOLEAN
-        short: Extracted folders are written with this mode
+        short: Enable the Prometheus metrics endpoint.
         desc: The web server currently only supports metrics; set this to true if you wish to use it.
       - name: listen_addr
         envvar: LISTEN_ADDR
@@ -576,7 +576,7 @@ sections:
       ##################################################################################
     docs: |
       Folders are a way to watch a folder for things to extract. You can use this to
-      monitor your download client's "move to" path if you're not using it with an Starr app.
+      monitor your download client's "move to" path if you're not using it with a Starr app.
     envvar_prefix: FOLDER_
     kind: list
     params:
@@ -606,7 +606,8 @@ sections:
         short: Delete requested files after this duration; `0` disables.
         desc: |
           Delete extracted or original files this long after extraction.
-          The default is 0. Set to 0 to disable all deletes. Uncomment it to enable deletes. Uses Go Duration.
+          The default is 10m. Set to 0 to disable all deletes. Deletes also
+          require `delete_files` and/or `delete_original`. Uses Go Duration.
       - name: disable_recursion
         envvar: DISABLE_RECURSION
         default: false
@@ -629,7 +630,7 @@ sections:
         envvar: DISABLE_LOG
         default: false
         recommend: *BOOLEAN
-        short: Turns off creation of extraction logs files for this folder.
+        short: Turns off creation of extraction log files for this folder.
         desc: Disable extraction log (unpackerred.txt) file creation?
       - name: move_back
         envvar: MOVE_BACK
@@ -645,7 +646,7 @@ sections:
         desc: Set this to true if you want this app to extract ISO files with .iso extension.
 
   webhook:
-    title: Web Hooks
+    title: Webhooks
     text: |
       ################
       ### Webhooks ###


### PR DESCRIPTION
## Summary
- `webserver.metrics.short` was copied from `dir_mode`; it now describes the Prometheus endpoint.
- Folder `delete_after` description matches the 10m default; deletes still need `delete_files` / `delete_original`.
- `disable_log` grammar, "a Starr app", `:::note[Metrics]`, and Webhooks heading.
- Regenerated `examples/unpackerr.conf.example` and `examples/docker-compose.yml`.

unpackerr.zip config docs pick this up from `main` via `generate.sh` after merge.

## Test plan
- [ ] `go generate ./init/config`
- [ ] Confirm metrics short and delete_after comments in the example conf


Made with [Cursor](https://cursor.com)