### PR TITLE
Fix merge-job gates that Homebrew used to hide

### DIFF
--- a/.github/scripts/require_secrets.sh
+++ b/.github/scripts/require_secrets.sh
@@ -28,7 +28,8 @@ need CODESIGN_URL
 need CODESIGN_CLIENT_CERT
 need CODESIGN_CLIENT_KEY
 
-# Nightly is Docker-only (no Darwin, no GitHub Release, no AUR/packagecloud).
+# Nightly still builds linux/windows/freebsd and publishes Docker.
+# It skips Darwin, GitHub Releases, AUR, and packagecloud.
 if [ "${CHANNEL}" != nightly ]; then
   need MACOS_SIGN_P12
   need MACOS_SIGN_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,8 +400,11 @@ jobs:
           rpmdists: el/6
           debdists: ubuntu/focal
       - name: Upload to unstable.golift.io
-        if: env.CHANNEL == 'unstable'
+        # Do not use env.CHANNEL: a step-level CHANNEL: unstable is visible to
+        # this step's own `if:`, so nightly and tagged releases ran the uploader
+        # (missing DMG on nightly; would publish v0.16.0 into the unstable feed
+        # on a tag once the cask pipe no longer kills merge first).
+        if: needs.channel.outputs.channel == 'unstable'
         env:
           UNSTABLE_UPLOAD_KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}
-          CHANNEL: unstable
         run: bash .github/scripts/unstable_upload.sh dist

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ MANUAL.html
 README
 README.html
 /*_manual.html
-/homebrew-mugs
 .secret*files.tar
 github_deploy_key*
 .metadata.make

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -495,9 +495,11 @@ signs:
   # embedded signatures; pacman wants a sidecar.
   - id: archlinux
     artifacts: package
-    # Merge artifact filters do not load sprig (hasSuffix is undefined there).
-    # eq is a Go template builtin; Extra.Format is archlinux/deb/rpm.
-    if: '{{ eq .Format "archlinux" }}'
+    # Merge artifact filters do not load sprig (hasSuffix is undefined there)
+    # and the artifact map has no Format key (eq .Format fatals "map has no
+    # entry for key" and silently skips every package). Use ArtifactExt:
+    # nFPM stores the conventional extension (.deb / .rpm / .pkg.tar.zst).
+    if: '{{ eq .ArtifactExt ".pkg.tar.zst" }}'
 
 release:
   disable: "{{ .IsNightly }}"


### PR DESCRIPTION
## Summary
- Gate `unstable.golift.io` on `needs.channel.outputs.channel`, and drop the step-level `CHANNEL: unstable` override. That override made the step `if:` always true, so nightly died on a missing DMG and a tagged merge would publish into the unstable feed now that the cask pipe is gone (#672, #671 §3).
- Sign archlinux packages with `{{ eq .ArtifactExt ".pkg.tar.zst" }}`. `.Format` is not on the filter map, so no `.pkg.tar.zst.sig` sidecar was ever produced (#671 §2).
- Nightly `require_secrets.sh` comment now matches what nightly actually runs (linux/windows/freebsd + Docker; skip Darwin/AUR/packagecloud). Drop leftover `/homebrew-mugs` gitignore.

Supersedes the unmerged parts of #671. Homebrew stays gone.

## Test plan
- [ ] Nightly `release N` does not run `unstable_upload.sh`
- [ ] A tagged merge does not upload to unstable.golift.io
- [ ] Push to `unstable` still uploads `Unpackerr.dmg` there
- [ ] Merge logs show `signing` the four `.pkg.tar.zst` files (not `excluded by invalid filter`)


Made with [Cursor](https://cursor.com)