### PR TITLE
Harden definitions validator against list panics and nested MDX braces

### DIFF
--- a/init/config/compose.go
+++ b/init/config/compose.go
@@ -114,17 +114,27 @@ func (p *Param) Compose(prefix string) string {
 	default:
 		return fmt.Sprint(prefix, p.EnvVar, "=", val, "\n")
 	case list:
+		items, ok := val.([]any)
+		if !ok {
+			return ""
+		}
+
 		var out strings.Builder
 
-		for idx, sv := range val.([]any) { //nolint:forcetypeassert
+		for idx, sv := range items {
 			fmt.Fprint(&out, prefix, p.EnvVar, idx, "=", sv, "\n")
 		}
 
 		return out.String()
 	case "conlist":
+		items, ok := val.([]any)
+		if !ok {
+			return ""
+		}
+
 		var out strings.Builder
 
-		for _, sv := range val.([]any) { //nolint:forcetypeassert
+		for _, sv := range items {
 			fmt.Fprint(&out, sv)
 		}
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -158,6 +158,11 @@ func TestMDXUnescapedBrace(t *testing.T) {
 		t.Fatalf("braces inside JS comments should be accepted: %v", commented)
 	}
 
+	regex := mdxProblems(`<X value={{re: /[}]/}} />`, "fixture")
+	if len(regex) != 0 {
+		t.Fatalf("braces inside JS regex character classes should be accepted: %v", regex)
+	}
+
 	escapedOpen := mdxProblems(`\{{x}}`, "fixture")
 	if len(escapedOpen) == 0 {
 		t.Fatal(`\{{x}} is an escaped { plus leftover braces and must be flagged`)
@@ -434,6 +439,21 @@ func TestMDXIndentedCodeContext(t *testing.T) {
 	if len(tabOpener) == 0 {
 		t.Fatal("a tab-indented ``` is indented code, not a fence; later { must be flagged")
 	}
+
+	afterHeading := mdxProblems("# Heading\n    {ok}\n", "fixture")
+	if len(afterHeading) != 0 {
+		t.Fatalf("indented code after an ATX heading is code: %v", afterHeading)
+	}
+
+	afterBreak := mdxProblems("---\n    {ok}\n", "fixture")
+	if len(afterBreak) != 0 {
+		t.Fatalf("indented code after a thematic break is code: %v", afterBreak)
+	}
+
+	afterList := mdxProblems("- item\n    {broken", "fixture")
+	if len(afterList) == 0 {
+		t.Fatal("an indented line continuing a list paragraph is MDX; { must be flagged")
+	}
 }
 
 func TestMDXExactBacktickRunCloses(t *testing.T) {
@@ -507,8 +527,10 @@ func TestValidateListKindOverride(t *testing.T) {
 func TestComposeListScalarDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
-	param := &Param{Kind: list, EnvVar: "X", Default: "not-a-list"}
-	if got := param.Compose("UN_"); got != "" {
-		t.Fatalf("scalar list compose should emit nothing, got %q", got)
+	for _, kind := range []string{list, "conlist"} {
+		param := &Param{Kind: kind, EnvVar: "X", Default: "not-a-list"}
+		if got := param.Compose("UN_"); got != "" {
+			t.Fatalf("%s scalar compose should emit nothing, got %q", kind, got)
+		}
 	}
 }

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -138,6 +138,16 @@ func TestMDXUnescapedBrace(t *testing.T) {
 		t.Fatalf("complete {{ JSX }} should be accepted: %v", accepted)
 	}
 
+	nested := mdxProblems("{{a: {b: 1}}}", "fixture")
+	if len(nested) != 0 {
+		t.Fatalf("nested {{ JSX }} objects should be accepted: %v", nested)
+	}
+
+	escapedOpen := mdxProblems(`\{{x}}`, "fixture")
+	if len(escapedOpen) == 0 {
+		t.Fatal(`\{{x}} is an escaped { plus leftover braces and must be flagged`)
+	}
+
 	mixed := mdxProblems("{{name}} and {broken", "fixture")
 	if len(mixed) == 0 {
 		t.Fatal("a bare { after a valid {{ }} span must still be flagged")
@@ -356,11 +366,17 @@ func TestMDXTildeAndLongFence(t *testing.T) {
 		t.Fatalf("content inside a ~~~ fence is code and should be accepted: %v", tilde)
 	}
 
-	// A marker indented four spaces is indented code, not a fence opener. The
-	// braces on that line are therefore MDX and must be flagged.
+	// A marker indented four spaces is indented code, not a fence opener, so
+	// braces on that line are also code and must not be flagged.
 	indented := mdxProblems("    ```{broken}\n", "fixture")
-	if len(indented) == 0 {
-		t.Fatal("a four-space-indented ``` is indented code, not a fence; the { must be flagged")
+	if len(indented) != 0 {
+		t.Fatalf("a four-space-indented line is indented code: %v", indented)
+	}
+
+	// A closing fence indented four spaces does not close; later braces stay code.
+	indentedClose := mdxProblems("```\n    ```\n{stillCode}\n```\n", "fixture")
+	if len(indentedClose) != 0 {
+		t.Fatalf("a four-space-indented closer must not end the fence: %v", indentedClose)
 	}
 
 	// A closing fence with trailing text does not close the block.
@@ -394,5 +410,55 @@ func TestValidateNilDefRendering(t *testing.T) {
 
 	if err := config.validate(); err == nil {
 		t.Fatal("a null def entry must fail validation, not panic")
+	}
+}
+
+func TestValidateListKindScalar(t *testing.T) {
+	t.Parallel()
+
+	config := loadTestConfig(t)
+	found := false
+
+	for _, param := range config.Sections["global"].Params {
+		if param != nil && param.Kind == list {
+			param.Default = "not-a-list"
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Fatal("fixture missing a list param")
+	}
+
+	if err := config.validate(); err == nil {
+		t.Fatal("a scalar default on a list param must fail validation, not panic")
+	}
+}
+
+func TestValidateListKindOverride(t *testing.T) {
+	t.Parallel()
+
+	config := loadTestConfig(t)
+
+	def := config.Defs["starr"]["radarr"]
+	if def.Defaults == nil {
+		def.Defaults = map[string]any{}
+	}
+
+	def.Defaults["paths"] = "/downloads"
+
+	if err := config.validate(); err == nil {
+		t.Fatal("a scalar list override must fail validation, not panic")
+	}
+}
+
+func TestComposeListScalarDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	param := &Param{Kind: list, EnvVar: "X", Default: "not-a-list"}
+	if got := param.Compose("UN_"); got != "" {
+		t.Fatalf("scalar list compose should emit nothing, got %q", got)
 	}
 }

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -454,6 +454,30 @@ func TestMDXIndentedCodeContext(t *testing.T) {
 	if len(afterList) == 0 {
 		t.Fatal("an indented line continuing a list paragraph is MDX; { must be flagged")
 	}
+
+	listBlank := mdxProblems("- item\n\n    {broken", "fixture")
+	if len(listBlank) == 0 {
+		t.Fatal("four spaces in a list item is a paragraph, not indented code; { must be flagged")
+	}
+
+	listCode := mdxProblems("- item\n\n      {ok}\n", "fixture")
+	if len(listCode) != 0 {
+		t.Fatalf("six spaces in a list item is indented code: %v", listCode)
+	}
+}
+
+func TestMDXJSXKeywordRegex(t *testing.T) {
+	t.Parallel()
+
+	ret := mdxProblems("{{fn: function () { return /}/ }}}", "fixture")
+	if len(ret) != 0 {
+		t.Fatalf("a regex after return should be accepted: %v", ret)
+	}
+
+	thr := mdxProblems("{{fn: function () { throw /}/ }}}", "fixture")
+	if len(thr) != 0 {
+		t.Fatalf("a regex after throw should be accepted: %v", thr)
+	}
 }
 
 func TestMDXJSXPostfixDivision(t *testing.T) {

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -478,6 +478,11 @@ func TestMDXJSXKeywordRegex(t *testing.T) {
 	if len(thr) != 0 {
 		t.Fatalf("a regex after throw should be accepted: %v", thr)
 	}
+
+	prop := mdxProblems("{{value: obj.return / 2}}", "fixture")
+	if len(prop) != 0 {
+		t.Fatalf("division after a .return property is not a regex: %v", prop)
+	}
 }
 
 func TestMDXJSXPostfixDivision(t *testing.T) {
@@ -510,6 +515,20 @@ func TestMDXSetextAndIndentedHeading(t *testing.T) {
 	notSetext := mdxProblems("--\n    {broken", "fixture")
 	if len(notSetext) == 0 {
 		t.Fatal("a standalone -- is a paragraph, not a setext underline; { must be flagged")
+	}
+}
+
+func TestMDXListFenceAndTabPad(t *testing.T) {
+	t.Parallel()
+
+	tabPad := mdxProblems("-\titem\n\n      {broken", "fixture")
+	if len(tabPad) == 0 {
+		t.Fatal("a tab after - pads to column 4; six spaces is still a list paragraph")
+	}
+
+	listFence := mdxProblems("- ```\n  code\n  ```\n{broken", "fixture")
+	if len(listFence) == 0 {
+		t.Fatal("a fence starting after a list marker must close; later { must be flagged")
 	}
 }
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -401,6 +401,41 @@ func TestMDXTildeAndLongFence(t *testing.T) {
 	}
 }
 
+func TestMDXIndentedCodeContext(t *testing.T) {
+	t.Parallel()
+
+	// CommonMark: indented code cannot interrupt a paragraph.
+	continuation := mdxProblems("text\n    {broken", "fixture")
+	if len(continuation) == 0 {
+		t.Fatal("an indented line continuing a paragraph is MDX; { must be flagged")
+	}
+
+	afterBlank := mdxProblems("text\n\n    {ok}\n", "fixture")
+	if len(afterBlank) != 0 {
+		t.Fatalf("indented code after a blank line is code: %v", afterBlank)
+	}
+
+	afterFence := mdxProblems("```\ncode\n```\n    {ok}\n", "fixture")
+	if len(afterFence) != 0 {
+		t.Fatalf("indented code after a fence is code: %v", afterFence)
+	}
+
+	tabbed := mdxProblems("\t{ok}\n", "fixture")
+	if len(tabbed) != 0 {
+		t.Fatalf("a tab-indented line is indented code: %v", tabbed)
+	}
+
+	tabCloser := mdxProblems("```\n\t```\n{stillCode}\n```\n", "fixture")
+	if len(tabCloser) != 0 {
+		t.Fatalf("a tab-indented closer must not end the fence: %v", tabCloser)
+	}
+
+	tabOpener := mdxProblems("\t```\n{broken}\n```\n", "fixture")
+	if len(tabOpener) == 0 {
+		t.Fatal("a tab-indented ``` is indented code, not a fence; later { must be flagged")
+	}
+}
+
 func TestMDXExactBacktickRunCloses(t *testing.T) {
 	t.Parallel()
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -503,6 +503,16 @@ func TestMDXJSXKeywordRegex(t *testing.T) {
 	if len(inst) != 0 {
 		t.Fatalf("a regex after instanceof should be accepted: %v", inst)
 	}
+
+	ofFor := mdxProblems("{{fn: () => { for (const x of /}/g) {} }}}", "fixture")
+	if len(ofFor) != 0 {
+		t.Fatalf("a regex after for-of should be accepted: %v", ofFor)
+	}
+
+	ofVar := mdxProblems("{{n: of /}/}}", "fixture")
+	if len(ofVar) == 0 {
+		t.Fatal("division after an of variable is not a regex; } must be flagged")
+	}
 }
 
 func TestMDXJSXPostfixDivision(t *testing.T) {
@@ -535,6 +545,11 @@ func TestMDXSetextAndIndentedHeading(t *testing.T) {
 	notSetext := mdxProblems("--\n    {broken", "fixture")
 	if len(notSetext) == 0 {
 		t.Fatal("a standalone -- is a paragraph, not a setext underline; { must be flagged")
+	}
+
+	spaced := mdxProblems("text\n- -\n    {broken", "fixture")
+	if len(spaced) == 0 {
+		t.Fatal("spaces in - - are not a setext underline; { must be flagged")
 	}
 }
 
@@ -584,6 +599,20 @@ func TestMDXListFenceAndTabPad(t *testing.T) {
 	one := mdxProblems("text\n1. ~~~\n   {ok}\n   ~~~\n", "fixture")
 	if len(one) != 0 {
 		t.Fatalf("a 1. list can interrupt a paragraph with a fence: %v", one)
+	}
+}
+
+func TestMDXThematicAndEmptyList(t *testing.T) {
+	t.Parallel()
+
+	breakThenCode := mdxProblems("* * *\n    {ok}\n", "fixture")
+	if len(breakThenCode) != 0 {
+		t.Fatalf("indented code after a thematic break is code: %v", breakThenCode)
+	}
+
+	emptyStar := mdxProblems("text\n*\n\n    {ok}\n", "fixture")
+	if len(emptyStar) != 0 {
+		t.Fatalf("an empty * cannot interrupt a paragraph; later indent is code: %v", emptyStar)
 	}
 }
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -493,6 +493,16 @@ func TestMDXJSXKeywordRegex(t *testing.T) {
 	if len(ctrl) != 0 {
 		t.Fatalf("a regex after if (x) should be accepted: %v", ctrl)
 	}
+
+	inOp := mdxProblems(`{{ok: "x" in /}/}}`, "fixture")
+	if len(inOp) != 0 {
+		t.Fatalf("a regex after in should be accepted: %v", inOp)
+	}
+
+	inst := mdxProblems("{{ok: x instanceof /}/}}", "fixture")
+	if len(inst) != 0 {
+		t.Fatalf("a regex after instanceof should be accepted: %v", inst)
+	}
 }
 
 func TestMDXJSXPostfixDivision(t *testing.T) {
@@ -559,6 +569,21 @@ func TestMDXListFenceAndTabPad(t *testing.T) {
 	rootFence := mdxProblems("- ```\n  inner\n```\n{ok}\n", "fixture")
 	if len(rootFence) != 0 {
 		t.Fatalf("a dedented fence after a list item opens a new fence: %v", rootFence)
+	}
+
+	nested := mdxProblems("- outer\n  - inner\n  outer\n\n    {broken", "fixture")
+	if len(nested) == 0 {
+		t.Fatal("dedenting to the outer list keeps its indent; { must be flagged")
+	}
+
+	ordered := mdxProblems("text\n2. ~~~\n   {broken}\n   ~~~", "fixture")
+	if len(ordered) == 0 {
+		t.Fatal("a 2. marker cannot interrupt a paragraph; { must be flagged")
+	}
+
+	one := mdxProblems("text\n1. ~~~\n   {ok}\n   ~~~\n", "fixture")
+	if len(one) != 0 {
+		t.Fatalf("a 1. list can interrupt a paragraph with a fence: %v", one)
 	}
 }
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -456,6 +456,39 @@ func TestMDXIndentedCodeContext(t *testing.T) {
 	}
 }
 
+func TestMDXJSXPostfixDivision(t *testing.T) {
+	t.Parallel()
+
+	plus := mdxProblems("{{n: i++ / 2}}", "fixture")
+	if len(plus) != 0 {
+		t.Fatalf("division after postfix ++ is not a regex: %v", plus)
+	}
+
+	minus := mdxProblems("{{n: i-- / 2}}", "fixture")
+	if len(minus) != 0 {
+		t.Fatalf("division after postfix -- is not a regex: %v", minus)
+	}
+}
+
+func TestMDXSetextAndIndentedHeading(t *testing.T) {
+	t.Parallel()
+
+	indentedHeading := mdxProblems("text\n    # still paragraph\n    {broken", "fixture")
+	if len(indentedHeading) == 0 {
+		t.Fatal("an indented # line continues the paragraph; later { must be flagged")
+	}
+
+	setext := mdxProblems("Title\n-\n    {ok}\n", "fixture")
+	if len(setext) != 0 {
+		t.Fatalf("indented code after a one-dash setext heading is code: %v", setext)
+	}
+
+	notSetext := mdxProblems("--\n    {broken", "fixture")
+	if len(notSetext) == 0 {
+		t.Fatal("a standalone -- is a paragraph, not a setext underline; { must be flagged")
+	}
+}
+
 func TestMDXExactBacktickRunCloses(t *testing.T) {
 	t.Parallel()
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -483,6 +483,16 @@ func TestMDXJSXKeywordRegex(t *testing.T) {
 	if len(prop) != 0 {
 		t.Fatalf("division after a .return property is not a regex: %v", prop)
 	}
+
+	div := mdxProblems("{{fn: () => { return 1 / 2 }}}", "fixture")
+	if len(div) != 0 {
+		t.Fatalf("division after return 1 is not a regex: %v", div)
+	}
+
+	ctrl := mdxProblems("{{fn: x => { if (x) /}/.test(x) }}}", "fixture")
+	if len(ctrl) != 0 {
+		t.Fatalf("a regex after if (x) should be accepted: %v", ctrl)
+	}
 }
 
 func TestMDXJSXPostfixDivision(t *testing.T) {
@@ -529,6 +539,26 @@ func TestMDXListFenceAndTabPad(t *testing.T) {
 	listFence := mdxProblems("- ```\n  code\n  ```\n{broken", "fixture")
 	if len(listFence) == 0 {
 		t.Fatal("a fence starting after a list marker must close; later { must be flagged")
+	}
+
+	dedent := mdxProblems("- ```\n  code\noutside {broken", "fixture")
+	if len(dedent) == 0 {
+		t.Fatal("a list fence ends when the line leaves the list; later { must be flagged")
+	}
+
+	blank := mdxProblems("- ```\n  code\n\n  {ok}\n  ```\n", "fixture")
+	if len(blank) != 0 {
+		t.Fatalf("a blank line does not end a list fence: %v", blank)
+	}
+
+	indentedList := mdxProblems("    - ```\n{broken", "fixture")
+	if len(indentedList) == 0 {
+		t.Fatal("an indented-code list marker is not a fence opener; later { must be flagged")
+	}
+
+	rootFence := mdxProblems("- ```\n  inner\n```\n{ok}\n", "fixture")
+	if len(rootFence) != 0 {
+		t.Fatalf("a dedented fence after a list item opens a new fence: %v", rootFence)
 	}
 }
 

--- a/init/config/definitions_test.go
+++ b/init/config/definitions_test.go
@@ -143,6 +143,21 @@ func TestMDXUnescapedBrace(t *testing.T) {
 		t.Fatalf("nested {{ JSX }} objects should be accepted: %v", nested)
 	}
 
+	quoted := mdxProblems(`<X value={{text: "}"}} />`, "fixture")
+	if len(quoted) != 0 {
+		t.Fatalf("braces inside JS strings should be accepted: %v", quoted)
+	}
+
+	quoted = mdxProblems(`<X value={{text: "{"}} />`, "fixture")
+	if len(quoted) != 0 {
+		t.Fatalf("an opening brace inside a JS string should be accepted: %v", quoted)
+	}
+
+	commented := mdxProblems("{{a: 1 /* } */}}", "fixture")
+	if len(commented) != 0 {
+		t.Fatalf("braces inside JS comments should be accepted: %v", commented)
+	}
+
 	escapedOpen := mdxProblems(`\{{x}}`, "fixture")
 	if len(escapedOpen) == 0 {
 		t.Fatal(`\{{x}} is an escaped { plus leftover braces and must be flagged`)

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -390,17 +390,20 @@ func stripAllowedBraces(line string) string {
 }
 
 // balancedBraceEnd returns the index after a complete brace group starting at
-// idx, counting nested unescaped { and }. Braces inside JavaScript strings and
-// comments are ignored. idx must point at an unescaped '{'.
+// idx, counting nested unescaped { and }. Braces inside JavaScript strings,
+// comments, and regex literals are ignored. idx must point at an unescaped '{'.
 func balancedBraceEnd(content string, idx int) int {
 	depth := 0
 
+	var prev byte
+
 	for pos := idx; pos < len(content); {
-		if skip, next := skipJSLexical(content, pos); skip {
+		if skip, next := skipJSLexical(content, pos, prev); skip {
 			if next < 0 {
 				return -1
 			}
 
+			prev = jsLexicalPrev(content, pos, next, prev)
 			pos = next
 
 			continue
@@ -414,10 +417,17 @@ func balancedBraceEnd(content string, idx int) int {
 		switch content[pos] {
 		case '{':
 			depth++
+			prev = '{'
 		case '}':
 			depth--
 			if depth == 0 {
 				return pos + 1
+			}
+
+			prev = '}'
+		default:
+			if content[pos] != ' ' && content[pos] != '\t' && content[pos] != '\n' && content[pos] != '\r' {
+				prev = content[pos]
 			}
 		}
 
@@ -427,9 +437,9 @@ func balancedBraceEnd(content string, idx int) int {
 	return -1
 }
 
-// skipJSLexical reports whether pos starts a JS string or comment and, if so,
-// the index after that construct (or -1 if a string is unterminated).
-func skipJSLexical(content string, pos int) (bool, int) {
+// skipJSLexical reports whether pos starts a JS string, comment, or regex
+// literal and, if so, the index after that construct (or -1 if unterminated).
+func skipJSLexical(content string, pos int, prev byte) (bool, int) {
 	if pos >= len(content) {
 		return false, pos
 	}
@@ -448,9 +458,86 @@ func skipJSLexical(content string, pos int) (bool, int) {
 		case '*':
 			return true, skipJSBlockComment(content, pos)
 		}
+
+		if canStartJSRegex(prev) {
+			return true, skipJSRegex(content, pos)
+		}
 	}
 
 	return false, pos
+}
+
+func jsLexicalPrev(content string, start, end int, prev byte) byte {
+	if start >= len(content) || content[start] != '/' {
+		if end > start {
+			return content[end-1]
+		}
+
+		return prev
+	}
+
+	if start+1 < len(content) && (content[start+1] == '/' || content[start+1] == '*') {
+		return prev
+	}
+
+	if end > start {
+		return content[end-1]
+	}
+
+	return prev
+}
+
+func canStartJSRegex(prev byte) bool {
+	switch prev {
+	case 0, '(', '[', '{', ',', '=', ':', ';', '!', '&', '|', '?', '+', '-', '*', '%', '^', '~', '<', '>':
+		return true
+	default:
+		return false
+	}
+}
+
+func skipJSRegex(content string, pos int) int {
+	inClass := false
+
+	for idx := pos + 1; idx < len(content); idx++ {
+		if content[idx] == '\n' {
+			return -1
+		}
+
+		if oddEscapes(content, idx) {
+			continue
+		}
+
+		switch {
+		case inClass:
+			if content[idx] == ']' {
+				inClass = false
+			}
+		case content[idx] == '[':
+			inClass = true
+		case content[idx] == '/':
+			return skipJSRegexpFlags(content, idx+1)
+		}
+	}
+
+	return -1
+}
+
+func skipJSRegexpFlags(content string, pos int) int {
+	for pos < len(content) && isJSRegexpFlag(content[pos]) {
+		pos++
+	}
+
+	return pos
+}
+
+func isJSRegexpFlag(char byte) bool {
+	switch char {
+	case 'd', 'g', 'i', 'm', 's', 'u', 'v', 'y':
+		return true
+	default:
+		return false
+	}
 }
 
 func skipJSString(content string, pos int) int {
@@ -489,6 +576,7 @@ const (
 	minFenceLen    = 3
 	maxFenceIndent = 3
 	tabWidth       = 4
+	minSetextDash  = 2
 )
 
 // stripCodeBlocks removes fenced and indented code. A fence opens with a run of
@@ -548,7 +636,7 @@ func stripCodeBlocks(content string) string {
 		out.WriteByte('\n')
 
 		inIndented = false
-		canStartIndented = false
+		canStartIndented = leafBlockLine(trimmed)
 	}
 
 	return out.String()
@@ -581,6 +669,90 @@ func leadingIndent(line string) int {
 	}
 
 	return col
+}
+
+// leafBlockLine reports whether trimmed is a CommonMark leaf block that ends
+// a paragraph: an ATX heading, thematic break, or setext underline. Indented
+// code may start on the next line. List items and other containers still hold
+// a paragraph, so they do not qualify.
+func leafBlockLine(trimmed string) bool {
+	return atxHeading(trimmed) || thematicBreak(trimmed) || setextUnderline(trimmed)
+}
+
+func atxHeading(trimmed string) bool {
+	hashes := 0
+	for hashes < len(trimmed) && trimmed[hashes] == '#' {
+		hashes++
+	}
+
+	if hashes < 1 || hashes > 6 {
+		return false
+	}
+
+	if hashes == len(trimmed) {
+		return true
+	}
+
+	return trimmed[hashes] == ' ' || trimmed[hashes] == '\t'
+}
+
+func thematicBreak(trimmed string) bool {
+	var marker byte
+
+	count := 0
+
+	for idx := range len(trimmed) {
+		char := trimmed[idx]
+		if char == ' ' || char == '\t' {
+			continue
+		}
+
+		if char != '-' && char != '*' && char != '_' {
+			return false
+		}
+
+		if marker == 0 {
+			marker = char
+		} else if char != marker {
+			return false
+		}
+
+		count++
+	}
+
+	return count >= minFenceLen
+}
+
+func setextUnderline(trimmed string) bool {
+	var marker byte
+
+	count := 0
+
+	for idx := range len(trimmed) {
+		char := trimmed[idx]
+		if char == ' ' || char == '\t' {
+			continue
+		}
+
+		if char != '=' && char != '-' {
+			return false
+		}
+
+		if marker == 0 {
+			marker = char
+		} else if char != marker {
+			return false
+		}
+
+		count++
+	}
+
+	if marker == '=' {
+		return count >= 1
+	}
+
+	// A single dash is a list marker, not a setext underline.
+	return count >= minSetextDash
 }
 
 // fenceOpener reports whether a trimmed line opens a code fence: 3+ of the same

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -448,14 +448,18 @@ func balancedBraceEnd(content string, idx int) int {
 type jsPunct struct {
 	prev, before byte
 	ident        string
+	parenDepth   int
 	keyword      bool
 	member       bool
+	control      bool
+	afterCtrl    bool
 }
 
 func (punct *jsPunct) saw(char byte, adjacent bool) {
 	if isJSIdentChar(char, punct.ident != "") {
 		if punct.ident == "" {
 			punct.member = punct.prev == '.'
+			punct.afterCtrl = false
 		}
 
 		punct.ident += string(char)
@@ -465,7 +469,37 @@ func (punct *jsPunct) saw(char byte, adjacent bool) {
 	}
 
 	punct.finishIdent()
+	punct.keyword = false
+	punct.trackControl(char)
 	punct.sawPunct(char, adjacent)
+}
+
+func (punct *jsPunct) trackControl(char byte) {
+	switch char {
+	case '(':
+		if punct.control && punct.parenDepth == 0 {
+			punct.parenDepth = 1
+		} else if punct.parenDepth > 0 {
+			punct.parenDepth++
+		}
+
+		punct.control = false
+		punct.afterCtrl = false
+	case ')':
+		if punct.parenDepth == 0 {
+			punct.afterCtrl = false
+
+			return
+		}
+
+		punct.parenDepth--
+		if punct.parenDepth == 0 {
+			punct.afterCtrl = true
+		}
+	default:
+		punct.control = false
+		punct.afterCtrl = false
+	}
 }
 
 func (punct *jsPunct) sawPunct(char byte, adjacent bool) {
@@ -484,6 +518,7 @@ func (punct *jsPunct) finishIdent() {
 	}
 
 	punct.keyword = !punct.member && jsRegexKeyword(punct.ident)
+	punct.control = !punct.member && jsControlKeyword(punct.ident)
 	punct.ident = ""
 	punct.member = false
 }
@@ -510,7 +545,7 @@ func (punct *jsPunct) brace(char byte, depth int, adjacent bool) (bool, int, boo
 }
 
 func (punct *jsPunct) canStartRegex() bool {
-	if punct.keyword {
+	if punct.keyword || punct.afterCtrl {
 		return true
 	}
 
@@ -537,6 +572,8 @@ func (punct *jsPunct) afterLexical(content string, start, end int) {
 	punct.ident = ""
 	punct.keyword = false
 	punct.member = false
+	punct.control = false
+	punct.afterCtrl = false
 
 	if end > start {
 		punct.prev = content[end-1]
@@ -558,6 +595,15 @@ func jsRegexKeyword(ident string) bool {
 	switch ident {
 	case "return", "throw", "case", "else", "do",
 		"typeof", "delete", "void", "new", "yield", "await":
+		return true
+	default:
+		return false
+	}
+}
+
+func jsControlKeyword(ident string) bool {
+	switch ident {
+	case "if", "while", "for", "with":
 		return true
 	default:
 		return false
@@ -720,12 +766,7 @@ func (scan *mdScan) line(line string) {
 	indent := leadingIndent(line)
 	trimmed := strings.TrimSpace(line)
 
-	if scan.inFence {
-		if fenceClosed(indent-scan.fenceBase, trimmed, scan.fenceChar, scan.fenceLen) {
-			scan.inFence = false
-			scan.canStartIndented, scan.lastWasParagraph = true, false
-		}
-
+	if scan.inFence && scan.continueFence(indent, trimmed) {
 		return
 	}
 
@@ -787,13 +828,34 @@ func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel in
 	scan.lastWasParagraph = !scan.canStartIndented
 }
 
-func (scan *mdScan) openFence(indent, rel int, trimmed string) bool {
-	if rel <= maxFenceIndent {
-		if char, length, isOpen := fenceOpener(trimmed); isOpen {
-			scan.startFence(char, length, scan.contentIndent)
+func (scan *mdScan) continueFence(indent int, trimmed string) bool {
+	if fenceClosed(indent-scan.fenceBase, trimmed, scan.fenceChar, scan.fenceLen) {
+		scan.inFence = false
+		scan.canStartIndented, scan.lastWasParagraph = true, false
 
-			return true
-		}
+		return true
+	}
+
+	if trimmed == "" || indent >= scan.fenceBase {
+		return true
+	}
+
+	scan.inFence = false
+	scan.contentIndent = 0
+	scan.canStartIndented, scan.lastWasParagraph = true, false
+
+	return false
+}
+
+func (scan *mdScan) openFence(indent, rel int, trimmed string) bool {
+	if rel > maxFenceIndent {
+		return false
+	}
+
+	if char, length, isOpen := fenceOpener(trimmed); isOpen {
+		scan.startFence(char, length, scan.contentIndent)
+
+		return true
 	}
 
 	if scan.lastWasParagraph && setextUnderline(trimmed) {
@@ -821,7 +883,7 @@ func (scan *mdScan) startFence(char byte, length, base int) {
 }
 
 func fenceClosed(rel int, trimmed string, fenceChar byte, fenceLen int) bool {
-	if rel > maxFenceIndent {
+	if rel < 0 || rel > maxFenceIndent {
 		return false
 	}
 

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -449,10 +449,15 @@ type jsPunct struct {
 	prev, before byte
 	ident        string
 	keyword      bool
+	member       bool
 }
 
 func (punct *jsPunct) saw(char byte, adjacent bool) {
 	if isJSIdentChar(char, punct.ident != "") {
+		if punct.ident == "" {
+			punct.member = punct.prev == '.'
+		}
+
 		punct.ident += string(char)
 		punct.sawPunct(char, adjacent)
 
@@ -478,8 +483,9 @@ func (punct *jsPunct) finishIdent() {
 		return
 	}
 
-	punct.keyword = jsRegexKeyword(punct.ident)
+	punct.keyword = !punct.member && jsRegexKeyword(punct.ident)
 	punct.ident = ""
+	punct.member = false
 }
 
 func (punct *jsPunct) brace(char byte, depth int, adjacent bool) (bool, int, bool) {
@@ -530,6 +536,7 @@ func (punct *jsPunct) afterLexical(content string, start, end int) {
 
 	punct.ident = ""
 	punct.keyword = false
+	punct.member = false
 
 	if end > start {
 		punct.prev = content[end-1]
@@ -729,13 +736,8 @@ func (scan *mdScan) line(line string) {
 		rel = indent
 	}
 
-	if rel <= maxFenceIndent {
-		if char, length, isOpen := fenceOpener(trimmed); isOpen {
-			scan.inFence, scan.fenceChar, scan.fenceLen, scan.fenceBase = true, char, length, scan.contentIndent
-			scan.inIndented, scan.canStartIndented, scan.lastWasParagraph = false, true, false
-
-			return
-		}
+	if scan.openFence(indent, rel, trimmed) {
+		return
 	}
 
 	if trimmed == "" {
@@ -762,8 +764,8 @@ func (scan *mdScan) syncList(indent int, trimmed string) {
 		return
 	}
 
-	if pad, ok := listMarkerPad(trimmed); ok {
-		scan.contentIndent = indent + pad
+	if col, _, ok := listItemSplit(indent, trimmed); ok {
+		scan.contentIndent = col
 		return
 	}
 
@@ -776,13 +778,46 @@ func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel in
 
 	scan.inIndented = false
 	if !scan.lastWasParagraph || !setextUnderline(trimmed) {
-		if pad, ok := listMarkerPad(trimmed); ok && rel <= maxFenceIndent {
-			scan.contentIndent = indent + pad
+		if col, _, ok := listItemSplit(indent, trimmed); ok && rel <= maxFenceIndent {
+			scan.contentIndent = col
 		}
 	}
 
 	scan.canStartIndented = rel <= maxFenceIndent && leafBlockLine(trimmed, scan.lastWasParagraph)
 	scan.lastWasParagraph = !scan.canStartIndented
+}
+
+func (scan *mdScan) openFence(indent, rel int, trimmed string) bool {
+	if rel <= maxFenceIndent {
+		if char, length, isOpen := fenceOpener(trimmed); isOpen {
+			scan.startFence(char, length, scan.contentIndent)
+
+			return true
+		}
+	}
+
+	if scan.lastWasParagraph && setextUnderline(trimmed) {
+		return false
+	}
+
+	col, rest, ok := listItemSplit(indent, trimmed)
+	if !ok {
+		return false
+	}
+
+	if char, length, isOpen := fenceOpener(strings.TrimSpace(rest)); isOpen {
+		scan.contentIndent = col
+		scan.startFence(char, length, col)
+
+		return true
+	}
+
+	return false
+}
+
+func (scan *mdScan) startFence(char byte, length, base int) {
+	scan.inFence, scan.fenceChar, scan.fenceLen, scan.fenceBase = true, char, length, base
+	scan.inIndented, scan.canStartIndented, scan.lastWasParagraph = false, true, false
 }
 
 func fenceClosed(rel int, trimmed string, fenceChar byte, fenceLen int) bool {
@@ -795,37 +830,60 @@ func fenceClosed(rel int, trimmed string, fenceChar byte, fenceLen int) bool {
 	return isClose && char == fenceChar && length >= fenceLen
 }
 
-// listMarkerPad reports the width of a CommonMark list marker plus its
-// following padding (1-4 spaces). The caller adds the line's indent to get
-// the list item's content column.
-func listMarkerPad(trimmed string) (int, bool) {
+// listItemSplit reports the content column of a CommonMark list item and the
+// remainder of the line after the marker and padding. Tabs in the padding
+// advance to the next tab stop from the marker's ending column.
+func listItemSplit(indent int, trimmed string) (int, string, bool) {
 	end, ok := consumeListMarker(trimmed)
 	if !ok {
-		return 0, false
+		return 0, "", false
 	}
 
+	col := indent + end
 	if end == len(trimmed) {
-		return end + 1, true
+		return col + 1, "", true
 	}
 
 	if trimmed[end] != ' ' && trimmed[end] != '\t' {
-		return 0, false
+		return 0, "", false
 	}
 
-	pad := 0
-	for end+pad < len(trimmed) && pad < tabWidth && trimmed[end+pad] == ' ' {
-		pad++
+	start := col
+	idx := end
+
+	for idx < len(trimmed) {
+		var advance int
+
+		switch trimmed[idx] {
+		case ' ':
+			advance = 1
+		case '\t':
+			advance = tabWidth - col%tabWidth
+		default:
+			if col == start {
+				return 0, "", false
+			}
+
+			return col, trimmed[idx:], true
+		}
+
+		if col-start+advance > tabWidth {
+			return start + 1, trimmed[end+1:], true
+		}
+
+		col += advance
+		idx++
+
+		if col-start >= tabWidth {
+			return col, trimmed[idx:], true
+		}
 	}
 
-	if pad == 0 {
-		pad = 1
+	if col == start {
+		return 0, "", false
 	}
 
-	if pad == tabWidth && end+pad < len(trimmed) && trimmed[end+pad] == ' ' {
-		pad = 1
-	}
-
-	return end + pad, true
+	return col, "", true
 }
 
 func consumeListMarker(trimmed string) (int, bool) {

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -594,7 +594,8 @@ func isJSIdentChar(char byte, cont bool) bool {
 func jsRegexKeyword(ident string) bool {
 	switch ident {
 	case "return", "throw", "case", "else", "do",
-		"typeof", "delete", "void", "new", "yield", "await":
+		"typeof", "delete", "void", "new", "yield", "await",
+		"in", "instanceof":
 		return true
 	default:
 		return false
@@ -752,6 +753,7 @@ func stripCodeBlocks(content string) string {
 
 type mdScan struct {
 	out              strings.Builder
+	listIndents      []int
 	inFence          bool
 	fenceChar        byte
 	fenceLen         int
@@ -801,16 +803,29 @@ func (scan *mdScan) line(line string) {
 }
 
 func (scan *mdScan) syncList(indent int, trimmed string) {
-	if trimmed == "" || indent >= scan.contentIndent {
+	if trimmed == "" {
 		return
 	}
 
-	if col, _, ok := listItemSplit(indent, trimmed); ok {
-		scan.contentIndent = col
+	scan.popLists(indent)
+}
+
+func (scan *mdScan) pushList(col int) {
+	scan.listIndents = append(scan.listIndents, col)
+	scan.contentIndent = col
+}
+
+func (scan *mdScan) popLists(indent int) {
+	for len(scan.listIndents) > 0 && indent < scan.listIndents[len(scan.listIndents)-1] {
+		scan.listIndents = scan.listIndents[:len(scan.listIndents)-1]
+	}
+
+	if len(scan.listIndents) == 0 {
+		scan.contentIndent = 0
 		return
 	}
 
-	scan.contentIndent = 0
+	scan.contentIndent = scan.listIndents[len(scan.listIndents)-1]
 }
 
 func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel int) {
@@ -819,8 +834,8 @@ func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel in
 
 	scan.inIndented = false
 	if !scan.lastWasParagraph || !setextUnderline(trimmed) {
-		if col, _, ok := listItemSplit(indent, trimmed); ok && rel <= maxFenceIndent {
-			scan.contentIndent = col
+		if col, _, ok := listItemSplit(indent, trimmed); ok && rel <= maxFenceIndent && scan.allowListItem(trimmed) {
+			scan.pushList(col)
 		}
 	}
 
@@ -841,7 +856,7 @@ func (scan *mdScan) continueFence(indent int, trimmed string) bool {
 	}
 
 	scan.inFence = false
-	scan.contentIndent = 0
+	scan.popLists(indent)
 	scan.canStartIndented, scan.lastWasParagraph = true, false
 
 	return false
@@ -863,12 +878,12 @@ func (scan *mdScan) openFence(indent, rel int, trimmed string) bool {
 	}
 
 	col, rest, ok := listItemSplit(indent, trimmed)
-	if !ok {
+	if !ok || !scan.allowListItem(trimmed) {
 		return false
 	}
 
 	if char, length, isOpen := fenceOpener(strings.TrimSpace(rest)); isOpen {
-		scan.contentIndent = col
+		scan.pushList(col)
 		scan.startFence(char, length, col)
 
 		return true
@@ -896,7 +911,7 @@ func fenceClosed(rel int, trimmed string, fenceChar byte, fenceLen int) bool {
 // remainder of the line after the marker and padding. Tabs in the padding
 // advance to the next tab stop from the marker's ending column.
 func listItemSplit(indent int, trimmed string) (int, string, bool) {
-	end, ok := consumeListMarker(trimmed)
+	end, _, ok := consumeListMarker(trimmed)
 	if !ok {
 		return 0, "", false
 	}
@@ -948,26 +963,49 @@ func listItemSplit(indent int, trimmed string) (int, string, bool) {
 	return col, "", true
 }
 
-func consumeListMarker(trimmed string) (int, bool) {
+// bulletStart is consumeListMarker's start value for -, *, and +. Ordered
+// markers return the parsed number, which is never negative.
+const (
+	bulletStart = -1
+	decimalBase = 10
+)
+
+func consumeListMarker(trimmed string) (int, int, bool) {
 	if trimmed == "" {
-		return 0, false
+		return 0, 0, false
 	}
 
 	switch trimmed[0] {
 	case '-', '*', '+':
-		return 1, true
+		return 1, bulletStart, true
 	}
 
 	digits := 0
+	start := 0
+
 	for digits < len(trimmed) && digits < 9 && trimmed[digits] >= '0' && trimmed[digits] <= '9' {
+		start = start*decimalBase + int(trimmed[digits]-'0')
 		digits++
 	}
 
 	if digits == 0 || digits >= len(trimmed) || (trimmed[digits] != '.' && trimmed[digits] != ')') {
-		return 0, false
+		return 0, 0, false
 	}
 
-	return digits + 1, true
+	return digits + 1, start, true
+}
+
+func (scan *mdScan) allowListItem(trimmed string) bool {
+	if !scan.lastWasParagraph {
+		return true
+	}
+
+	_, start, ok := consumeListMarker(trimmed)
+	if !ok {
+		return false
+	}
+
+	return start == bulletStart || start == 1
 }
 
 // leadingIndent returns the visual column of the first non-whitespace rune.

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -306,7 +306,7 @@ func isSeq(val any) bool {
 func mdxProblems(content, where string) []string {
 	var errs []string
 
-	stripped := stripInlineCode(stripIndentedCode(stripFencedCode(content)))
+	stripped := stripInlineCode(stripCodeBlocks(content))
 
 	if admonitionSpace.MatchString(stripped) {
 		errs = append(errs, where+": use :::note[Title] (MDX v2); :::note Title fails Docusaurus compile")
@@ -482,74 +482,106 @@ func skipJSBlockComment(content string, pos int) int {
 	return pos + 2 + end + len("*/")
 }
 
-// stripFencedCode removes fenced code blocks. A fence opens with a run of 3+
-// backticks or tildes (indented at most three spaces) and closes only with the
-// same marker character, a run at least as long, and whitespace-only trailing
-// text (CommonMark). Info strings on the opening fence are ignored.
-func stripFencedCode(content string) string {
-	var out strings.Builder
+// minFenceLen is the minimum run length that opens a CommonMark code fence.
+// maxFenceIndent is the maximum leading columns before a fence becomes indented code.
+// tabWidth is the CommonMark tab-stop width used when measuring indentation.
+const (
+	minFenceLen    = 3
+	maxFenceIndent = 3
+	tabWidth       = 4
+)
 
-	inFence := false
-	fenceChar := byte(0)
-	fenceLen := 0
+// stripCodeBlocks removes fenced and indented code. A fence opens with a run of
+// 3+ backticks or tildes (indented at most three columns) and closes only with
+// the same marker character, a run at least as long, and whitespace-only
+// trailing text (CommonMark). Info strings on the opening fence are ignored.
+// Indented code (4+ columns, including tabs) cannot interrupt a paragraph.
+func stripCodeBlocks(content string) string {
+	var (
+		out              strings.Builder
+		inFence          bool
+		fenceChar        byte
+		fenceLen         int
+		inIndented       bool
+		canStartIndented = true
+	)
 
 	for line := range strings.SplitSeq(content, "\n") {
-		// CommonMark allows up to 3 leading spaces; more makes it indented code.
-		indent := leadingSpaces(line)
+		indent := leadingIndent(line)
 		trimmed := strings.TrimSpace(line)
 
-		if !inFence {
-			if indent <= maxFenceIndent {
-				if char, length, isOpen := fenceOpener(trimmed); isOpen {
-					inFence, fenceChar, fenceLen = true, char, length
-					continue
-				}
+		if inFence {
+			if fenceClosed(indent, trimmed, fenceChar, fenceLen) {
+				inFence = false
+				canStartIndented = true
 			}
-
-			out.WriteString(line)
-			out.WriteByte('\n')
 
 			continue
 		}
 
-		// Inside a fence: close on a compatible marker with at most three leading
-		// spaces and only trailing whitespace after the run.
 		if indent <= maxFenceIndent {
-			if char, length, isClose := fenceCloser(trimmed); isClose && char == fenceChar && length >= fenceLen {
-				inFence = false
+			if char, length, isOpen := fenceOpener(trimmed); isOpen {
+				inFence, fenceChar, fenceLen = true, char, length
+				inIndented = false
+				canStartIndented = true
+
+				continue
 			}
 		}
-	}
 
-	return out.String()
-}
+		if trimmed == "" {
+			out.WriteString(line)
+			out.WriteByte('\n')
 
-// stripIndentedCode removes CommonMark indented code lines (4+ leading spaces).
-func stripIndentedCode(content string) string {
-	var out strings.Builder
+			inIndented = false
+			canStartIndented = true
 
-	for line := range strings.SplitSeq(content, "\n") {
-		if leadingSpaces(line) > maxFenceIndent {
+			continue
+		}
+
+		if indent > maxFenceIndent && (canStartIndented || inIndented) {
+			inIndented = true
 			continue
 		}
 
 		out.WriteString(line)
 		out.WriteByte('\n')
+
+		inIndented = false
+		canStartIndented = false
 	}
 
 	return out.String()
 }
 
-func leadingSpaces(line string) int {
-	return len(line) - len(strings.TrimLeft(line, " "))
+func fenceClosed(indent int, trimmed string, fenceChar byte, fenceLen int) bool {
+	if indent > maxFenceIndent {
+		return false
+	}
+
+	char, length, isClose := fenceCloser(trimmed)
+
+	return isClose && char == fenceChar && length >= fenceLen
 }
 
-// minFenceLen is the minimum run length that opens a CommonMark code fence.
-// maxFenceIndent is the maximum leading spaces before a fence becomes indented code.
-const (
-	minFenceLen    = 3
-	maxFenceIndent = 3
-)
+// leadingIndent returns the visual column of the first non-whitespace rune.
+// CommonMark tabs advance to the next tab stop.
+func leadingIndent(line string) int {
+	col := 0
+
+	for _, r := range line {
+		switch r {
+		case ' ':
+			col++
+		case '\t':
+			col += tabWidth - col%tabWidth
+		default:
+			return col
+		}
+	}
+
+	return col
+}
 
 // fenceOpener reports whether a trimmed line opens a code fence: 3+ of the same
 // backtick or tilde. An optional info string may follow the run.

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -390,31 +390,96 @@ func stripAllowedBraces(line string) string {
 }
 
 // balancedBraceEnd returns the index after a complete brace group starting at
-// idx, counting nested unescaped { and }. idx must point at an unescaped '{'.
+// idx, counting nested unescaped { and }. Braces inside JavaScript strings and
+// comments are ignored. idx must point at an unescaped '{'.
 func balancedBraceEnd(content string, idx int) int {
 	depth := 0
 
-	for pos := idx; pos < len(content); pos++ {
-		if content[pos] != '{' && content[pos] != '}' {
+	for pos := idx; pos < len(content); {
+		if skip, next := skipJSLexical(content, pos); skip {
+			if next < 0 {
+				return -1
+			}
+
+			pos = next
+
 			continue
 		}
 
 		if oddEscapes(content, pos) {
+			pos++
 			continue
 		}
 
-		if content[pos] == '{' {
+		switch content[pos] {
+		case '{':
 			depth++
-			continue
+		case '}':
+			depth--
+			if depth == 0 {
+				return pos + 1
+			}
 		}
 
-		depth--
-		if depth == 0 {
-			return pos + 1
+		pos++
+	}
+
+	return -1
+}
+
+// skipJSLexical reports whether pos starts a JS string or comment and, if so,
+// the index after that construct (or -1 if a string is unterminated).
+func skipJSLexical(content string, pos int) (bool, int) {
+	if pos >= len(content) {
+		return false, pos
+	}
+
+	switch content[pos] {
+	case '"', '\'', '`':
+		return true, skipJSString(content, pos)
+	case '/':
+		if pos+1 >= len(content) {
+			return false, pos
+		}
+
+		switch content[pos+1] {
+		case '/':
+			return true, skipJSLineComment(content, pos)
+		case '*':
+			return true, skipJSBlockComment(content, pos)
+		}
+	}
+
+	return false, pos
+}
+
+func skipJSString(content string, pos int) int {
+	quote := content[pos]
+
+	for idx := pos + 1; idx < len(content); idx++ {
+		if content[idx] == quote && !oddEscapes(content, idx) {
+			return idx + 1
 		}
 	}
 
 	return -1
+}
+
+func skipJSLineComment(content string, pos int) int {
+	if nl := strings.IndexByte(content[pos:], '\n'); nl >= 0 {
+		return pos + nl
+	}
+
+	return len(content)
+}
+
+func skipJSBlockComment(content string, pos int) int {
+	end := strings.Index(content[pos+2:], "*/")
+	if end < 0 {
+		return len(content)
+	}
+
+	return pos + 2 + end + len("*/")
 }
 
 // stripFencedCode removes fenced code blocks. A fence opens with a run of 3+

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -395,16 +395,28 @@ func stripAllowedBraces(line string) string {
 func balancedBraceEnd(content string, idx int) int {
 	depth := 0
 
-	var prev byte
+	var (
+		punct    jsPunct
+		adjacent bool
+	)
 
 	for pos := idx; pos < len(content); {
-		if skip, next := skipJSLexical(content, pos, prev); skip {
+		if skip, next := skipJSLexical(content, pos, punct.canStartRegex()); skip {
 			if next < 0 {
 				return -1
 			}
 
-			prev = jsLexicalPrev(content, pos, next, prev)
+			punct.afterLexical(content, pos, next)
+
+			adjacent = false
 			pos = next
+
+			continue
+		}
+
+		if isJSSpace(content[pos]) {
+			adjacent = false
+			pos++
 
 			continue
 		}
@@ -417,18 +429,20 @@ func balancedBraceEnd(content string, idx int) int {
 		switch content[pos] {
 		case '{':
 			depth++
-			prev = '{'
+
+			punct.saw('{', adjacent)
+			adjacent = true
 		case '}':
 			depth--
 			if depth == 0 {
 				return pos + 1
 			}
 
-			prev = '}'
+			punct.saw('}', adjacent)
+			adjacent = true
 		default:
-			if content[pos] != ' ' && content[pos] != '\t' && content[pos] != '\n' && content[pos] != '\r' {
-				prev = content[pos]
-			}
+			punct.saw(content[pos], adjacent)
+			adjacent = true
 		}
 
 		pos++
@@ -437,9 +451,54 @@ func balancedBraceEnd(content string, idx int) int {
 	return -1
 }
 
+type jsPunct struct {
+	prev, before byte
+}
+
+func (punct *jsPunct) saw(char byte, adjacent bool) {
+	if adjacent {
+		punct.before = punct.prev
+	} else {
+		punct.before = 0
+	}
+
+	punct.prev = char
+}
+
+func (punct *jsPunct) canStartRegex() bool {
+	if punct.prev == '+' && punct.before == '+' {
+		return false
+	}
+
+	if punct.prev == '-' && punct.before == '-' {
+		return false
+	}
+
+	return canStartJSRegex(punct.prev)
+}
+
+func (punct *jsPunct) afterLexical(content string, start, end int) {
+	if start >= len(content) {
+		return
+	}
+
+	if content[start] == '/' && start+1 < len(content) && (content[start+1] == '/' || content[start+1] == '*') {
+		return
+	}
+
+	if end > start {
+		punct.prev = content[end-1]
+		punct.before = 0
+	}
+}
+
+func isJSSpace(char byte) bool {
+	return char == ' ' || char == '\t' || char == '\n' || char == '\r'
+}
+
 // skipJSLexical reports whether pos starts a JS string, comment, or regex
 // literal and, if so, the index after that construct (or -1 if unterminated).
-func skipJSLexical(content string, pos int, prev byte) (bool, int) {
+func skipJSLexical(content string, pos int, startRegex bool) (bool, int) {
 	if pos >= len(content) {
 		return false, pos
 	}
@@ -459,32 +518,12 @@ func skipJSLexical(content string, pos int, prev byte) (bool, int) {
 			return true, skipJSBlockComment(content, pos)
 		}
 
-		if canStartJSRegex(prev) {
+		if startRegex {
 			return true, skipJSRegex(content, pos)
 		}
 	}
 
 	return false, pos
-}
-
-func jsLexicalPrev(content string, start, end int, prev byte) byte {
-	if start >= len(content) || content[start] != '/' {
-		if end > start {
-			return content[end-1]
-		}
-
-		return prev
-	}
-
-	if start+1 < len(content) && (content[start+1] == '/' || content[start+1] == '*') {
-		return prev
-	}
-
-	if end > start {
-		return content[end-1]
-	}
-
-	return prev
 }
 
 func canStartJSRegex(prev byte) bool {
@@ -576,7 +615,6 @@ const (
 	minFenceLen    = 3
 	maxFenceIndent = 3
 	tabWidth       = 4
-	minSetextDash  = 2
 )
 
 // stripCodeBlocks removes fenced and indented code. A fence opens with a run of
@@ -592,6 +630,7 @@ func stripCodeBlocks(content string) string {
 		fenceLen         int
 		inIndented       bool
 		canStartIndented = true
+		lastWasParagraph bool
 	)
 
 	for line := range strings.SplitSeq(content, "\n") {
@@ -601,7 +640,7 @@ func stripCodeBlocks(content string) string {
 		if inFence {
 			if fenceClosed(indent, trimmed, fenceChar, fenceLen) {
 				inFence = false
-				canStartIndented = true
+				canStartIndented, lastWasParagraph = true, false
 			}
 
 			continue
@@ -610,8 +649,7 @@ func stripCodeBlocks(content string) string {
 		if indent <= maxFenceIndent {
 			if char, length, isOpen := fenceOpener(trimmed); isOpen {
 				inFence, fenceChar, fenceLen = true, char, length
-				inIndented = false
-				canStartIndented = true
+				inIndented, canStartIndented, lastWasParagraph = false, true, false
 
 				continue
 			}
@@ -621,14 +659,15 @@ func stripCodeBlocks(content string) string {
 			out.WriteString(line)
 			out.WriteByte('\n')
 
-			inIndented = false
-			canStartIndented = true
+			inIndented, canStartIndented, lastWasParagraph = false, true, false
 
 			continue
 		}
 
 		if indent > maxFenceIndent && (canStartIndented || inIndented) {
 			inIndented = true
+			lastWasParagraph = false
+
 			continue
 		}
 
@@ -636,7 +675,8 @@ func stripCodeBlocks(content string) string {
 		out.WriteByte('\n')
 
 		inIndented = false
-		canStartIndented = leafBlockLine(trimmed)
+		canStartIndented = indent <= maxFenceIndent && leafBlockLine(trimmed, lastWasParagraph)
+		lastWasParagraph = !canStartIndented
 	}
 
 	return out.String()
@@ -671,12 +711,21 @@ func leadingIndent(line string) int {
 	return col
 }
 
-// leafBlockLine reports whether trimmed is a CommonMark leaf block that ends
-// a paragraph: an ATX heading, thematic break, or setext underline. Indented
-// code may start on the next line. List items and other containers still hold
-// a paragraph, so they do not qualify.
-func leafBlockLine(trimmed string) bool {
-	return atxHeading(trimmed) || thematicBreak(trimmed) || setextUnderline(trimmed)
+// leafBlockLine reports whether trimmed is a CommonMark leaf that ends a
+// paragraph so indented code may start on the next line. ATX headings always
+// qualify. Setext underlines only qualify after a paragraph. Thematic breaks
+// qualify when they are not a setext underline (after a paragraph, dashes are
+// setext; stars and underscores are still thematic).
+func leafBlockLine(trimmed string, lastWasParagraph bool) bool {
+	if atxHeading(trimmed) {
+		return true
+	}
+
+	if lastWasParagraph {
+		return setextUnderline(trimmed) || thematicBreak(trimmed)
+	}
+
+	return thematicBreak(trimmed)
 }
 
 func atxHeading(trimmed string) bool {
@@ -747,12 +796,11 @@ func setextUnderline(trimmed string) bool {
 		count++
 	}
 
-	if marker == '=' {
+	if marker == '=' || marker == '-' {
 		return count >= 1
 	}
 
-	// A single dash is a list marker, not a setext underline.
-	return count >= minSetextDash
+	return false
 }
 
 // fenceOpener reports whether a trimmed line opens a code fence: 3+ of the same

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -453,6 +453,8 @@ type jsPunct struct {
 	member       bool
 	control      bool
 	afterCtrl    bool
+	forCtrl      bool
+	forParen     bool
 }
 
 func (punct *jsPunct) saw(char byte, adjacent bool) {
@@ -479,11 +481,13 @@ func (punct *jsPunct) trackControl(char byte) {
 	case '(':
 		if punct.control && punct.parenDepth == 0 {
 			punct.parenDepth = 1
+			punct.forParen = punct.forCtrl
 		} else if punct.parenDepth > 0 {
 			punct.parenDepth++
 		}
 
 		punct.control = false
+		punct.forCtrl = false
 		punct.afterCtrl = false
 	case ')':
 		if punct.parenDepth == 0 {
@@ -495,9 +499,11 @@ func (punct *jsPunct) trackControl(char byte) {
 		punct.parenDepth--
 		if punct.parenDepth == 0 {
 			punct.afterCtrl = true
+			punct.forParen = false
 		}
 	default:
 		punct.control = false
+		punct.forCtrl = false
 		punct.afterCtrl = false
 	}
 }
@@ -517,8 +523,11 @@ func (punct *jsPunct) finishIdent() {
 		return
 	}
 
-	punct.keyword = !punct.member && jsRegexKeyword(punct.ident)
+	isFor := punct.ident == "for"
+	ofInFor := punct.ident == "of" && punct.forParen && punct.parenDepth > 0
+	punct.keyword = !punct.member && (jsRegexKeyword(punct.ident) || ofInFor)
 	punct.control = !punct.member && jsControlKeyword(punct.ident)
+	punct.forCtrl = !punct.member && isFor
 	punct.ident = ""
 	punct.member = false
 }
@@ -833,7 +842,7 @@ func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel in
 	scan.out.WriteByte('\n')
 
 	scan.inIndented = false
-	if !scan.lastWasParagraph || !setextUnderline(trimmed) {
+	if !thematicBreak(trimmed) && (!scan.lastWasParagraph || !setextUnderline(trimmed)) {
 		if col, _, ok := listItemSplit(indent, trimmed); ok && rel <= maxFenceIndent && scan.allowListItem(trimmed) {
 			scan.pushList(col)
 		}
@@ -1001,11 +1010,20 @@ func (scan *mdScan) allowListItem(trimmed string) bool {
 	}
 
 	_, start, ok := consumeListMarker(trimmed)
-	if !ok {
+	if !ok || !listItemHasContent(trimmed) {
 		return false
 	}
 
 	return start == bulletStart || start == 1
+}
+
+func listItemHasContent(trimmed string) bool {
+	end, _, ok := consumeListMarker(trimmed)
+	if !ok || end >= len(trimmed) {
+		return false
+	}
+
+	return strings.TrimSpace(trimmed[end:]) != ""
 }
 
 // leadingIndent returns the visual column of the first non-whitespace rune.
@@ -1089,34 +1107,22 @@ func thematicBreak(trimmed string) bool {
 }
 
 func setextUnderline(trimmed string) bool {
-	var marker byte
-
-	count := 0
-
-	for idx := range len(trimmed) {
-		char := trimmed[idx]
-		if char == ' ' || char == '\t' {
-			continue
-		}
-
-		if char != '=' && char != '-' {
-			return false
-		}
-
-		if marker == 0 {
-			marker = char
-		} else if char != marker {
-			return false
-		}
-
-		count++
+	if trimmed == "" {
+		return false
 	}
 
-	if marker == '=' || marker == '-' {
-		return count >= 1
+	marker := trimmed[0]
+	if marker != '=' && marker != '-' {
+		return false
 	}
 
-	return false
+	for idx := 1; idx < len(trimmed); idx++ {
+		if trimmed[idx] != marker {
+			return false
+		}
+	}
+
+	return true
 }
 
 // fenceOpener reports whether a trimmed line opens a code fence: 3+ of the same

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -401,6 +401,10 @@ func balancedBraceEnd(content string, idx int) int {
 	)
 
 	for pos := idx; pos < len(content); {
+		if !isJSIdentChar(content[pos], punct.ident != "") {
+			punct.finishIdent()
+		}
+
 		if skip, next := skipJSLexical(content, pos, punct.canStartRegex()); skip {
 			if next < 0 {
 				return -1
@@ -415,6 +419,8 @@ func balancedBraceEnd(content string, idx int) int {
 		}
 
 		if isJSSpace(content[pos]) {
+			punct.finishIdent()
+
 			adjacent = false
 			pos++
 
@@ -426,23 +432,11 @@ func balancedBraceEnd(content string, idx int) int {
 			continue
 		}
 
-		switch content[pos] {
-		case '{':
-			depth++
+		var done bool
 
-			punct.saw('{', adjacent)
-			adjacent = true
-		case '}':
-			depth--
-			if depth == 0 {
-				return pos + 1
-			}
-
-			punct.saw('}', adjacent)
-			adjacent = true
-		default:
-			punct.saw(content[pos], adjacent)
-			adjacent = true
+		done, depth, adjacent = punct.brace(content[pos], depth, adjacent)
+		if done {
+			return pos + 1
 		}
 
 		pos++
@@ -453,9 +447,23 @@ func balancedBraceEnd(content string, idx int) int {
 
 type jsPunct struct {
 	prev, before byte
+	ident        string
+	keyword      bool
 }
 
 func (punct *jsPunct) saw(char byte, adjacent bool) {
+	if isJSIdentChar(char, punct.ident != "") {
+		punct.ident += string(char)
+		punct.sawPunct(char, adjacent)
+
+		return
+	}
+
+	punct.finishIdent()
+	punct.sawPunct(char, adjacent)
+}
+
+func (punct *jsPunct) sawPunct(char byte, adjacent bool) {
 	if adjacent {
 		punct.before = punct.prev
 	} else {
@@ -465,7 +473,41 @@ func (punct *jsPunct) saw(char byte, adjacent bool) {
 	punct.prev = char
 }
 
+func (punct *jsPunct) finishIdent() {
+	if punct.ident == "" {
+		return
+	}
+
+	punct.keyword = jsRegexKeyword(punct.ident)
+	punct.ident = ""
+}
+
+func (punct *jsPunct) brace(char byte, depth int, adjacent bool) (bool, int, bool) {
+	switch char {
+	case '{':
+		punct.saw('{', adjacent)
+		return false, depth + 1, true
+	case '}':
+		depth--
+		if depth == 0 {
+			return true, 0, adjacent
+		}
+
+		punct.saw('}', adjacent)
+
+		return false, depth, true
+	default:
+		punct.saw(char, adjacent)
+
+		return false, depth, true
+	}
+}
+
 func (punct *jsPunct) canStartRegex() bool {
+	if punct.keyword {
+		return true
+	}
+
 	if punct.prev == '+' && punct.before == '+' {
 		return false
 	}
@@ -486,9 +528,32 @@ func (punct *jsPunct) afterLexical(content string, start, end int) {
 		return
 	}
 
+	punct.ident = ""
+	punct.keyword = false
+
 	if end > start {
 		punct.prev = content[end-1]
 		punct.before = 0
+	}
+}
+
+func isJSIdentChar(char byte, cont bool) bool {
+	if char == '_' || char == '$' ||
+		(char >= 'A' && char <= 'Z') ||
+		(char >= 'a' && char <= 'z') {
+		return true
+	}
+
+	return cont && char >= '0' && char <= '9'
+}
+
+func jsRegexKeyword(ident string) bool {
+	switch ident {
+	case "return", "throw", "case", "else", "do",
+		"typeof", "delete", "void", "new", "yield", "await":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -623,73 +688,166 @@ const (
 // trailing text (CommonMark). Info strings on the opening fence are ignored.
 // Indented code (4+ columns, including tabs) cannot interrupt a paragraph.
 func stripCodeBlocks(content string) string {
-	var (
-		out              strings.Builder
-		inFence          bool
-		fenceChar        byte
-		fenceLen         int
-		inIndented       bool
-		canStartIndented = true
-		lastWasParagraph bool
-	)
+	scan := mdScan{canStartIndented: true}
 
 	for line := range strings.SplitSeq(content, "\n") {
-		indent := leadingIndent(line)
-		trimmed := strings.TrimSpace(line)
-
-		if inFence {
-			if fenceClosed(indent, trimmed, fenceChar, fenceLen) {
-				inFence = false
-				canStartIndented, lastWasParagraph = true, false
-			}
-
-			continue
-		}
-
-		if indent <= maxFenceIndent {
-			if char, length, isOpen := fenceOpener(trimmed); isOpen {
-				inFence, fenceChar, fenceLen = true, char, length
-				inIndented, canStartIndented, lastWasParagraph = false, true, false
-
-				continue
-			}
-		}
-
-		if trimmed == "" {
-			out.WriteString(line)
-			out.WriteByte('\n')
-
-			inIndented, canStartIndented, lastWasParagraph = false, true, false
-
-			continue
-		}
-
-		if indent > maxFenceIndent && (canStartIndented || inIndented) {
-			inIndented = true
-			lastWasParagraph = false
-
-			continue
-		}
-
-		out.WriteString(line)
-		out.WriteByte('\n')
-
-		inIndented = false
-		canStartIndented = indent <= maxFenceIndent && leafBlockLine(trimmed, lastWasParagraph)
-		lastWasParagraph = !canStartIndented
+		scan.line(line)
 	}
 
-	return out.String()
+	return scan.out.String()
 }
 
-func fenceClosed(indent int, trimmed string, fenceChar byte, fenceLen int) bool {
-	if indent > maxFenceIndent {
+type mdScan struct {
+	out              strings.Builder
+	inFence          bool
+	fenceChar        byte
+	fenceLen         int
+	fenceBase        int
+	inIndented       bool
+	canStartIndented bool
+	lastWasParagraph bool
+	contentIndent    int
+}
+
+func (scan *mdScan) line(line string) {
+	indent := leadingIndent(line)
+	trimmed := strings.TrimSpace(line)
+
+	if scan.inFence {
+		if fenceClosed(indent-scan.fenceBase, trimmed, scan.fenceChar, scan.fenceLen) {
+			scan.inFence = false
+			scan.canStartIndented, scan.lastWasParagraph = true, false
+		}
+
+		return
+	}
+
+	scan.syncList(indent, trimmed)
+
+	rel := indent - scan.contentIndent
+	if rel < 0 {
+		rel = indent
+	}
+
+	if rel <= maxFenceIndent {
+		if char, length, isOpen := fenceOpener(trimmed); isOpen {
+			scan.inFence, scan.fenceChar, scan.fenceLen, scan.fenceBase = true, char, length, scan.contentIndent
+			scan.inIndented, scan.canStartIndented, scan.lastWasParagraph = false, true, false
+
+			return
+		}
+	}
+
+	if trimmed == "" {
+		scan.out.WriteString(line)
+		scan.out.WriteByte('\n')
+
+		scan.inIndented, scan.canStartIndented, scan.lastWasParagraph = false, true, false
+
+		return
+	}
+
+	if rel > maxFenceIndent && (scan.canStartIndented || scan.inIndented) {
+		scan.inIndented = true
+		scan.lastWasParagraph = false
+
+		return
+	}
+
+	scan.writeContent(line, indent, trimmed, rel)
+}
+
+func (scan *mdScan) syncList(indent int, trimmed string) {
+	if trimmed == "" || indent >= scan.contentIndent {
+		return
+	}
+
+	if pad, ok := listMarkerPad(trimmed); ok {
+		scan.contentIndent = indent + pad
+		return
+	}
+
+	scan.contentIndent = 0
+}
+
+func (scan *mdScan) writeContent(line string, indent int, trimmed string, rel int) {
+	scan.out.WriteString(line)
+	scan.out.WriteByte('\n')
+
+	scan.inIndented = false
+	if !scan.lastWasParagraph || !setextUnderline(trimmed) {
+		if pad, ok := listMarkerPad(trimmed); ok && rel <= maxFenceIndent {
+			scan.contentIndent = indent + pad
+		}
+	}
+
+	scan.canStartIndented = rel <= maxFenceIndent && leafBlockLine(trimmed, scan.lastWasParagraph)
+	scan.lastWasParagraph = !scan.canStartIndented
+}
+
+func fenceClosed(rel int, trimmed string, fenceChar byte, fenceLen int) bool {
+	if rel > maxFenceIndent {
 		return false
 	}
 
 	char, length, isClose := fenceCloser(trimmed)
 
 	return isClose && char == fenceChar && length >= fenceLen
+}
+
+// listMarkerPad reports the width of a CommonMark list marker plus its
+// following padding (1-4 spaces). The caller adds the line's indent to get
+// the list item's content column.
+func listMarkerPad(trimmed string) (int, bool) {
+	end, ok := consumeListMarker(trimmed)
+	if !ok {
+		return 0, false
+	}
+
+	if end == len(trimmed) {
+		return end + 1, true
+	}
+
+	if trimmed[end] != ' ' && trimmed[end] != '\t' {
+		return 0, false
+	}
+
+	pad := 0
+	for end+pad < len(trimmed) && pad < tabWidth && trimmed[end+pad] == ' ' {
+		pad++
+	}
+
+	if pad == 0 {
+		pad = 1
+	}
+
+	if pad == tabWidth && end+pad < len(trimmed) && trimmed[end+pad] == ' ' {
+		pad = 1
+	}
+
+	return end + pad, true
+}
+
+func consumeListMarker(trimmed string) (int, bool) {
+	if trimmed == "" {
+		return 0, false
+	}
+
+	switch trimmed[0] {
+	case '-', '*', '+':
+		return 1, true
+	}
+
+	digits := 0
+	for digits < len(trimmed) && digits < 9 && trimmed[digits] >= '0' && trimmed[digits] <= '9' {
+		digits++
+	}
+
+	if digits == 0 || digits >= len(trimmed) || (trimmed[digits] != '.' && trimmed[digits] != ')') {
+		return 0, false
+	}
+
+	return digits + 1, true
 }
 
 // leadingIndent returns the visual column of the first non-whitespace rune.

--- a/init/config/validate.go
+++ b/init/config/validate.go
@@ -165,6 +165,7 @@ func (c *Config) validateDefs() []string {
 			}
 
 			errs = append(errs, mdxProblems(def.Title, string(defName)+"."+string(item)+" title")...)
+			errs = append(errs, c.validateDefListOverrides(defName, item, def)...)
 		}
 	}
 
@@ -230,6 +231,8 @@ func (h *Header) validate(name section) []string {
 			errs = append(errs, string(name)+"."+param.Name+": unknown kind "+param.Kind)
 		}
 
+		errs = append(errs, param.validateListValues(string(name)+"."+param.Name)...)
+
 		where := string(name) + "." + param.Name + " short"
 		errs = append(errs, mdxProblems(param.Short, where)...)
 
@@ -241,11 +244,69 @@ func (h *Header) validate(name section) []string {
 	return errs
 }
 
+func (p *Param) validateListValues(where string) []string {
+	if p.Kind != list && p.Kind != "conlist" {
+		return nil
+	}
+
+	var errs []string
+
+	for _, item := range []struct {
+		label string
+		val   any
+	}{
+		{"default", p.Default},
+		{"example", p.Example},
+		{"docker", p.Docker},
+	} {
+		if item.val != nil && !isSeq(item.val) {
+			errs = append(errs, where+": "+p.Kind+" "+item.label+" must be a list")
+		}
+	}
+
+	return errs
+}
+
+func (c *Config) validateDefListOverrides(defName, item section, def *Def) []string {
+	header := c.Sections[defName]
+	if header == nil {
+		return nil
+	}
+
+	var errs []string
+
+	for _, param := range header.Params {
+		if param == nil || (param.Kind != list && param.Kind != "conlist") {
+			continue
+		}
+
+		where := string(defName) + "." + string(item) + "." + param.Name
+		if val, ok := def.Defaults[param.Name]; ok && !isSeq(val) {
+			errs = append(errs, where+": "+param.Kind+" default override must be a list")
+		}
+
+		if val, ok := def.Examples[param.Name]; ok && !isSeq(val) {
+			errs = append(errs, where+": "+param.Kind+" example override must be a list")
+		}
+
+		if val, ok := def.DockerExample[param.Name]; ok && !isSeq(val) {
+			errs = append(errs, where+": "+param.Kind+" docker override must be a list")
+		}
+	}
+
+	return errs
+}
+
+func isSeq(val any) bool {
+	_, ok := val.([]any)
+	return ok
+}
+
 // mdxProblems finds Docusaurus MDX v2 compile breakers in generated website markdown.
 func mdxProblems(content, where string) []string {
 	var errs []string
 
-	stripped := stripInlineCode(stripFencedCode(content))
+	stripped := stripInlineCode(stripIndentedCode(stripFencedCode(content)))
 
 	if admonitionSpace.MatchString(stripped) {
 		errs = append(errs, where+": use :::note[Title] (MDX v2); :::note Title fails Docusaurus compile")
@@ -263,7 +324,7 @@ func mdxProblems(content, where string) []string {
 
 // hasUnescapedBrace reports whether a line contains a { or } that MDX will
 // parse as JSX. Complete {{...}} and {/*...*/} spans are removed first, then
-// backslash-escaped braces (\{, \}, and \\{) are ignored.
+// braces preceded by an odd number of backslashes are ignored.
 func hasUnescapedBrace(line string) bool {
 	stripped := stripAllowedBraces(line)
 
@@ -292,6 +353,7 @@ func oddEscapes(content string, idx int) bool {
 }
 
 // stripAllowedBraces removes complete {{...}} JSX and {/*...*/} comment spans.
+// JSX spans are depth-balanced so nested objects like {{a: {b: 1}}} match.
 // Leftover { or } characters are MDX compile breakers.
 func stripAllowedBraces(line string) string {
 	var out strings.Builder
@@ -300,7 +362,7 @@ func stripAllowedBraces(line string) string {
 		rest := line[idx:]
 
 		switch {
-		case strings.HasPrefix(rest, "{/*"):
+		case strings.HasPrefix(rest, "{/*") && !oddEscapes(line, idx):
 			end := strings.Index(rest, "*/}")
 			if end < 0 {
 				out.WriteString(rest)
@@ -308,14 +370,16 @@ func stripAllowedBraces(line string) string {
 			}
 
 			idx += end + len("*/}")
-		case strings.HasPrefix(rest, "{{"):
-			end := strings.Index(rest[len("{{"):], "}}")
+		case strings.HasPrefix(rest, "{{") && !oddEscapes(line, idx):
+			end := balancedBraceEnd(line, idx)
 			if end < 0 {
-				out.WriteString(rest)
-				return out.String()
+				out.WriteByte(line[idx])
+				idx++
+
+				continue
 			}
 
-			idx += len("{{") + end + len("}}")
+			idx = end
 		default:
 			out.WriteByte(line[idx])
 			idx++
@@ -323,6 +387,34 @@ func stripAllowedBraces(line string) string {
 	}
 
 	return out.String()
+}
+
+// balancedBraceEnd returns the index after a complete brace group starting at
+// idx, counting nested unescaped { and }. idx must point at an unescaped '{'.
+func balancedBraceEnd(content string, idx int) int {
+	depth := 0
+
+	for pos := idx; pos < len(content); pos++ {
+		if content[pos] != '{' && content[pos] != '}' {
+			continue
+		}
+
+		if oddEscapes(content, pos) {
+			continue
+		}
+
+		if content[pos] == '{' {
+			depth++
+			continue
+		}
+
+		depth--
+		if depth == 0 {
+			return pos + 1
+		}
+	}
+
+	return -1
 }
 
 // stripFencedCode removes fenced code blocks. A fence opens with a run of 3+
@@ -338,7 +430,7 @@ func stripFencedCode(content string) string {
 
 	for line := range strings.SplitSeq(content, "\n") {
 		// CommonMark allows up to 3 leading spaces; more makes it indented code.
-		indent := len(line) - len(strings.TrimLeft(line, " "))
+		indent := leadingSpaces(line)
 		trimmed := strings.TrimSpace(line)
 
 		if !inFence {
@@ -355,13 +447,36 @@ func stripFencedCode(content string) string {
 			continue
 		}
 
-		// Inside a fence: close on a compatible marker with only trailing spaces.
-		if char, length, isClose := fenceCloser(trimmed); isClose && char == fenceChar && length >= fenceLen {
-			inFence = false
+		// Inside a fence: close on a compatible marker with at most three leading
+		// spaces and only trailing whitespace after the run.
+		if indent <= maxFenceIndent {
+			if char, length, isClose := fenceCloser(trimmed); isClose && char == fenceChar && length >= fenceLen {
+				inFence = false
+			}
 		}
 	}
 
 	return out.String()
+}
+
+// stripIndentedCode removes CommonMark indented code lines (4+ leading spaces).
+func stripIndentedCode(content string) string {
+	var out strings.Builder
+
+	for line := range strings.SplitSeq(content, "\n") {
+		if leadingSpaces(line) > maxFenceIndent {
+			continue
+		}
+
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+
+	return out.String()
+}
+
+func leadingSpaces(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
 }
 
 // minFenceLen is the minimum run length that opens a CommonMark code fence.


### PR DESCRIPTION
## Summary

Follow-up to #659 (merged accidentally). Fixes the remaining Copilot comments from the 17:16 round, the suppressed indented-code false positive, and Qwen's depth-balance note on `{{...}}`.

- Require `list`/`conlist` defaults, examples, docker values, and def overrides to be sequences before render; `Compose` uses comma-ok so a scalar cannot panic.
- Depth-balance `{{...}}` so nested objects like `{{a: {b: 1}}}` are accepted, and `\{{x}}` is not treated as a complete span.
- Closing fences need the same ≤3-space indent as openers; 4-space-indented lines are stripped as CommonMark indented code.

## Test plan

- [ ] `go test ./init/config/` passes
- [ ] `golangci-lint run ./init/config/` is clean
- [ ] A scalar `default` on a `list` param fails validation instead of panicking
- [ ] `{{a: {b: 1}}}` is accepted; `\{{x}}` is still flagged


Made with [Cursor](https://cursor.com)