### PR TITLE
Give the daemon /etc/unpackerr and drop Python from release bash

### DIFF
--- a/.github/scripts/aur_publish.sh
+++ b/.github/scripts/aur_publish.sh
@@ -84,6 +84,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+cp -f init/systemd/unpackerr.install "${stage}/unpackerr.install"
+
 # PKGBUILD functions keep ${pkgname}/${pkgver}/${pkgdir} for makepkg.
 cat > "${stage}/PKGBUILD" <<EOF
 # Maintainer: David Newhall II <captain at golift dot io>
@@ -106,6 +108,7 @@ optdepends=(
   'rtorrent: torrent downloader'
 )
 backup=('etc/unpackerr/unpackerr.conf')
+install=unpackerr.install
 source=("${pkgname}-${pkgver}.tar.gz::${source_url}")
 sha256sums=('${sum}')
 
@@ -171,6 +174,7 @@ EOF
   echo "	makedepends = gzip"
   echo "	provides = unpackerr"
   echo "	backup = etc/unpackerr/unpackerr.conf"
+  echo "	install = unpackerr.install"
   echo "	source = ${source_url}"
   echo "	sha256sums = ${sum}"
   echo
@@ -181,7 +185,7 @@ echo "AUR ${pkgname} ${pkgver}-${pkgrel} sha256=${sum}"
 
 if [ "${DRY_RUN:-}" = 1 ]; then
   mkdir -p "${dir}/aur"
-  cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${dir}/aur/"
+  cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${stage}/unpackerr.install" "${dir}/aur/"
   echo "DRY_RUN=1 wrote ${dir}/aur/PKGBUILD"
   exit 0
 fi
@@ -193,7 +197,7 @@ if [ -z "${AUR_DEPLOY_KEY:-}" ]; then
   fi
   echo "AUR_DEPLOY_KEY unset; wrote files without pushing:" >&2
   mkdir -p "${dir}/aur"
-  cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${dir}/aur/"
+  cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${stage}/unpackerr.install" "${dir}/aur/"
   ls -l "${dir}/aur"
   exit 0
 fi
@@ -206,10 +210,10 @@ export GIT_SSH_COMMAND="ssh -i ${keyfile} -o IdentitiesOnly=yes -o StrictHostKey
 
 clone="${stage}/repo"
 git clone --depth 1 "${aur_git}" "${clone}"
-cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${clone}/"
+cp -f "${stage}/PKGBUILD" "${stage}/.SRCINFO" "${stage}/unpackerr.install" "${clone}/"
 git -C "${clone}" config user.name goreleaserbot
 git -C "${clone}" config user.email bot@goreleaser.com
-git -C "${clone}" add PKGBUILD .SRCINFO
+git -C "${clone}" add PKGBUILD .SRCINFO unpackerr.install
 if git -C "${clone}" diff --cached --quiet; then
   echo "AUR already at ${pkgver}-${pkgrel}"
   exit 0

--- a/.github/scripts/macos_keychain.sh
+++ b/.github/scripts/macos_keychain.sh
@@ -23,9 +23,8 @@ password="${KEYCHAIN_PASSWORD:-$(openssl rand -base64 32)}"
 # one-line (or wrapped) base64. macOS openssl base64 -d without -A yields
 # empty files for long lines; -A treats the whole buffer as one line.
 write_secret() {
-  local dest=$1 envname=$2
-  local raw s compact mod
-  raw="${!envname-}"
+  local dest=$1 envname=$2 raw=$3
+  local s compact mod
   s="${raw//$'\r'/}"
   s="${s#"${s%%[![:space:]]*}"}"
   s="${s%"${s##*[![:space:]]}"}"
@@ -59,8 +58,8 @@ write_secret() {
   echo "${envname}: ${#raw} chars -> $(wc -c < "${dest}" | tr -d ' ') bytes"
 }
 
-write_secret "${cert}" MACOS_SIGN_P12
-write_secret "${key}" MACOS_NOTARY_KEY
+write_secret "${cert}" MACOS_SIGN_P12 "${MACOS_SIGN_P12}"
+write_secret "${key}" MACOS_NOTARY_KEY "${MACOS_NOTARY_KEY}"
 chmod 600 "${cert}" "${key}"
 echo "p12 $(wc -c < "${cert}" | tr -d ' ') bytes ($(file -b "${cert}"))"
 echo "p8 $(wc -c < "${key}" | tr -d ' ') bytes ($(file -b "${key}"))"

--- a/.github/scripts/macos_keychain.sh
+++ b/.github/scripts/macos_keychain.sh
@@ -20,35 +20,43 @@ profile="${MACOS_NOTARY_PROFILE_NAME:-unpackerr}"
 password="${KEYCHAIN_PASSWORD:-$(openssl rand -base64 32)}"
 
 # Quill accepted "path or base64". GitHub secrets are either PEM text or
-# one-line base64. macOS openssl base64 -d without -A yields empty files
-# for long lines, and PEM is not base64 at all.
+# one-line (or wrapped) base64. macOS openssl base64 -d without -A yields
+# empty files for long lines; -A treats the whole buffer as one line.
 write_secret() {
   local dest=$1 envname=$2
-  python3 - "${dest}" "${envname}" <<'PY'
-import base64, os, pathlib, sys
-
-dest, envname = sys.argv[1], sys.argv[2]
-raw = os.environ.get(envname, "")
-if not raw.strip():
-    sys.stderr.write(f"{envname} empty\n")
-    sys.exit(1)
-s = raw.strip().replace("\r", "")
-if "BEGIN " in s:
-    data = (s if s.endswith("\n") else s + "\n").encode()
-else:
-    compact = "".join(s.split())
-    compact += "=" * ((4 - len(compact) % 4) % 4)
-    try:
-        data = base64.b64decode(compact)
-    except Exception as exc:
-        sys.stderr.write(f"{envname} base64 decode failed: {exc}\n")
-        sys.exit(1)
-if not data:
-    sys.stderr.write(f"{envname} decoded to empty ({len(raw)} input chars)\n")
-    sys.exit(1)
-pathlib.Path(dest).write_bytes(data)
-print(f"{envname}: {len(raw)} chars -> {len(data)} bytes")
-PY
+  local raw s compact mod
+  raw="${!envname-}"
+  s="${raw//$'\r'/}"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  if [ -z "${s}" ]; then
+    echo "${envname} empty" >&2
+    exit 1
+  fi
+  if [[ "${s}" == *"BEGIN "* ]]; then
+    printf '%s\n' "${s}" > "${dest}"
+  else
+    compact="$(printf '%s' "${s}" | tr -d '[:space:]')"
+    mod=$(( ${#compact} % 4 ))
+    case "${mod}" in
+      0) ;;
+      2) compact="${compact}==" ;;
+      3) compact="${compact}=" ;;
+      *)
+        echo "${envname} base64 decode failed: length ${#compact} mod 4 = ${mod}" >&2
+        exit 1
+        ;;
+    esac
+    if ! printf '%s' "${compact}" | openssl base64 -d -A > "${dest}"; then
+      echo "${envname} base64 decode failed" >&2
+      exit 1
+    fi
+  fi
+  if [ ! -s "${dest}" ]; then
+    echo "${envname} decoded to empty (${#raw} input chars)" >&2
+    exit 1
+  fi
+  echo "${envname}: ${#raw} chars -> $(wc -c < "${dest}" | tr -d ' ') bytes"
 }
 
 write_secret "${cert}" MACOS_SIGN_P12

--- a/.github/scripts/unstable_upload.sh
+++ b/.github/scripts/unstable_upload.sh
@@ -108,13 +108,16 @@ dest_name() {
 }
 
 zip_exe() {
-  local src=$1 dest=$2
-  python3 - "${src}" "${dest}" <<'PY'
-import sys, zipfile
-src, dest = sys.argv[1], sys.argv[2]
-with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-    zf.write(src, arcname="unpackerr.exe")
-PY
+  local src=$1 dest=$2 work
+  if ! command -v zip >/dev/null; then
+    echo "zip is required to stage Windows unstable artifacts" >&2
+    exit 1
+  fi
+  work="$(mktemp -d "${TMPDIR:-/tmp}/unpackerr-zip.XXXXXX")"
+  dest="$(cd "$(dirname "${dest}")" && pwd)/$(basename "${dest}")"
+  cp -f "${src}" "${work}/unpackerr.exe"
+  (cd "${work}" && zip -9q "${dest}" unpackerr.exe)
+  rm -rf "${work}"
 }
 
 # Prefer GOARM 7 over 6 when both exist (same dest name).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -278,6 +278,11 @@ nfpms:
       signature:
         key_file: "{{ .Env.GPG_SIGNING_KEY }}"
         type: origin
+    # nFPM maps scripts.postinstall to Arch post_install only. Upgrades must
+    # still claim leftover root:root configs (same script is idempotent).
+    archlinux:
+      scripts:
+        postupgrade: init/systemd/after-install.sh
     scripts:
       preinstall: init/systemd/before-install.sh
       postinstall: init/systemd/after-install.sh

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -7,8 +7,9 @@
 # this script with no args on install *and* upgrade.
 #
 # uid 0 alone is not "unclaimed": a User=/Group= override is often
-# root:www-data with 0750/0640. Require uid and gid 0. Skip symlinks so a
-# root-owned link cannot move the chown onto a file outside the config dir.
+# root:www-data with 0750/0640. Require uid and gid 0. Skip the path if it
+# is a symlink, and skip child claims if the config directory is a symlink,
+# so chown cannot follow a link onto a file outside the packaged tree.
 
 OS="$(uname -s)"
 
@@ -29,8 +30,10 @@ chown_if_root_root() {
 }
 
 chown_if_root_root "${confdir}"
-chown_if_root_root "${confdir}/unpackerr.conf"
-chown_if_root_root "${confdir}/unpackerr.conf.example"
+if [ ! -L "${confdir}" ]; then
+  chown_if_root_root "${confdir}/unpackerr.conf"
+  chown_if_root_root "${confdir}/unpackerr.conf.example"
+fi
 
 if [ ! -d "${logdir}" ]; then
   mkdir "${logdir}"

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -3,13 +3,20 @@
 # This file is used by deb, rpm and BSD packages.
 # FPM/nFPM adds this as the after-install script.
 #
-# Chown /etc/unpackerr only on a first install. Upgrades must not reset an
-# admin who overrode User=/Group= and chowned the config to match.
+# Chown the packaged config files only on a first install. Upgrades must not
+# reset an admin who overrode User=/Group= and chowned the config to match.
+# Name the packaged files instead of chown -R so extra files in the directory
+# (password lists, drop-in confs) keep the ownership the admin set.
 
 OS="$(uname -s)"
 
-logdir='/var/log/unpackerr'
-[ "${OS}" = "Linux" ] || logdir='/usr/local/var/log/unpackerr'
+if [ "${OS}" = "Linux" ]; then
+  confdir=/etc/unpackerr
+  logdir=/var/log/unpackerr
+else
+  confdir=/usr/local/etc/unpackerr
+  logdir=/usr/local/var/log/unpackerr
+fi
 
 # nFPM: deb $1=configure $2=oldver-or-empty; rpm $1=1 install / $1=2 upgrade.
 first_install=0
@@ -19,13 +26,10 @@ elif [ "${1:-}" = "configure" ] && [ -z "${2:-}" ]; then
   first_install=1
 fi
 
-if [ "${first_install}" = 1 ]; then
-  if [ -d /usr/local/etc/unpackerr ]; then
-    chown -R unpackerr: /usr/local/etc/unpackerr
-  fi
-  if [ -d /etc/unpackerr ]; then
-    chown -R unpackerr: /etc/unpackerr
-  fi
+if [ "${first_install}" = 1 ] && [ -d "${confdir}" ]; then
+  chown unpackerr: "${confdir}"
+  [ -f "${confdir}/unpackerr.conf" ] && chown unpackerr: "${confdir}/unpackerr.conf"
+  [ -f "${confdir}/unpackerr.conf.example" ] && chown unpackerr: "${confdir}/unpackerr.conf.example"
 fi
 
 if [ ! -d "${logdir}" ]; then

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -8,11 +8,19 @@ OS="$(uname -s)"
 logdir='/var/log/unpackerr'
 [ "${OS}" = "Linux" ] || logdir='/usr/local/var/log/unpackerr'
 
+if [ -d /usr/local/etc/unpackerr ]; then
+  chown -R unpackerr: /usr/local/etc/unpackerr
+fi
+
+if [ -d /etc/unpackerr ]; then
+  chown -R unpackerr: /etc/unpackerr
+fi
+
 if [ ! -d "${logdir}" ]; then
   mkdir "${logdir}"
-  chown unpackerr: "${logdir}"
-  chmod 0755 "${logdir}"
 fi
+chown unpackerr: "${logdir}"
+chmod 0755 "${logdir}"
 
 if [ -x "/bin/systemctl" ]; then
   # Reload and restart - this starts the application as user nobody.

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -2,11 +2,13 @@
 
 # This file is used by deb, rpm, nFPM archlinux, and FreeBSD packages.
 #
-# Claim packaged config paths that are still root-owned. Do not use packager
-# $1/$2 as "first install": nFPM Arch passes the version string, and FreeBSD
-# pkg runs this script with no args on install *and* upgrade. An admin who
-# overrode User=/Group= has already chowned away from root, so we leave them
-# alone. Extra files in the directory are not touched.
+# Claim packaged paths that are still root:root. Do not use packager $1/$2 as
+# "first install": nFPM Arch passes the version string, and FreeBSD pkg runs
+# this script with no args on install *and* upgrade.
+#
+# uid 0 alone is not "unclaimed": a User=/Group= override is often
+# root:www-data with 0750/0640. Require uid and gid 0. Skip symlinks so a
+# root-owned link cannot move the chown onto a file outside the config dir.
 
 OS="$(uname -s)"
 
@@ -18,23 +20,24 @@ else
   logdir=/usr/local/var/log/unpackerr
 fi
 
-chown_if_root() {
+chown_if_root_root() {
+  [ -L "$1" ] && return 0
   [ -e "$1" ] || return 0
-  uid="$(stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1")"
-  [ "${uid}" = 0 ] || return 0
+  ug="$(stat -c '%u %g' "$1" 2>/dev/null || stat -f '%u %g' "$1")"
+  [ "${ug}" = "0 0" ] || return 0
   chown unpackerr: "$1"
 }
 
-chown_if_root "${confdir}"
-chown_if_root "${confdir}/unpackerr.conf"
-chown_if_root "${confdir}/unpackerr.conf.example"
+chown_if_root_root "${confdir}"
+chown_if_root_root "${confdir}/unpackerr.conf"
+chown_if_root_root "${confdir}/unpackerr.conf.example"
 
 if [ ! -d "${logdir}" ]; then
   mkdir "${logdir}"
   chown unpackerr: "${logdir}"
   chmod 0755 "${logdir}"
 else
-  chown_if_root "${logdir}"
+  chown_if_root_root "${logdir}"
 fi
 
 if [ -x "/bin/systemctl" ]; then

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-# This file is used by deb, rpm and BSD packages.
-# FPM/nFPM adds this as the after-install script.
+# This file is used by deb, rpm, nFPM archlinux, and FreeBSD packages.
 #
-# Chown the packaged config files only on a first install. Upgrades must not
-# reset an admin who overrode User=/Group= and chowned the config to match.
-# Name the packaged files instead of chown -R so extra files in the directory
-# (password lists, drop-in confs) keep the ownership the admin set.
+# Claim packaged config paths that are still root-owned. Do not use packager
+# $1/$2 as "first install": nFPM Arch passes the version string, and FreeBSD
+# pkg runs this script with no args on install *and* upgrade. An admin who
+# overrode User=/Group= has already chowned away from root, so we leave them
+# alone. Extra files in the directory are not touched.
 
 OS="$(uname -s)"
 
@@ -18,24 +18,23 @@ else
   logdir=/usr/local/var/log/unpackerr
 fi
 
-# nFPM: deb $1=configure $2=oldver-or-empty; rpm $1=1 install / $1=2 upgrade.
-first_install=0
-if [ "${1:-}" = "1" ] || [ "${1:-}" = "install" ]; then
-  first_install=1
-elif [ "${1:-}" = "configure" ] && [ -z "${2:-}" ]; then
-  first_install=1
-fi
+chown_if_root() {
+  [ -e "$1" ] || return 0
+  uid="$(stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1")"
+  [ "${uid}" = 0 ] || return 0
+  chown unpackerr: "$1"
+}
 
-if [ "${first_install}" = 1 ] && [ -d "${confdir}" ]; then
-  chown unpackerr: "${confdir}"
-  [ -f "${confdir}/unpackerr.conf" ] && chown unpackerr: "${confdir}/unpackerr.conf"
-  [ -f "${confdir}/unpackerr.conf.example" ] && chown unpackerr: "${confdir}/unpackerr.conf.example"
-fi
+chown_if_root "${confdir}"
+chown_if_root "${confdir}/unpackerr.conf"
+chown_if_root "${confdir}/unpackerr.conf.example"
 
 if [ ! -d "${logdir}" ]; then
   mkdir "${logdir}"
   chown unpackerr: "${logdir}"
   chmod 0755 "${logdir}"
+else
+  chown_if_root "${logdir}"
 fi
 
 if [ -x "/bin/systemctl" ]; then

--- a/init/systemd/after-install.sh
+++ b/init/systemd/after-install.sh
@@ -1,26 +1,38 @@
 #!/bin/sh
 
 # This file is used by deb, rpm and BSD packages.
-# FPM adds this as the after-install script.
+# FPM/nFPM adds this as the after-install script.
+#
+# Chown /etc/unpackerr only on a first install. Upgrades must not reset an
+# admin who overrode User=/Group= and chowned the config to match.
 
 OS="$(uname -s)"
 
 logdir='/var/log/unpackerr'
 [ "${OS}" = "Linux" ] || logdir='/usr/local/var/log/unpackerr'
 
-if [ -d /usr/local/etc/unpackerr ]; then
-  chown -R unpackerr: /usr/local/etc/unpackerr
+# nFPM: deb $1=configure $2=oldver-or-empty; rpm $1=1 install / $1=2 upgrade.
+first_install=0
+if [ "${1:-}" = "1" ] || [ "${1:-}" = "install" ]; then
+  first_install=1
+elif [ "${1:-}" = "configure" ] && [ -z "${2:-}" ]; then
+  first_install=1
 fi
 
-if [ -d /etc/unpackerr ]; then
-  chown -R unpackerr: /etc/unpackerr
+if [ "${first_install}" = 1 ]; then
+  if [ -d /usr/local/etc/unpackerr ]; then
+    chown -R unpackerr: /usr/local/etc/unpackerr
+  fi
+  if [ -d /etc/unpackerr ]; then
+    chown -R unpackerr: /etc/unpackerr
+  fi
 fi
 
 if [ ! -d "${logdir}" ]; then
   mkdir "${logdir}"
+  chown unpackerr: "${logdir}"
+  chmod 0755 "${logdir}"
 fi
-chown unpackerr: "${logdir}"
-chmod 0755 "${logdir}"
 
 if [ -x "/bin/systemctl" ]; then
   # Reload and restart - this starts the application as user nobody.

--- a/init/systemd/unpackerr.install
+++ b/init/systemd/unpackerr.install
@@ -1,23 +1,31 @@
-# Claim packaged config paths that are still root-owned. post_upgrade is a
-# no-op: an admin who overrode User=/Group= has already chowned away from root.
-# Name the packaged files instead of chown -R so extra files keep their owner.
-# Always return 0 so a missing example file cannot fail the pacman transaction.
-post_install() {
+# Claim packaged paths that are still root:root. Same helper on install and
+# upgrade so existing AUR trees left root:root get migrated, and a User=
+# override (often root:www-data, or a non-root uid) is left alone.
+# Skip symlinks. Always return 0 so a missing example cannot fail pacman.
+
+chown_if_root_root() {
+  [ -L "$1" ] && return 0
+  [ -e "$1" ] || return 0
+  ug="$(stat -c '%u %g' "$1" 2>/dev/null || stat -f '%u %g' "$1")"
+  [ "${ug}" = "0 0" ] || return 0
+  chown unpackerr:unpackerr "$1" || true
+}
+
+claim_packaged_config() {
   if command -v systemd-sysusers >/dev/null; then
     systemd-sysusers unpackerr.conf || true
   fi
-  if [ -d /etc/unpackerr ]; then
-    chown unpackerr:unpackerr /etc/unpackerr || true
-    if [ -f /etc/unpackerr/unpackerr.conf ]; then
-      chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf || true
-    fi
-    if [ -f /etc/unpackerr/unpackerr.conf.example ]; then
-      chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf.example || true
-    fi
-  fi
+  chown_if_root_root /etc/unpackerr
+  chown_if_root_root /etc/unpackerr/unpackerr.conf
+  chown_if_root_root /etc/unpackerr/unpackerr.conf.example
+}
+
+post_install() {
+  claim_packaged_config
   return 0
 }
 
 post_upgrade() {
-  :
+  claim_packaged_config
+  return 0
 }

--- a/init/systemd/unpackerr.install
+++ b/init/systemd/unpackerr.install
@@ -1,15 +1,21 @@
-# Fresh install only. Upgrades must not reset config ownership for admins
-# who overrode User=/Group= in a systemd drop-in. Name the packaged files
-# instead of chown -R so extra files in the directory keep their owner.
+# Claim packaged config paths that are still root-owned. post_upgrade is a
+# no-op: an admin who overrode User=/Group= has already chowned away from root.
+# Name the packaged files instead of chown -R so extra files keep their owner.
+# Always return 0 so a missing example file cannot fail the pacman transaction.
 post_install() {
   if command -v systemd-sysusers >/dev/null; then
-    systemd-sysusers unpackerr.conf
+    systemd-sysusers unpackerr.conf || true
   fi
   if [ -d /etc/unpackerr ]; then
-    chown unpackerr:unpackerr /etc/unpackerr
-    [ -f /etc/unpackerr/unpackerr.conf ] && chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf
-    [ -f /etc/unpackerr/unpackerr.conf.example ] && chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf.example
+    chown unpackerr:unpackerr /etc/unpackerr || true
+    if [ -f /etc/unpackerr/unpackerr.conf ]; then
+      chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf || true
+    fi
+    if [ -f /etc/unpackerr/unpackerr.conf.example ]; then
+      chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf.example || true
+    fi
   fi
+  return 0
 }
 
 post_upgrade() {

--- a/init/systemd/unpackerr.install
+++ b/init/systemd/unpackerr.install
@@ -1,11 +1,14 @@
 # Fresh install only. Upgrades must not reset config ownership for admins
-# who overrode User=/Group= in a systemd drop-in.
+# who overrode User=/Group= in a systemd drop-in. Name the packaged files
+# instead of chown -R so extra files in the directory keep their owner.
 post_install() {
   if command -v systemd-sysusers >/dev/null; then
     systemd-sysusers unpackerr.conf
   fi
   if [ -d /etc/unpackerr ]; then
-    chown -R unpackerr:unpackerr /etc/unpackerr
+    chown unpackerr:unpackerr /etc/unpackerr
+    [ -f /etc/unpackerr/unpackerr.conf ] && chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf
+    [ -f /etc/unpackerr/unpackerr.conf.example ] && chown unpackerr:unpackerr /etc/unpackerr/unpackerr.conf.example
   fi
 }
 

--- a/init/systemd/unpackerr.install
+++ b/init/systemd/unpackerr.install
@@ -1,0 +1,14 @@
+# Fresh install only. Upgrades must not reset config ownership for admins
+# who overrode User=/Group= in a systemd drop-in.
+post_install() {
+  if command -v systemd-sysusers >/dev/null; then
+    systemd-sysusers unpackerr.conf
+  fi
+  if [ -d /etc/unpackerr ]; then
+    chown -R unpackerr:unpackerr /etc/unpackerr
+  fi
+}
+
+post_upgrade() {
+  :
+}

--- a/init/systemd/unpackerr.install
+++ b/init/systemd/unpackerr.install
@@ -1,7 +1,9 @@
 # Claim packaged paths that are still root:root. Same helper on install and
 # upgrade so existing AUR trees left root:root get migrated, and a User=
 # override (often root:www-data, or a non-root uid) is left alone.
-# Skip symlinks. Always return 0 so a missing example cannot fail pacman.
+# Skip the path if it is a symlink, and skip child claims if /etc/unpackerr
+# is a symlink, so chown cannot follow a link outside the packaged tree.
+# Always return 0 so a missing example cannot fail pacman.
 
 chown_if_root_root() {
   [ -L "$1" ] && return 0
@@ -16,8 +18,10 @@ claim_packaged_config() {
     systemd-sysusers unpackerr.conf || true
   fi
   chown_if_root_root /etc/unpackerr
-  chown_if_root_root /etc/unpackerr/unpackerr.conf
-  chown_if_root_root /etc/unpackerr/unpackerr.conf.example
+  if [ ! -L /etc/unpackerr ]; then
+    chown_if_root_root /etc/unpackerr/unpackerr.conf
+    chown_if_root_root /etc/unpackerr/unpackerr.conf.example
+  fi
 }
 
 post_install() {

--- a/init/systemd/unpackerr.tmpfiles
+++ b/init/systemd/unpackerr.tmpfiles
@@ -1,2 +1,8 @@
-# systemd-tmpfiles.d — log dir for User=unpackerr (see unpackerr.service).
+# systemd-tmpfiles.d — config and log dirs for User=unpackerr (see unpackerr.service).
+# Chown packaged conf files before the directory. systemd rejects an unpackerr-owned
+# directory that still contains root-owned files ("unsafe path transition").
+z /etc/unpackerr/unpackerr.conf 0644 unpackerr unpackerr -
+z /etc/unpackerr/unpackerr.conf.example 0644 unpackerr unpackerr -
+z /etc/unpackerr 0755 unpackerr unpackerr -
 d /var/log/unpackerr 0755 unpackerr unpackerr -
+z /var/log/unpackerr 0755 unpackerr unpackerr -

--- a/init/systemd/unpackerr.tmpfiles
+++ b/init/systemd/unpackerr.tmpfiles
@@ -1,8 +1,6 @@
-# systemd-tmpfiles.d — config and log dirs for User=unpackerr (see unpackerr.service).
-# Chown packaged conf files before the directory. systemd rejects an unpackerr-owned
-# directory that still contains root-owned files ("unsafe path transition").
-z /etc/unpackerr/unpackerr.conf 0644 unpackerr unpackerr -
-z /etc/unpackerr/unpackerr.conf.example 0644 unpackerr unpackerr -
-z /etc/unpackerr 0755 unpackerr unpackerr -
+# systemd-tmpfiles.d — log dir for User=unpackerr (see unpackerr.service).
+# Do not chown /etc/unpackerr here. systemd-tmpfiles runs on every boot and
+# would reset an admin who overrode User=/Group= (see the unit comments).
+# Fresh-install ownership is set once from after-install.sh (deb/rpm) or
+# unpackerr.install (AUR).
 d /var/log/unpackerr 0755 unpackerr unpackerr -
-z /var/log/unpackerr 0755 unpackerr unpackerr -

--- a/init/systemd/unpackerr.tmpfiles
+++ b/init/systemd/unpackerr.tmpfiles
@@ -1,6 +1,6 @@
 # systemd-tmpfiles.d — log dir for User=unpackerr (see unpackerr.service).
 # Do not chown /etc/unpackerr here. systemd-tmpfiles runs on every boot and
 # would reset an admin who overrode User=/Group= (see the unit comments).
-# Fresh-install ownership is set once from after-install.sh (deb/rpm) or
-# unpackerr.install (AUR).
+# Config ownership is claimed while the path is still root-owned, from
+# after-install.sh (deb/rpm/nFPM/FreeBSD) or unpackerr.install (AUR).
 d /var/log/unpackerr 0755 unpackerr unpackerr -

--- a/init/systemd/unpackerr.tmpfiles
+++ b/init/systemd/unpackerr.tmpfiles
@@ -1,6 +1,6 @@
 # systemd-tmpfiles.d — log dir for User=unpackerr (see unpackerr.service).
 # Do not chown /etc/unpackerr here. systemd-tmpfiles runs on every boot and
 # would reset an admin who overrode User=/Group= (see the unit comments).
-# Config ownership is claimed while the path is still root-owned, from
+# Config ownership is claimed while the path is still root:root, from
 # after-install.sh (deb/rpm/nFPM/FreeBSD) or unpackerr.install (AUR).
 d /var/log/unpackerr 0755 unpackerr unpackerr -


### PR DESCRIPTION
## Summary
- Drop Python from the release bash scripts (`openssl base64 -d -A` for signing secrets, `zip` for Windows unstable artifacts).
- Give the daemon the packaged config files **only while those paths are still `root:root`**. systemd-tmpfiles does **not** touch `/etc/unpackerr` (it would reset a `User=`/`Group=` override on every boot). AUR `post_install`/`post_upgrade` and the nFPM/fpm after-install script claim packaged files by name, skip symlinks, and leave `root:www-data` (or any non-root uid/gid) alone.

## Test plan
- [ ] Confirm `python3` is gone from `.github/scripts/*.sh`
- [ ] Fresh deb/rpm/nFPM Arch/AUR/FreeBSD install: `/etc/unpackerr` (or `/usr/local/etc/unpackerr` on BSD) and the two packaged conf files are `unpackerr:unpackerr`
- [ ] Upgrade after `chown www-data:` **or** `chown root:www-data` plus `chmod 0600` and an extra file in that directory: ownership, mode, and the extra file are unchanged
- [ ] AUR upgrade of a leftover `root:root` tree from an older package becomes `unpackerr:unpackerr`
- [ ] `systemd-tmpfiles --create /usr/lib/tmpfiles.d/unpackerr.conf` does not log an unsafe path transition and does not change `/etc/unpackerr`