### PR TITLE
Drop Homebrew from the release

### DIFF
--- a/.github/scripts/require_secrets.sh
+++ b/.github/scripts/require_secrets.sh
@@ -28,7 +28,7 @@ need CODESIGN_URL
 need CODESIGN_CLIENT_CERT
 need CODESIGN_CLIENT_KEY
 
-# Nightly is Docker-only (no Darwin, no GitHub Release, no brew/AUR/packagecloud).
+# Nightly is Docker-only (no Darwin, no GitHub Release, no AUR/packagecloud).
 if [ "${CHANNEL}" != nightly ]; then
   need MACOS_SIGN_P12
   need MACOS_SIGN_PASSWORD
@@ -39,7 +39,6 @@ if [ "${CHANNEL}" != nightly ]; then
 fi
 
 if [ "${CHANNEL}" = release ]; then
-  need HOMEBREW_TAP_GITHUB_TOKEN
   need AUR_DEPLOY_KEY
 fi
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,11 +4,11 @@ Two workflows. `test-and-lint` (`codetests.yml`) runs tests and golangci-lint on
 
 ## Channels
 
-`release.yml` maps the GitHub event to a `CHANNEL` env that `.goreleaser.yaml` reads (`dockers_v2.disable`, packagecloud repo, unstable upload). `--nightly` is a GoReleaser flag: it bumps the version and turns off GitHub Releases / brew / AUR.
+`release.yml` maps the GitHub event to a `CHANNEL` env that `.goreleaser.yaml` reads (`dockers_v2.disable`, packagecloud repo, unstable upload). `--nightly` is a GoReleaser flag: it bumps the version and turns off GitHub Releases / AUR.
 
 | Trigger | CHANNEL | GoReleaser extra | What it publishes |
 |---|---|---|---|
-| Push tag `v*` | `release` | (none) | GitHub Release, Docker `:latest` + version tags, Homebrew cask, AUR, packagecloud `golift/pkgs` |
+| Push tag `v*` | `release` | (none) | GitHub Release, Docker `:latest` + version tags, AUR, packagecloud `golift/pkgs` |
 | Push branch `unstable` | `unstable` | `--nightly` | Docker `:unstable`, packagecloud `golift/unstable`, [unstable.golift.io](https://unstable.golift.io/?dir=unpackerr) |
 | Cron `27 12 * * *` UTC, or `workflow_dispatch` on `main` | `nightly` | `--nightly` | Docker `:nightly` only |
 
@@ -38,7 +38,7 @@ So:
 2. **require secrets** — fail closed if any signing/upload/push secret needed for that channel is empty. Missing secrets used to skip Docker Hub, Windows Authenticode, or unstable.golift.io and still go green.
 3. **Build: linux / freebsd** (`split` on ubuntu) and **Build: windows** (own job: OIDC + signerd certs stay off the other legs) — `release --clean --split`. Filter with **`GGOOS`**, not `GOOS`. `GOOS` leaks into `go run` before-hooks (man pages, goversioninfo) and they then target the wrong OS. FreeBSD then runs `freebsd_txz.sh` (`fpm -t freebsd`).
 4. **Build: darwin** (`split-darwin` on macos-latest, skipped on nightly) — import Developer ID + App Store Connect key, same `--split` with `GGOOS=darwin`, staple the DMG.
-5. **release N** — download `dist-*` artifacts, import GPG (checksum signatures are created at merge, not split), `continue --merge`. Display name is `release` plus that `REVISION`. This is the only job that pushes Docker / GitHub / brew / AUR / packagecloud / unstable.golift.io.
+5. **release N** — download `dist-*` artifacts, import GPG (checksum signatures are created at merge, not split), `continue --merge`. Display name is `release` plus that `REVISION`. This is the only job that pushes Docker / GitHub / AUR / packagecloud / unstable.golift.io.
 
 `REVISION` must be in the goreleaser-action `env:` map (Actions does not automatically forward `GITHUB_ENV` into a later step’s `env:` block). On `--nightly`, `nightly.version_template` already bakes it into `{{ .Version }}` (example `0.15.3-1056`), so man-page hooks use `{{ .Version }}` only — do not append `REVISION` again. The env var is still required: that template *creates* `.Version`, and tagged builds keep `.Version` as the semver while ldflags `Revision` / Darwin `CFBundleVersion` / Windows FileVersion still need the count. Darwin `CFBundleShortVersionString` and Windows FileVersion `x.y.z` use the prefix of `{{ .Version }}`, not `.RawVersion` (that stays on the last tag during `--nightly`).
 
@@ -53,8 +53,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 ## Merge destinations
 
 - **Docker** — always `ghcr.io/unpackerr/unpackerr` and Hub `docker.io/golift/unpackerr` (`DOCKERHUB_PUBLISH=1`). Empty `DOCKERHUB_PASSWORD` fails the merge job. Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`.
-- **GitHub Release** — tagged `v*` only (`release.disable: "{{ .IsNightly }}"`). Windows assets are `unpackerr.amd64.exe.zip`. FreeBSD assets are pkgng `unpackerr-<version>.{amd64,i386,armhf,arm64}.txz`.
-- **Homebrew** — notarized `Unpackerr.app` from the `unpackerr-dmg` DMG → `golift/homebrew-mugs` `Casks/`. Skip on `--nightly` (and that channel has no Darwin job).
+- **GitHub Release** — tagged `v*` only (`release.disable: "{{ .IsNightly }}"`). macOS is the notarized `Unpackerr.dmg`. Windows assets are `unpackerr.amd64.exe.zip`. FreeBSD assets are pkgng `unpackerr-<version>.{amd64,i386,armhf,arm64}.txz`. Homebrew is unsupported.
 - **AUR** — `aur_sources` over SSH. Skip on `--nightly` and on `--split` (`disable: "{{ or .IsNightly (not .IsMerging) }}"`). The pipe wants the source tarball, which exists only after `continue --merge`; split otherwise fatals `no linux archives found`.
 - **packagecloud** — `golift/pkgs` vs `golift/unstable`. Skip when `CHANNEL=nightly`.
 - **unstable.golift.io** — only `CHANNEL=unstable`. Auto-update URLs are **stable names**; version lives in a sibling `.txt` (plain `0.15.3-1056`, not JSON). Payload is a gzipped/zipped **binary**, not the versioned `tar.gz`. Script: `.github/scripts/unstable_upload.sh` (reads `dist/$GOOS/artifacts.json` after split/merge). Upload overwrites by name. Empty `UNSTABLE_UPLOAD_KEY` fails in GitHub Actions.
@@ -70,7 +69,7 @@ Linux nFPM names are conventional (`unpackerr_0.15.3-1081_amd64.deb`, `unpackerr
 
 ## Secrets
 
-Set on the `Unpackerr/unpackerr` repo (or org, granted to this public repo). `.github/scripts/require_secrets.sh` runs before any build job and **fails the workflow** if a secret required for that `CHANNEL` is empty. Nightly does not require Apple / Homebrew / AUR / packagecloud / unstable-upload secrets (those destinations are skipped).
+Set on the `Unpackerr/unpackerr` repo (or org, granted to this public repo). `.github/scripts/require_secrets.sh` runs before any build job and **fails the workflow** if a secret required for that `CHANNEL` is empty. Nightly does not require Apple / AUR / packagecloud / unstable-upload secrets (those destinations are skipped).
 
 | Secret | Used by |
 |---|---|
@@ -80,7 +79,6 @@ Set on the `Unpackerr/unpackerr` repo (or org, granted to this public repo). `.g
 | `MACOS_NOTARY_KEY`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER_ID` | App Store Connect `.p8` |
 | `CODESIGN_URL`, `CODESIGN_CLIENT_CERT`, `CODESIGN_CLIENT_KEY` | Windows Authenticode (OIDC + mTLS) |
 | `DOCKERHUB_PASSWORD` | Hub login (required) |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | `golift/homebrew-mugs` (release channel) |
 | `PACKAGECLOUD_TOKEN` | `golift/pkgs` / `golift/unstable` |
 | `AUR_DEPLOY_KEY` | AUR `unpackerr` (release channel) |
 | `UNSTABLE_UPLOAD_KEY` | unstable.golift.io (unstable channel) |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 # Darwin App/DMG notarization needs xcrun/codesign (macOS). Linux/Windows/FreeBSD
-# split on ubuntu; merge publishes Docker, GitHub, Homebrew, AUR, packagecloud.
+# split on ubuntu; merge publishes Docker, GitHub, AUR, packagecloud.
 # See README.md in this folder.
 jobs:
   channel:
@@ -81,7 +81,6 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           AUR_DEPLOY_KEY: ${{ secrets.AUR_DEPLOY_KEY }}
           UNSTABLE_UPLOAD_KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}
         run: bash .github/scripts/require_secrets.sh
@@ -377,7 +376,6 @@ jobs:
           REVISION: ${{ needs.channel.outputs.revision }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_KEY }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           USER: github-actions
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
           AUR_DEPLOY_KEY: ${{ secrets.AUR_DEPLOY_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -214,7 +214,7 @@ archives:
   - id: default
     ids: [unpackerr, unpackerr-darwin]
     formats: [tar.gz]
-    # Flat tarball for GitHub. Homebrew installs the notarized DMG, not this archive.
+    # Flat tarball for GitHub. macOS installs are the notarized DMG, not this archive.
     wrap_in_directory: false
     files:
       - LICENSE
@@ -484,96 +484,6 @@ aur_sources:
       echo 'u unpackerr - "unpackerr daemon"' > unpackerr.sysusers
       install -D -m 644 unpackerr.sysusers "${pkgdir}/usr/lib/sysusers.d/unpackerr.conf"
       install -D -m 644 init/systemd/unpackerr.tmpfiles "${pkgdir}/usr/lib/tmpfiles.d/unpackerr.conf"
-
-homebrew_casks:
-  - name: unpackerr
-    # Notarized DMG (macos_native signs unpackerr-app / unpackerr-dmg). The
-    # unsigned darwin tar.gz (ids: default) is GitHub-only; Gatekeeper rejects it.
-    ids: [unpackerr-dmg]
-    app: Unpackerr.app
-    binaries:
-      - '#{appdir}/Unpackerr.app/Contents/MacOS/unpackerr'
-    skip_upload: "{{ .IsNightly }}"
-    repository:
-      owner: golift
-      name: homebrew-mugs
-      branch: master
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
-    directory: Casks
-    homepage: https://unpackerr.zip
-    description: Extracts downloads so Radarr, Sonarr, Lidarr or Readarr may import them.
-    license: MIT
-    url:
-      template: "https://github.com/Unpackerr/unpackerr/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-      verified: github.com/Unpackerr/unpackerr
-    # Do not set `service:` — cask `service` is ~/Library/Services (Automator), not LaunchAgents.
-    # Install a LaunchAgent in postflight; brew services is formula-only.
-    hooks:
-      post:
-        install: |
-          staged_app = "#{staged_path}/Unpackerr.app"
-          conf_src = "#{staged_app}/Contents/Resources/unpackerr.conf.example"
-          conf_dir = HOMEBREW_PREFIX/"etc/unpackerr"
-          conf_dir.mkpath
-          FileUtils.cp conf_src, conf_dir/"unpackerr.conf.example"
-          had_conf = (conf_dir/"unpackerr.conf").exist?
-          FileUtils.cp conf_src, conf_dir/"unpackerr.conf" unless had_conf
-          man1 = HOMEBREW_PREFIX/"share/man/man1"
-          man1.mkpath
-          FileUtils.cp "#{staged_app}/Contents/Resources/unpackerr.1.gz", man1/"unpackerr.1.gz"
-          (HOMEBREW_PREFIX/"var/log").mkpath
-          label = "io.golift.unpackerr"
-          agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
-          agent.dirname.mkpath
-          binary = "#{appdir}/Unpackerr.app/Contents/MacOS/unpackerr"
-          conf = conf_dir/"unpackerr.conf"
-          log = HOMEBREW_PREFIX/"var/log/unpackerr.log"
-          agent.write <<~XML
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-              <key>Label</key><string>#{label}</string>
-              <key>ProgramArguments</key>
-              <array>
-                <string>#{binary}</string>
-                <string>--config</string>
-                <string>#{conf}</string>
-              </array>
-              <key>RunAtLoad</key><true/>
-              <key>KeepAlive</key><true/>
-              <key>WorkingDirectory</key><string>#{HOMEBREW_PREFIX}</string>
-              <key>StandardOutPath</key><string>#{log}</string>
-              <key>StandardErrorPath</key><string>#{log}</string>
-            </dict>
-            </plist>
-          XML
-          if had_conf
-            uid = Process.uid
-            system "/bin/launchctl", "bootout", "gui/#{uid}/#{label}"
-            system "/bin/launchctl", "bootstrap", "gui/#{uid}", agent.to_s
-          end
-        uninstall: |
-          label = "io.golift.unpackerr"
-          agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
-          system "/bin/launchctl", "bootout", "gui/#{Process.uid}/#{label}"
-          agent.delete if agent.exist?
-          man = HOMEBREW_PREFIX/"share/man/man1/unpackerr.1.gz"
-          man.delete if man.exist?
-    caveats: |
-      First install: edit #{HOMEBREW_PREFIX}/etc/unpackerr/unpackerr.conf then:
-        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.unpackerr.plist
-      Upgrades restart the LaunchAgent when that config already exists.
-      Restart: launchctl kickstart -k gui/$(id -u)/io.golift.unpackerr
-      Stop:    launchctl bootout gui/$(id -u)/io.golift.unpackerr
-      (brew services does not manage casks.)
-      Menu bar: open Unpackerr.app (do not also run the LaunchAgent).
-      The LaunchAgent runs the signed CLI inside the app (no menu bar).
-      The manual explains the config file options: man unpackerr
 
 checksum:
   name_template: checksums.sha256.txt


### PR DESCRIPTION
## Summary
- Remove `homebrew_casks` from GoReleaser so tagged `continue --merge` no longer dies looking for a DMG the cask pipe cannot consume.
- macOS stays the notarized `Unpackerr.dmg` on the GitHub Release. Homebrew is unsupported.
- Stop requiring `HOMEBREW_TAP_GITHUB_TOKEN`.
- Closes #671

The last published cask on `golift/homebrew-mugs` is leftover; this does not delete it.

## Test plan
- [ ] Merge, move `v0.16.0` onto this commit, confirm merge publishes GitHub Release + Docker + AUR (no brew step)
- [ ] Darwin still notarizes and staples `Unpackerr.dmg`
- [ ] `require_secrets.sh` on a tagged run no longer demands `HOMEBREW_TAP_GITHUB_TOKEN`


Made with [Cursor](https://cursor.com)