### PR TITLE
Load README and webhook logos from unpackerr.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img style="max-width:840px;" src="https://raw.githubusercontent.com/wiki/Unpackerr/unpackerr/images/unpackerr-logo-text.png">
+<img style="max-width:840px;" src="https://unpackerr.zip/img/unpackerr.png">
 
 ## About
 

--- a/pkg/unpackerr/webhooks_templates.go
+++ b/pkg/unpackerr/webhooks_templates.go
@@ -122,13 +122,13 @@ const WebhookTemplateGotify = `{
 // WebhookTemplateDiscord is used when sending a webhook to discord.com.
 const WebhookTemplateDiscord = `{
   "username": "{{nickname}}",
-  "avatar_url": "https://raw.githubusercontent.com/wiki/Unpackerr/unpackerr/images/logo.png",
+  "avatar_url": "https://unpackerr.zip/img/icon.png",
   "embeds": [{
     "title": {{encode (index .IDs "title")}},
     "timestamp": "{{timestamp .Time}}",
     "author": {
      "name": "Unpackerr: {{.Event.Desc}}",
-     "icon_url": "https://raw.githubusercontent.com/wiki/Unpackerr/unpackerr/images/logo.png",
+     "icon_url": "https://unpackerr.zip/img/icon.png",
      "url": "https://github.com/Unpackerr/unpackerr/releases"
     },
     "color": {{ if (eq 1 .Event)}}1752220
@@ -180,7 +180,7 @@ const WebhookTemplateSlack = `
 {
   "username": "{{nickname}}",
   {{if channel}}"channel": "{{channel}}",{{end}}
-  "icon_url": "https://raw.githubusercontent.com/wiki/Unpackerr/unpackerr/images/logo.png",
+  "icon_url": "https://unpackerr.zip/img/icon.png",
   "blocks": [
     {
       "type": "header",


### PR DESCRIPTION
## Summary
- Point the README wordmark at https://unpackerr.zip/img/unpackerr.png (already live; same file as the old wiki `unpackerr-logo-text.png`).
- Point Discord/Slack webhook avatars at https://unpackerr.zip/img/icon.png (same 256px chest as the old wiki `images/logo.png`).

The wiki git repo still has the files, but the wiki is disabled so the raw GitHub wiki URLs 404.

Companion: Unpackerr/unpackerr.github.io also gets `unpackerr-logo-text.png` under that filename.

## Test plan
- [ ] README on GitHub shows the Unpackerr wordmark
- [ ] Discord/Slack webhook templates fetch https://unpackerr.zip/img/icon.png


Made with [Cursor](https://cursor.com)