### PR TITLE
Start the HTTP server from listen_addr, not metrics

### DIFF
--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -34,7 +34,7 @@ log_queues = "1m"
 ## Default is no log file; this is unset.
 ## Except on macOS and Windows, the log file gets set to "~/.unpackerr/unpackerr.log"
 ## log_files=0 turns off auto-rotation so logrotate can own the file.
-## After logrotate renames the live file, send SIGHUP (systemctl reload unpackerr)
+## After logrotate renames the live file, send SIGHUP (`systemctl reload unpackerr`)
 ## to close and reopen it. Use logrotate `create` plus postrotate HUP, not copytruncate.
 ## Default files is 10 and size(mb) is 10 Megabytes.
 #log_file = '/downloads/unpackerr.log'
@@ -94,9 +94,11 @@ dir_mode = "0755"
 passwords = []
 
 [webserver]
-## The web server currently only supports metrics; set this to true if you wish to use it.
+## Expose Prometheus metrics at /metrics. The HTTP server starts whenever listen_addr is set;
+## this only controls the /metrics route.
  metrics = false
 ## This may be set to a port or an ip:port to bind a specific IP. 0.0.0.0 binds ALL IPs.
+## Set this to an empty string to disable the HTTP server.
  listen_addr = "0.0.0.0:5656"
 ## Recommend setting a log file for HTTP requests. Otherwise, they go with other logs.
  log_file = ''
@@ -396,4 +398,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 30 AUG 2026 08:13 UTC
+## => Content Auto Generated, 03 SEP 2026 08:08 UTC

--- a/init/config/definitions.yml
+++ b/init/config/definitions.yml
@@ -411,10 +411,11 @@ sections:
   webserver:
     title: Web Server
     docs: |
-      :::note[Metrics]
-      The web server currently only provides prometheus metrics, which you can display in
-      [Grafana](https://grafana.com/grafana/dashboards/18817-unpackerr/).
-      It provides no UI. This may change in the future. The web server was added in v0.12.0.
+      :::note[Web Server]
+      The HTTP server listens whenever `listen_addr` is set (default `0.0.0.0:5656`).
+      Set `listen_addr = ""` to turn it off. `metrics = true` exposes Prometheus
+      metrics at `/metrics` for [Grafana](https://grafana.com/grafana/dashboards/18817-unpackerr/).
+      The web server was added in v0.12.0.
       :::
     envvar_prefix: WEBSERVER_
     params:
@@ -423,12 +424,16 @@ sections:
         default: false
         recommend: *BOOLEAN
         short: Enable the Prometheus metrics endpoint.
-        desc: The web server currently only supports metrics; set this to true if you wish to use it.
+        desc: |
+          Expose Prometheus metrics at /metrics. The HTTP server starts whenever listen_addr is set;
+          this only controls the /metrics route.
       - name: listen_addr
         envvar: LISTEN_ADDR
         default: 0.0.0.0:5656
-        short: ip:port to listen on; `0.0.0.0` is all IPs.
-        desc: This may be set to a port or an ip:port to bind a specific IP. 0.0.0.0 binds ALL IPs.
+        short: ip:port to listen on; empty string disables the HTTP server.
+        desc: |
+          This may be set to a port or an ip:port to bind a specific IP. 0.0.0.0 binds ALL IPs.
+          Set this to an empty string to disable the HTTP server.
       - name: log_file
         envvar: LOG_FILE
         default: ''

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -30,8 +30,33 @@ type WebServer struct {
 	server     *http.Server
 }
 
+func (w *WebServer) listenAddr() string {
+	if w == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(w.ListenAddr)
+}
+
 func (w *WebServer) Enabled() bool {
-	return w != nil && strings.TrimSpace(w.ListenAddr) != ""
+	return w.listenAddr() != ""
+}
+
+func (w *WebServer) bindAddr() string {
+	addr := w.listenAddr()
+	if addr != "" && !strings.Contains(addr, ":") {
+		return "0.0.0.0:" + addr
+	}
+
+	return addr
+}
+
+func (w *WebServer) normalizeURLBase() {
+	if w == nil {
+		return
+	}
+
+	w.URLBase = strings.TrimSuffix(path.Join("/", w.URLBase), "/") + "/"
 }
 
 func (u *Unpackerr) logWebserver() {
@@ -40,10 +65,7 @@ func (u *Unpackerr) logWebserver() {
 		return
 	}
 
-	addr := u.Webserver.ListenAddr
-	if !strings.Contains(addr, ":") {
-		addr = "0.0.0.0:" + addr
-	}
+	u.Webserver.normalizeURLBase()
 
 	ssl := ""
 	if u.Webserver.SSLCrtFile != "" && u.Webserver.SSLKeyFile != "" {
@@ -51,10 +73,10 @@ func (u *Unpackerr) logWebserver() {
 	}
 
 	u.Printf(" => Starting webserver. Listen address: http%s://%v%s (%d upstreams)",
-		ssl, addr, u.Webserver.URLBase, len(u.Webserver.Upstreams))
+		ssl, u.Webserver.bindAddr(), u.Webserver.URLBase, len(u.Webserver.Upstreams))
 
 	if u.Webserver.Metrics {
-		u.Printf(" => Prometheus metrics enabled at %smetrics", u.Webserver.URLBase)
+		u.Printf(" => Prometheus metrics enabled at %s", path.Join(u.Webserver.URLBase, "metrics"))
 	}
 }
 
@@ -63,12 +85,7 @@ func (u *Unpackerr) startWebServer() {
 		return
 	}
 
-	addr := u.Webserver.ListenAddr
-	if !strings.Contains(addr, ":") {
-		addr = "0.0.0.0:" + addr
-	}
-
-	u.Webserver.URLBase = strings.TrimSuffix(path.Join("/", u.Webserver.URLBase), "/") + "/"
+	u.Webserver.normalizeURLBase()
 	u.Webserver.allow = MakeIPs(u.Webserver.Upstreams)
 	u.Webserver.router = httprouter.New()
 	apache, _ := apachelog.New(`%{X-Forwarded-For}i %l - %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"`)
@@ -80,7 +97,7 @@ func (u *Unpackerr) startWebServer() {
 	u.webRoutes()
 
 	u.Webserver.server = &http.Server{
-		Addr:              addr,
+		Addr:              u.Webserver.bindAddr(),
 		Handler:           smx,
 		ReadTimeout:       0,
 		ReadHeaderTimeout: defaultTimeout,

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -31,7 +31,7 @@ type WebServer struct {
 }
 
 func (w *WebServer) Enabled() bool {
-	return w != nil && w.Metrics && w.ListenAddr != ""
+	return w != nil && strings.TrimSpace(w.ListenAddr) != ""
 }
 
 func (u *Unpackerr) logWebserver() {
@@ -52,6 +52,10 @@ func (u *Unpackerr) logWebserver() {
 
 	u.Printf(" => Starting webserver. Listen address: http%s://%v%s (%d upstreams)",
 		ssl, addr, u.Webserver.URLBase, len(u.Webserver.Upstreams))
+
+	if u.Webserver.Metrics {
+		u.Printf(" => Prometheus metrics enabled at %smetrics", u.Webserver.URLBase)
+	}
 }
 
 func (u *Unpackerr) startWebServer() {

--- a/pkg/unpackerr/webserver_test.go
+++ b/pkg/unpackerr/webserver_test.go
@@ -17,6 +17,7 @@ func TestWebServerEnabled(t *testing.T) {
 		{name: "port only", server: &WebServer{ListenAddr: "5656"}, want: true},
 		{name: "metrics does not gate", server: &WebServer{Metrics: true, ListenAddr: ""}, want: false},
 		{name: "metrics on with listen", server: &WebServer{Metrics: true, ListenAddr: "127.0.0.1:5656"}, want: true},
+		{name: "padded listen", server: &WebServer{ListenAddr: " 127.0.0.1:5656 "}, want: true},
 	}
 
 	for _, test := range tests {
@@ -27,5 +28,30 @@ func TestWebServerEnabled(t *testing.T) {
 				t.Fatalf("Enabled() = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestWebServerBindAddr(t *testing.T) {
+	t.Parallel()
+
+	got := (&WebServer{ListenAddr: " 5656 "}).bindAddr()
+	if got != "0.0.0.0:5656" {
+		t.Fatalf("port only %q", got)
+	}
+
+	got = (&WebServer{ListenAddr: " 127.0.0.1:5659 "}).bindAddr()
+	if got != "127.0.0.1:5659" {
+		t.Fatalf("trimmed %q", got)
+	}
+}
+
+func TestWebServerNormalizeURLBase(t *testing.T) {
+	t.Parallel()
+
+	server := &WebServer{URLBase: "custom"}
+	server.normalizeURLBase()
+
+	if server.URLBase != "/custom/" {
+		t.Fatalf("urlbase %q", server.URLBase)
 	}
 }

--- a/pkg/unpackerr/webserver_test.go
+++ b/pkg/unpackerr/webserver_test.go
@@ -1,0 +1,31 @@
+package unpackerr
+
+import "testing"
+
+func TestWebServerEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		server *WebServer
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty listen", server: &WebServer{ListenAddr: ""}, want: false},
+		{name: "whitespace listen", server: &WebServer{ListenAddr: "  \t"}, want: false},
+		{name: "default listen metrics off", server: &WebServer{ListenAddr: "0.0.0.0:5656"}, want: true},
+		{name: "port only", server: &WebServer{ListenAddr: "5656"}, want: true},
+		{name: "metrics does not gate", server: &WebServer{Metrics: true, ListenAddr: ""}, want: false},
+		{name: "metrics on with listen", server: &WebServer{Metrics: true, ListenAddr: "127.0.0.1:5656"}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := test.server.Enabled(); got != test.want {
+				t.Fatalf("Enabled() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `Enabled()` is a non-empty `listen_addr` (whitespace counts as empty). `metrics` only registers `/metrics`.
- Default installs already have `listen_addr = "0.0.0.0:5656"` and `metrics = false`, so they start listening after this change. Set `listen_addr = ""` to keep the server off.
- Example conf and `definitions.yml` no longer say the web server is metrics-only.

First PR in the API/UI stack. `/metrics` is still unauthenticated here; auth lands in a later PR.

## Test plan
- [x] `go test ./pkg/unpackerr/ ./init/config/`
- [x] `golangci-lint run ./pkg/unpackerr/`
- [ ] Default config (`metrics = false`, default listen) binds `:5656` and `/` returns Welcome
- [ ] `listen_addr = ""` logs `Webserver Disabled` and does not bind
- [ ] `metrics = true` still serves `/metrics`


Made with [Cursor](https://cursor.com)