### PR TITLE
Stamp Windows FileVersion into the exe

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,7 +40,7 @@ So:
 4. **Build: darwin** (`split-darwin` on macos-latest, skipped on nightly) — import Developer ID + App Store Connect key, same `--split` with `GGOOS=darwin`, staple the DMG.
 5. **release N** — download `dist-*` artifacts, import GPG (checksum signatures are created at merge, not split), `continue --merge`. Display name is `release` plus that `REVISION`. This is the only job that pushes Docker / GitHub / brew / AUR / packagecloud / unstable.golift.io.
 
-`REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` / Windows FileVersion still need the count.
+`REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` / Windows FileVersion still need the count. Darwin `CFBundleShortVersionString` and Windows FileVersion `x.y.z` use the prefix of `{{ .Version }}`, not `.RawVersion` (that stays on the last tag during `--nightly`).
 
 nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}` stayed literal and Packagecloud rejected `Version: 0.15.3~1081-${PKG_RELEASE}`. The tagged linux split inserts `release: REVISION` after the `nfpm-release:` marker; `--nightly` leaves it unset. Package files use `{{ replace "~" "-" .ConventionalFileName }}` (`unpackerr_0.15.2-960_i386.deb`, not `_linux_386`). Do not put `CHANNEL` in the package version. Do not set nFPM `version_metadata`. Tagged FreeBSD packages are `unpackerr-0.15.3_REVISION.amd64.txz`.
 
@@ -66,7 +66,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 | `unpackerr.{amd64,386,arm,arm64}.linux.gz` | gzipped binary |
 | `unpackerr.{amd64,i386,armhf,arm64}.freebsd.gz` | gzipped binary |
 
-Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. Windows is `-H=windowsgui` with FileVersion from the `x.y.z` prefix of `{{ .Version }}` plus `REVISION` (not `.RawVersion`: that stays on the last tag during `--nightly`). Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
+Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. `CFBundleShortVersionString` and Windows FileVersion both take the `x.y.z` prefix of `{{ .Version }}` (not `.RawVersion`: that stays on the last tag during `--nightly`); Windows FileVersion’s fourth number is `REVISION`. Windows is `-H=windowsgui`. Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
 
 ## Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,11 +36,11 @@ So:
 
 1. **channel** — compute `CHANNEL`, extra args, and `REVISION` (`git rev-list --count --all`). This is the only place the count is taken; later jobs pass `needs.channel.outputs.revision`.
 2. **require secrets** — fail closed if any signing/upload/push secret needed for that channel is empty. Missing secrets used to skip Docker Hub, Windows Authenticode, or unstable.golift.io and still go green.
-3. **Build: linux / freebsd** (`split` on ubuntu) and **Build: windows** (own job: OIDC + signerd certs stay off the other legs) — `release --clean --split`. Filter with **`GGOOS`**, not `GOOS`. `GOOS` leaks into `go run` before-hooks (man pages, rsrc) and they then target the wrong OS. FreeBSD then runs `freebsd_txz.sh` (`fpm -t freebsd`).
+3. **Build: linux / freebsd** (`split` on ubuntu) and **Build: windows** (own job: OIDC + signerd certs stay off the other legs) — `release --clean --split`. Filter with **`GGOOS`**, not `GOOS`. `GOOS` leaks into `go run` before-hooks (man pages, goversioninfo) and they then target the wrong OS. FreeBSD then runs `freebsd_txz.sh` (`fpm -t freebsd`).
 4. **Build: darwin** (`split-darwin` on macos-latest, skipped on nightly) — import Developer ID + App Store Connect key, same `--split` with `GGOOS=darwin`, staple the DMG.
 5. **release N** — download `dist-*` artifacts, import GPG (checksum signatures are created at merge, not split), `continue --merge`. Display name is `release` plus that `REVISION`. This is the only job that pushes Docker / GitHub / brew / AUR / packagecloud / unstable.golift.io.
 
-`REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` still need the count.
+`REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` / Windows FileVersion still need the count.
 
 nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}` stayed literal and Packagecloud rejected `Version: 0.15.3~1081-${PKG_RELEASE}`. The tagged linux split inserts `release: REVISION` after the `nfpm-release:` marker; `--nightly` leaves it unset. Package files use `{{ replace "~" "-" .ConventionalFileName }}` (`unpackerr_0.15.2-960_i386.deb`, not `_linux_386`). Do not put `CHANNEL` in the package version. Do not set nFPM `version_metadata`. Tagged FreeBSD packages are `unpackerr-0.15.3_REVISION.amd64.txz`.
 
@@ -66,7 +66,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 | `unpackerr.{amd64,386,arm,arm64}.linux.gz` | gzipped binary |
 | `unpackerr.{amd64,i386,armhf,arm64}.freebsd.gz` | gzipped binary |
 
-Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. Windows is `-H=windowsgui`. Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
+Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. Windows is `-H=windowsgui` with FileVersion `Major.Minor.Patch.REVISION`. Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
 
 ## Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,7 +66,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 | `unpackerr.{amd64,386,arm,arm64}.linux.gz` | gzipped binary |
 | `unpackerr.{amd64,i386,armhf,arm64}.freebsd.gz` | gzipped binary |
 
-Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. Windows is `-H=windowsgui` with FileVersion `Major.Minor.Patch.REVISION`. Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
+Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr-0.15.3-1081.x86_64.rpm`). Arches: amd64, arm64, i386, armv7 (one `armhf` / RPM `armv7hl`). Darwin min macOS 13. Windows is `-H=windowsgui` with FileVersion from the `x.y.z` prefix of `{{ .Version }}` plus `REVISION` (not `.RawVersion`: that stays on the last tag during `--nightly`). Empty `CODESIGN_URL` fails in GitHub Actions (local snapshots still skip).
 
 ## Secrets
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,8 +27,10 @@ before:
     # rsrc only embeds icon+manifest. goversioninfo does that and VERSIONINFO
     # (Explorer File version). -64: before-hooks run on darwin/arm64 too;
     # the Windows build is amd64. Skip JSON: versions come from these flags.
-    # FileVersion is Major.Minor.Patch.REVISION (Darwin CFBundleVersion).
-    # ProductVersion string is the release version (nightly includes -REVISION).
+    # --nightly rewrites .Version (incpatch-REVISION) but .RawVersion / .Major /
+    # .Minor / .Patch stay on the last tag. FileVersion is the x.y.z prefix of
+    # .Version plus REVISION; goversioninfo fills the numeric fields from that
+    # string. ProductVersion string is .Version (nightly includes -REVISION).
     - >-
       go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0
       -64 -skip-versioninfo
@@ -40,12 +42,8 @@ before:
       -internal-name unpackerr
       -original-name unpackerr.exe
       -product-name Unpackerr
-      -file-version "{{ .RawVersion }}.{{ .Env.REVISION }}"
+      -file-version "{{ index (split .Version "-") 0 }}.{{ .Env.REVISION }}"
       -product-version "{{ .Version }}"
-      -ver-major {{ .Major }}
-      -ver-minor {{ .Minor }}
-      -ver-patch {{ .Patch }}
-      -ver-build {{ .Env.REVISION }}
       -translation 1033
       -charset 1200
       -o rsrc_windows_amd64.syso

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,8 @@ nightly:
   # This is why REVISION is still computed (once, in the channel job) even
   # though {{ .Version }} already includes it on --nightly: this template is
   # what *creates* that version. Tagged builds keep .Version as the semver
-  # tag; ldflags Revision and Darwin CFBundleVersion still need the count.
+  # tag; ldflags Revision, Darwin CFBundleVersion, and Windows FileVersion
+  # still need the count.
   version_template: "{{ incpatch .Version }}-{{ .Env.REVISION }}"
 
 before:
@@ -23,7 +24,31 @@ before:
     - go run github.com/davidnewhall/md2roff@v0.0.1 --manual unpackerr --version "{{.Version}}" --date "{{.Date}}" README.md
     - gzip -9nf examples/MANUAL
     - mv -f examples/MANUAL.gz unpackerr.1.gz
-    - go run github.com/akavel/rsrc@v0.10.2 -arch amd64 -ico init/windows/application.ico -manifest init/windows/manifest.xml -o rsrc_windows_amd64.syso
+    # rsrc only embeds icon+manifest. goversioninfo does that and VERSIONINFO
+    # (Explorer File version). -64: before-hooks run on darwin/arm64 too;
+    # the Windows build is amd64. Skip JSON: versions come from these flags.
+    # FileVersion is Major.Minor.Patch.REVISION (Darwin CFBundleVersion).
+    # ProductVersion string is the release version (nightly includes -REVISION).
+    - >-
+      go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0
+      -64 -skip-versioninfo
+      -icon init/windows/application.ico
+      -manifest init/windows/manifest.xml
+      -company "Go Lift"
+      -copyright "© Go Lift (https://golift.io)"
+      -description "Extracts downloads so Radarr, Sonarr, Lidarr or Readarr may import them."
+      -internal-name unpackerr
+      -original-name unpackerr.exe
+      -product-name Unpackerr
+      -file-version "{{ .RawVersion }}.{{ .Env.REVISION }}"
+      -product-version "{{ .Version }}"
+      -ver-major {{ .Major }}
+      -ver-minor {{ .Minor }}
+      -ver-patch {{ .Patch }}
+      -ver-build {{ .Env.REVISION }}
+      -translation 1033
+      -charset 1200
+      -o rsrc_windows_amd64.syso
 
 builds:
   - id: unpackerr

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,8 @@ nightly:
   # though {{ .Version }} already includes it on --nightly: this template is
   # what *creates* that version. Tagged builds keep .Version as the semver
   # tag; ldflags Revision, Darwin CFBundleVersion, and Windows FileVersion
-  # still need the count.
+  # still need the count. CFBundleShortVersionString / FileVersion x.y.z come
+  # from .Version (not .RawVersion: that stays on the last tag during --nightly).
   version_template: "{{ incpatch .Version }}-{{ .Env.REVISION }}"
 
 before:

--- a/init/macos/Info.plist.tmpl
+++ b/init/macos/Info.plist.tmpl
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>{{ .Env.REVISION }}</string>
 	<key>CFBundleShortVersionString</key>
-	<string>{{ .RawVersion }}</string>
+	<string>{{ index (split .Version "-") 0 }}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleExecutable</key>

--- a/init/windows/README.md
+++ b/init/windows/README.md
@@ -1,3 +1,8 @@
 If your app is used on windows, change this icon. You should also set the app name in the manifest.xml file.
 I used this website to make a 64x64 icon: https://icoconvert.com
 This icon belongs to the application (file), not the tray icon.
+
+GoReleaser embeds icon, manifest, and VERSIONINFO via goversioninfo
+(`rsrc_windows_amd64.syso`). Explorer File version is
+`Major.Minor.Patch.REVISION` (same fourth number as Darwin CFBundleVersion).
+Product version is the release version string (nightly includes `-REVISION`).

--- a/init/windows/README.md
+++ b/init/windows/README.md
@@ -4,7 +4,8 @@ This icon belongs to the application (file), not the tray icon.
 
 GoReleaser embeds icon, manifest, and VERSIONINFO via goversioninfo
 (`rsrc_windows_amd64.syso`). Explorer File version is the `x.y.z` prefix of
-the release version plus `REVISION` (same fourth number as Darwin
-CFBundleVersion). Product version is the release version string
-(nightly includes `-REVISION`). Do not use GoReleaser `.RawVersion` here:
-on `--nightly` it stays on the last tag while `.Version` is already incpatched.
+the release version plus `REVISION` (same split as Darwin
+CFBundleShortVersionString; fourth number matches CFBundleVersion).
+Product version is the release version string (nightly includes `-REVISION`).
+Do not use GoReleaser `.RawVersion` here: on `--nightly` it stays on the last
+tag while `.Version` is already incpatched.

--- a/init/windows/README.md
+++ b/init/windows/README.md
@@ -3,6 +3,8 @@ I used this website to make a 64x64 icon: https://icoconvert.com
 This icon belongs to the application (file), not the tray icon.
 
 GoReleaser embeds icon, manifest, and VERSIONINFO via goversioninfo
-(`rsrc_windows_amd64.syso`). Explorer File version is
-`Major.Minor.Patch.REVISION` (same fourth number as Darwin CFBundleVersion).
-Product version is the release version string (nightly includes `-REVISION`).
+(`rsrc_windows_amd64.syso`). Explorer File version is the `x.y.z` prefix of
+the release version plus `REVISION` (same fourth number as Darwin
+CFBundleVersion). Product version is the release version string
+(nightly includes `-REVISION`). Do not use GoReleaser `.RawVersion` here:
+on `--nightly` it stays on the last tag while `.Version` is already incpatched.


### PR DESCRIPTION
## Summary
- Replace the `rsrc` before-hook with `goversioninfo` so the Windows exe still gets the icon and manifest, plus a PE `VERSIONINFO` resource Explorer can show.
- File version is `Major.Minor.Patch.REVISION` (same fourth number as Darwin `CFBundleVersion`). Product version is the release version string (`0.15.3` on a tag, `0.15.3-1056` on nightly).
- Authenticode signing is unchanged (`signexe.sh` still runs after the binary exists).

## Test plan
- [ ] After merge, a tagged or unstable Windows build shows File version in Explorer → Properties → Details (not `0.0.0.0`).
- [ ] Icon and DPI-aware manifest are still present (tray/app icon, no blurry dialogs).
- [ ] `unpackerr --version` still matches ldflags (`golift.io/version`).


Made with [Cursor](https://cursor.com)