### PR TITLE
Skip AUR during GoReleaser --split

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,7 +42,7 @@ So:
 
 `REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` / Windows FileVersion still need the count. Darwin `CFBundleShortVersionString` and Windows FileVersion `x.y.z` use the prefix of `{{ .Version }}`, not `.RawVersion` (that stays on the last tag during `--nightly`).
 
-nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}` stayed literal and Packagecloud rejected `Version: 0.15.3~1081-${PKG_RELEASE}`. The tagged linux split inserts `release: REVISION` after the `nfpm-release:` marker; `--nightly` leaves it unset. Package files use `{{ replace "~" "-" .ConventionalFileName }}` (`unpackerr_0.15.2-960_i386.deb`, not `_linux_386`). Do not put `CHANNEL` in the package version. Do not set nFPM `version_metadata`. Tagged FreeBSD packages are `unpackerr-0.15.3_REVISION.amd64.txz`.
+nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}` stayed literal and Packagecloud rejected `Version: 0.15.3~1081-${PKG_RELEASE}`. The tagged linux split inserts `release: REVISION` after the `nfpm-release:` marker; `--nightly` leaves it unset. Package files use `{{ replace .ConventionalFileName "~" "-" }}` (GoReleaser `replace` is STRING/OLD/NEW, not sprig). That yields `unpackerr_0.15.2-960_i386.deb`, not `_linux_386`. Do not put `CHANNEL` in the package version. Do not set nFPM `version_metadata`. Tagged FreeBSD packages are `unpackerr-0.15.3_REVISION.amd64.txz`.
 
 ## Darwin signing
 
@@ -55,7 +55,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 - **Docker** — always `ghcr.io/unpackerr/unpackerr` and Hub `docker.io/golift/unpackerr` (`DOCKERHUB_PUBLISH=1`). Empty `DOCKERHUB_PASSWORD` fails the merge job. Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`.
 - **GitHub Release** — tagged `v*` only (`release.disable: "{{ .IsNightly }}"`). Windows assets are `unpackerr.amd64.exe.zip`. FreeBSD assets are pkgng `unpackerr-<version>.{amd64,i386,armhf,arm64}.txz`.
 - **Homebrew** — notarized `Unpackerr.app` from the `unpackerr-dmg` DMG → `golift/homebrew-mugs` `Casks/`. Skip on `--nightly` (and that channel has no Darwin job).
-- **AUR** — `aur_sources` over SSH. Skip on `--nightly`.
+- **AUR** — `aur_sources` over SSH. Skip on `--nightly` and on `--split` (`disable: "{{ or .IsNightly (not .IsMerging) }}"`). The pipe wants the source tarball, which exists only after `continue --merge`; split otherwise fatals `no linux archives found`.
 - **packagecloud** — `golift/pkgs` vs `golift/unstable`. Skip when `CHANNEL=nightly`.
 - **unstable.golift.io** — only `CHANNEL=unstable`. Auto-update URLs are **stable names**; version lives in a sibling `.txt` (plain `0.15.3-1056`, not JSON). Payload is a gzipped/zipped **binary**, not the versioned `tar.gz`. Script: `.github/scripts/unstable_upload.sh` (reads `dist/$GOOS/artifacts.json` after split/merge). Upload overwrites by name. Empty `UNSTABLE_UPLOAD_KEY` fails in GitHub Actions.
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -252,7 +252,8 @@ nfpms:
     # Default is unpackerr_VERSION_linux_386.deb. Conventional names match
     # v0.15.2 (unpackerr_0.15.2-960_i386.deb). nFPM uses ~ for semver
     # prerelease; GitHub replaces tilde with a dot, so swap it for a hyphen.
-    file_name_template: '{{ replace "~" "-" .ConventionalFileName }}'
+    # GoReleaser replace is STRING OLD NEW (not sprig OLD NEW STRING).
+    file_name_template: '{{ replace .ConventionalFileName "~" "-" }}'
     vendor: Go Lift
     homepage: https://unpackerr.zip
     maintainer: David Newhall II <captain at golift dot io>
@@ -415,7 +416,9 @@ dockers_v2:
 
 aur_sources:
   - name: unpackerr
-    disable: "{{ .IsNightly }}"
+    # PKGBUILD needs the source tarball, which exists only on continue --merge.
+    # --split has none; AUR then fatals "no linux archives found".
+    disable: "{{ or .IsNightly (not .IsMerging) }}"
     homepage: https://unpackerr.zip
     description: Extracts downloads so Radarr, Sonarr, Lidarr or Readarr may import them.
     license: MIT


### PR DESCRIPTION
## Summary
- Tagged `v0.16.0` split jobs all died with `no linux archives found`: `aur_sources` runs on `--split` but the source tarball only exists on `continue --merge`. Skip AUR unless `.IsMerging` (still skipped on `--nightly`).
- nFPM `replace` used sprig argument order, so every package was named `~.deb`. GoReleaser is STRING/OLD/NEW.

Fixes the failed [v0.16.0 release run](https://github.com/Unpackerr/unpackerr/actions/runs/33335465041).

## Test plan
- [ ] Merge, move `v0.16.0` onto this commit, confirm split jobs finish and merge publishes
- [ ] Linux artifacts are `unpackerr_*_amd64.deb` (not `~.deb`)


Made with [Cursor](https://cursor.com)