### PR TITLE
Add JSONL extract history and GET /api/queue and /api/history

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     - UN_LOG_FILES=10
     - UN_LOG_FILE_MB=10
     - UN_LOG_FILE_MODE=0600
+    - UN_KEEP_HISTORY=200
     - UN_INTERVAL=2m
     - UN_PROGRESS=15s
     - UN_START_DELAY=1m

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -42,6 +42,11 @@ log_files = 10
 log_file_mb = 10
 log_file_mode = "0600"
 
+## How many completed or failed items to keep in unpackerr.history.jsonl
+## (next to the log file, or the config file if logs go to stdout).
+## The tray menu still shows only the last 10 names. `0` disables history.
+keep_history = 200
+
 ## How often to poll starr apps (sonarr, radarr, etc).
 ## Recommend 1m-5m. Uses Go Duration.
 interval = "2m"

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -296,6 +296,21 @@ sections:
           - value: '0644'
           - value: '0664'
         short: 'POSIX mode used for new log files; not for Windows'
+      - name: keep_history
+        envvar: KEEP_HISTORY
+        default: 200
+        recommend:
+          - value: 0
+          - value: 50
+          - value: 100
+          - value: 200
+          - value: 500
+          - value: 1000
+        short: Completed items kept in the history file and API.
+        desc: |
+          How many completed or failed items to keep in unpackerr.history.jsonl
+          (next to the log file, or the config file if logs go to stdout).
+          The tray menu still shows only the last 10 names. `0` disables history.
       - name: interval
         envvar: INTERVAL
         default: 2m

--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -24,10 +24,20 @@ func (u *Unpackerr) registerAPIRoutes() {
 	base := path.Join(u.Webserver.URLBase, "api")
 	u.Webserver.router.GET(path.Join(base, "stats"), u.requirePerm(PermReadSystemStats, u.statsHandler))
 	u.Webserver.router.GET(path.Join(base, "system"), u.requirePerm(PermReadSystemInfo, u.systemHandler))
+	u.Webserver.router.GET(path.Join(base, "queue"), u.requirePerm(PermReadSystemQueue, u.queueHandler))
+	u.Webserver.router.GET(path.Join(base, "history"), u.requirePerm(PermReadSystemHistory, u.historyHandler))
 }
 
 func (u *Unpackerr) statsHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	writeJSON(response, http.StatusOK, u.stats())
+}
+
+func (u *Unpackerr) queueHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	writeJSON(response, http.StatusOK, u.queueSnapshot())
+}
+
+func (u *Unpackerr) historyHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	writeJSON(response, http.StatusOK, u.historySnapshot())
 }
 
 func (u *Unpackerr) systemHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -66,7 +66,7 @@ type Config struct {
 	StartDelay    cnfg.Duration    `json:"startDelay"         toml:"start_delay"    xml:"start_delay"    yaml:"startDelay"`
 	RetryDelay    cnfg.Duration    `json:"retryDelay"         toml:"retry_delay"    xml:"retry_delay"    yaml:"retryDelay"`
 	Progress      cnfg.Duration    `json:"progress"           toml:"progress"       xml:"progress"       yaml:"progress"`
-	KeepHistory   uint             `json:"keepHistory"        toml:"keep_history"   xml:"keep_history"   yaml:"keepHistory"` // undocumented.
+	KeepHistory   uint             `json:"keepHistory"        toml:"keep_history"   xml:"keep_history"   yaml:"keepHistory"`
 	Passwords     StringSlice      `json:"passwords"          toml:"passwords"      xml:"password"       yaml:"passwords"`
 	Webserver     *WebServer       `json:"webserver"          toml:"webserver"      xml:"webserver"      yaml:"webserver"`
 	Lidarr        []*LidarrConfig  `json:"lidarr,omitempty"   toml:"lidarr"         xml:"lidarr"         yaml:"lidarr,omitempty"`

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -195,7 +195,7 @@ func (u *Unpackerr) validateConfig() (uint64, uint64) { //nolint:cyclop
 	}
 
 	if u.KeepHistory != 0 {
-		u.Items = make([]string, u.KeepHistory)
+		u.Items = make([]string, min(u.KeepHistory, trayHistory))
 	}
 
 	return fileMode, dirMode

--- a/pkg/unpackerr/cnfgfile_test.go
+++ b/pkg/unpackerr/cnfgfile_test.go
@@ -339,9 +339,8 @@ func TestConfigTOMLTagsInSchema(t *testing.T) {
 	}
 
 	skip := map[string]struct{}{
-		"keep_history": {}, // undocumented until the history API
-		"path":         {}, // legacy StarrConfig alias for paths
-		"key":          {}, // nested [[webserver.api_keys]]; parent api_keys is in the schema
+		"path": {}, // legacy StarrConfig alias for paths
+		"key":  {}, // nested [[webserver.api_keys]]; parent api_keys is in the schema
 	}
 
 	missing := missingSchemaTags(reflect.TypeFor[Config](), schema.ParamNames(), skip)

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -338,12 +338,7 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	u.folders.Folders[name].updated = now
 	u.folders.Folders[name].status = QUEUED
 
-	// Do not extract r00 file if rar file with same name exists.
-	if strings.HasSuffix(strings.ToLower(name), ".r00") &&
-		xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
-		u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
-		u.folders.Folders[name].status = EXTRACTEDNOTHING
-
+	if u.skipR00WhenRarExists(name, now) {
 		return
 	}
 
@@ -398,6 +393,24 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	}
 
 	u.Printf("[Folder] Queued: %s, queue size: %d", name, queueSize)
+}
+
+// skipR00WhenRarExists records a completed no-op when a .r00 companion is skipped
+// because the matching .rar is already present.
+func (u *Unpackerr) skipR00WhenRarExists(name string, now time.Time) bool {
+	if !strings.HasSuffix(strings.ToLower(name), ".r00") ||
+		!xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
+		return false
+	}
+
+	u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
+	u.folders.Folders[name].status = EXTRACTEDNOTHING
+	u.lockHistory()
+	_ = u.updateQueueStatus(&newStatus{Name: name, Status: QUEUED}, now, false)
+	u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTEDNOTHING}, now, true)
+	u.unlockHistory()
+
+	return true
 }
 
 // folderExcludeSuffixes returns archive suffixes to ignore when scanning for items to extract.
@@ -813,7 +826,7 @@ func (u *Unpackerr) updateQueueStatus(data *newStatus, now time.Time, sendHook b
 		u.runAllHooks(u.Map[data.Name])
 	}
 
-	u.maybeRecordHistory(u.Map[data.Name])
+	u.maybeRecordHistory(data.Name, u.Map[data.Name])
 
 	return u.Map[data.Name]
 }

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -813,5 +813,7 @@ func (u *Unpackerr) updateQueueStatus(data *newStatus, now time.Time, sendHook b
 		u.runAllHooks(u.Map[data.Name])
 	}
 
+	u.maybeRecordHistory(u.Map[data.Name])
+
 	return u.Map[data.Name]
 }

--- a/pkg/unpackerr/folder_test.go
+++ b/pkg/unpackerr/folder_test.go
@@ -200,3 +200,36 @@ func newTestFolders(t *testing.T, cfg *FolderConfig) *Folders {
 
 	return folders
 }
+
+func TestExtractTrackedItemR00WithRarRecordsHistory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r00 := filepath.Join(dir, "show.r00")
+	rar := filepath.Join(dir, "show.rar")
+
+	if err := os.WriteFile(r00, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(rar, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := New()
+	unpack.KeepHistory = 10
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+	unpack.folders = &Folders{
+		Logs: noopLogger{},
+		Folders: map[string]*Folder{
+			r00: {config: &FolderConfig{}, status: WAITING},
+		},
+	}
+
+	unpack.extractTrackedItem(r00, unpack.folders.Folders[r00], time.Now())
+
+	got := unpack.historySnapshot()
+	if len(got) != 1 || got[0].Status != EXTRACTEDNOTHING || got[0].ID != r00 {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -14,9 +14,9 @@ const (
 )
 
 // History holds the history of extracted items.
-// mu guards Map, Finished, Retries, and per-item Status/Updated so HTTP stats
-// and Prometheus Collect can snapshot without racing the main loop. It is not
-// reentrant; do not lock inside a caller that already holds it.
+// mu guards Map, Finished, Retries, per-item Status/Updated, and XProg progress
+// so HTTP stats, queue snapshots, and Prometheus Collect cannot race the main loop.
+// It is not reentrant; do not lock inside a caller that already holds it.
 type History struct {
 	mu       sync.RWMutex
 	Items    []string

--- a/pkg/unpackerr/history_test.go
+++ b/pkg/unpackerr/history_test.go
@@ -3,6 +3,8 @@ package unpackerr
 import (
 	"strconv"
 	"testing"
+
+	"golift.io/xtractr"
 )
 
 func TestStatsConcurrentWithHistoryWrites(t *testing.T) {
@@ -32,6 +34,38 @@ func TestStatsConcurrentWithHistoryWrites(t *testing.T) {
 
 	for range 2000 {
 		_ = unpack.stats()
+	}
+
+	<-done
+}
+
+func TestQueueSnapshotConcurrentWithProgress(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	item := &Extract{Path: "/dl/a", Status: EXTRACTING}
+	item.XProg = &ExtractProgress{Extract: item, Archives: 1}
+	unpack.Map["a"] = item
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for idx := range 2000 {
+			unpack.handleProgress(&ExtractProgress{
+				Progress: &xtractr.Progress{
+					XFile:      &xtractr.XFile{FilePath: "/dl/a/file.rar"},
+					Compressed: 100,
+					Read:       uint64(idx),
+				},
+				Extract: item,
+			})
+		}
+	}()
+
+	for range 2000 {
+		_ = unpack.queueSnapshot()
 	}
 
 	<-done

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -1,0 +1,292 @@
+package unpackerr
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	historyFileName = "unpackerr.history.jsonl"
+	historyScanMax  = 1024 * 1024
+)
+
+// HistoryRecord is one completed or failed pipeline item (JSONL + API).
+type HistoryRecord struct {
+	ID         string        `json:"id"`
+	App        string        `json:"app"`
+	URL        string        `json:"url,omitempty"`
+	Path       string        `json:"path"`
+	OutputPath string        `json:"outputPath,omitempty"`
+	Status     ExtractStatus `json:"status"`
+	Retries    uint          `json:"retries"`
+	Started    time.Time     `json:"started"`
+	Updated    time.Time     `json:"updated"`
+	Finished   time.Time     `json:"finished"`
+	Archives   int           `json:"archives,omitempty"`
+	Files      int           `json:"files,omitempty"`
+	Bytes      uint64        `json:"bytes,omitempty"`
+	Ratio      float64       `json:"ratio,omitempty"`
+	Elapsed    string        `json:"elapsed,omitempty"`
+	Error      string        `json:"error,omitempty"`
+	Progress   string        `json:"progress,omitempty"`
+}
+
+// QueueItem is a live in-flight extract for GET /api/queue.
+type QueueItem struct {
+	ID         string        `json:"id"`
+	App        string        `json:"app"`
+	URL        string        `json:"url,omitempty"`
+	Path       string        `json:"path"`
+	OutputPath string        `json:"outputPath,omitempty"`
+	Status     ExtractStatus `json:"status"`
+	Retries    uint          `json:"retries"`
+	Updated    time.Time     `json:"updated"`
+	Progress   string        `json:"progress,omitempty"`
+	Error      string        `json:"error,omitempty"`
+}
+
+func (status ExtractStatus) isDurableHistory() bool {
+	switch status {
+	case EXTRACTFAILED, EXTRACTEDNOTHING, IMPORTED, DELETED, DELETEFAILED:
+		return true
+	default:
+		return false
+	}
+}
+
+func (u *Unpackerr) historyFilePath() string {
+	if u.LogFile != "" {
+		return filepath.Join(filepath.Dir(u.LogFile), historyFileName)
+	}
+
+	if u.ConfigFile != "" {
+		return filepath.Join(filepath.Dir(u.ConfigFile), historyFileName)
+	}
+
+	return ""
+}
+
+func (u *Unpackerr) loadHistory() {
+	if u.KeepHistory == 0 {
+		return
+	}
+
+	if path := u.historyFilePath(); path != "" {
+		u.histPath = path
+	}
+
+	if u.histPath == "" {
+		return
+	}
+
+	file, err := os.Open(u.histPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			u.Errorf("Opening history file: %v", err)
+		}
+
+		return
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(nil, historyScanMax)
+
+	var records []HistoryRecord
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var rec HistoryRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			u.Errorf("Skipping bad history line: %v", err)
+			continue
+		}
+
+		records = append(records, rec)
+	}
+
+	if err := scanner.Err(); err != nil {
+		u.Errorf("Reading history file: %v", err)
+	}
+
+	if limit := int(u.KeepHistory); limit > 0 && len(records) > limit {
+		records = records[len(records)-limit:]
+	}
+
+	u.histMu.Lock()
+	u.records = records
+	u.histMu.Unlock()
+}
+
+func (u *Unpackerr) maybeRecordHistory(item *Extract) {
+	if item == nil || u.KeepHistory == 0 || !item.Status.isDurableHistory() {
+		return
+	}
+
+	u.upsertHistory(historyFromExtract(item))
+}
+
+func historyFromExtract(item *Extract) HistoryRecord {
+	now := item.Updated
+	rec := HistoryRecord{
+		ID:         item.Path,
+		App:        string(item.App),
+		URL:        item.URL,
+		Path:       item.Path,
+		OutputPath: item.OutputPath,
+		Status:     item.Status,
+		Retries:    item.Retries,
+		Started:    now,
+		Updated:    now,
+		Finished:   now,
+	}
+
+	if item.XProg != nil {
+		if prog := item.XProg.String(); prog != "no progress yet" {
+			rec.Progress = prog
+		}
+
+		if item.XProg.Progress != nil && item.XProg.Compressed > 0 && item.Resp != nil && item.Resp.Size > 0 {
+			rec.Ratio = float64(item.Resp.Size) / float64(item.XProg.Compressed)
+		}
+	}
+
+	if item.Resp != nil {
+		if !item.Resp.Started.IsZero() {
+			rec.Started = item.Resp.Started
+		}
+
+		rec.Archives = item.Resp.Archives.Count() + item.Resp.Extras.Count()
+		rec.Files = len(item.Resp.NewFiles)
+		rec.Bytes = item.Resp.Size
+
+		if item.Resp.Elapsed > 0 {
+			rec.Elapsed = item.Resp.Elapsed.Round(time.Second).String()
+		}
+
+		if item.Resp.Error != nil {
+			rec.Error = item.Resp.Error.Error()
+		}
+	}
+
+	return rec
+}
+
+func (u *Unpackerr) upsertHistory(rec HistoryRecord) {
+	if rec.ID == "" {
+		rec.ID = rec.Path
+	}
+
+	u.histMu.Lock()
+	defer u.histMu.Unlock()
+
+	found := -1
+
+	for idx := range u.records {
+		if u.records[idx].ID == rec.ID {
+			found = idx
+			if rec.Started.IsZero() {
+				rec.Started = u.records[idx].Started
+			}
+
+			break
+		}
+	}
+
+	if found >= 0 {
+		u.records = append(u.records[:found], u.records[found+1:]...)
+	}
+
+	u.records = append(u.records, rec)
+
+	if limit := int(u.KeepHistory); limit > 0 && len(u.records) > limit {
+		u.records = u.records[len(u.records)-limit:]
+	}
+
+	if err := u.writeHistoryLocked(); err != nil {
+		u.Errorf("Writing history file: %v", err)
+	}
+}
+
+func (u *Unpackerr) writeHistoryLocked() error {
+	if u.histPath == "" {
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+
+	for idx := range u.records {
+		if err := enc.Encode(u.records[idx]); err != nil {
+			return fmt.Errorf("encoding history: %w", err)
+		}
+	}
+
+	if err := os.WriteFile(u.histPath, buf.Bytes(), defaultLogFileMode); err != nil {
+		return fmt.Errorf("writing history file: %w", err)
+	}
+
+	return nil
+}
+
+func (u *Unpackerr) historySnapshot() []HistoryRecord {
+	u.histMu.Lock()
+	defer u.histMu.Unlock()
+
+	out := make([]HistoryRecord, len(u.records))
+	for idx := range u.records {
+		out[len(out)-1-idx] = u.records[idx]
+	}
+
+	return out
+}
+
+func (u *Unpackerr) queueSnapshot() []QueueItem {
+	u.rLockHistory()
+	defer u.rUnlockHistory()
+
+	out := make([]QueueItem, 0, len(u.Map))
+
+	for name, item := range u.Map {
+		out = append(out, queueFromExtract(name, item))
+	}
+
+	return out
+}
+
+func queueFromExtract(id string, item *Extract) QueueItem {
+	queue := QueueItem{
+		ID:         id,
+		App:        string(item.App),
+		URL:        item.URL,
+		Path:       item.Path,
+		OutputPath: item.OutputPath,
+		Status:     item.Status,
+		Retries:    item.Retries,
+		Updated:    item.Updated,
+	}
+
+	if item.XProg != nil {
+		if prog := item.XProg.String(); prog != "no progress yet" {
+			queue.Progress = prog
+		}
+	}
+
+	if item.Resp != nil && item.Resp.Error != nil {
+		queue.Error = item.Resp.Error.Error()
+	}
+
+	return queue
+}

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/Unpackerr/unpackerr/pkg/configdef"
 )
 
 const (
@@ -61,7 +64,7 @@ func (status ExtractStatus) isDurableHistory() bool {
 }
 
 func (u *Unpackerr) historyFilePath() string {
-	if u.LogFile != "" {
+	if u.LogFile != "" && u.rotatorr != nil {
 		return filepath.Join(filepath.Dir(u.LogFile), historyFileName)
 	}
 
@@ -69,7 +72,7 @@ func (u *Unpackerr) historyFilePath() string {
 		return filepath.Join(filepath.Dir(u.ConfigFile), historyFileName)
 	}
 
-	return ""
+	return expandHomedir(filepath.Join("~", ".unpackerr", historyFileName))
 }
 
 func (u *Unpackerr) loadHistory() {
@@ -77,70 +80,108 @@ func (u *Unpackerr) loadHistory() {
 		return
 	}
 
-	if path := u.historyFilePath(); path != "" {
-		u.histPath = path
+	if u.histPath == "" {
+		u.histPath = u.historyFilePath()
 	}
 
 	if u.histPath == "" {
+		u.Printf("[Unpackerr] History file disabled; keep_history=%d but no log, config, or home path", u.KeepHistory)
+
 		return
 	}
 
+	records := u.readHistoryRecords()
+	trimmed := false
+
+	if limit := int(u.KeepHistory); limit > 0 && len(records) > limit {
+		records = records[len(records)-limit:]
+		trimmed = true
+	}
+
+	u.histMu.Lock()
+	u.records = records
+
+	if trimmed {
+		if err := u.writeHistoryLocked(); err != nil {
+			u.Errorf("Writing history file: %v", err)
+		}
+	}
+
+	u.histMu.Unlock()
+}
+
+func (u *Unpackerr) readHistoryRecords() []HistoryRecord {
 	file, err := os.Open(u.histPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			u.Errorf("Opening history file: %v", err)
 		}
 
-		return
+		return nil
 	}
 
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(nil, historyScanMax)
+	reader := bufio.NewReader(file)
 
 	var records []HistoryRecord
 
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 {
-			continue
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		records = u.appendHistoryLine(records, line)
+
+		if errors.Is(readErr, io.EOF) {
+			break
 		}
 
-		var rec HistoryRecord
-		if err := json.Unmarshal(line, &rec); err != nil {
-			u.Errorf("Skipping bad history line: %v", err)
-			continue
+		if readErr != nil {
+			u.Errorf("Reading history file: %v", readErr)
+
+			break
 		}
-
-		records = append(records, rec)
 	}
 
-	if err := scanner.Err(); err != nil {
-		u.Errorf("Reading history file: %v", err)
-	}
-
-	if limit := int(u.KeepHistory); limit > 0 && len(records) > limit {
-		records = records[len(records)-limit:]
-	}
-
-	u.histMu.Lock()
-	u.records = records
-	u.histMu.Unlock()
+	return records
 }
 
-func (u *Unpackerr) maybeRecordHistory(item *Extract) {
+func (u *Unpackerr) appendHistoryLine(records []HistoryRecord, line []byte) []HistoryRecord {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return records
+	}
+
+	if len(line) > historyScanMax {
+		u.Errorf("Skipping oversized history line")
+
+		return records
+	}
+
+	var rec HistoryRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		u.Errorf("Skipping bad history line: %v", err)
+
+		return records
+	}
+
+	return append(records, rec)
+}
+
+func (u *Unpackerr) maybeRecordHistory(itemID string, item *Extract) {
 	if item == nil || u.KeepHistory == 0 || !item.Status.isDurableHistory() {
 		return
 	}
 
-	u.upsertHistory(historyFromExtract(item))
+	u.upsertHistory(historyFromExtract(itemID, item))
 }
 
-func historyFromExtract(item *Extract) HistoryRecord {
+func historyFromExtract(itemID string, item *Extract) HistoryRecord {
 	now := item.Updated
+	if itemID == "" {
+		itemID = item.Path
+	}
+
 	rec := HistoryRecord{
-		ID:         item.Path,
+		ID:         itemID,
 		App:        string(item.App),
 		URL:        item.URL,
 		Path:       item.Path,
@@ -234,7 +275,7 @@ func (u *Unpackerr) writeHistoryLocked() error {
 		}
 	}
 
-	if err := os.WriteFile(u.histPath, buf.Bytes(), defaultLogFileMode); err != nil {
+	if err := configdef.AtomicWrite(u.histPath, buf.Bytes()); err != nil {
 		return fmt.Errorf("writing history file: %w", err)
 	}
 

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -19,6 +19,8 @@ const (
 	historyScanMax  = 1024 * 1024
 )
 
+var errHistoryLineTooLong = errors.New("history line exceeds maximum")
+
 // HistoryRecord is one completed or failed pipeline item (JSONL + API).
 type HistoryRecord struct {
 	ID         string        `json:"id"`
@@ -127,32 +129,25 @@ func (u *Unpackerr) readHistoryRecords() []HistoryRecord {
 	var records []HistoryRecord
 
 	for {
-		line, readErr := reader.ReadBytes('\n')
-		records = u.appendHistoryLine(records, line)
-
-		if errors.Is(readErr, io.EOF) {
-			break
-		}
-
-		if readErr != nil {
+		line, readErr := readBoundedLine(reader, historyScanMax)
+		switch {
+		case errors.Is(readErr, errHistoryLineTooLong):
+			u.Errorf("Skipping oversized history line")
+		case errors.Is(readErr, io.EOF):
+			return u.appendHistoryLine(records, line)
+		case readErr != nil:
 			u.Errorf("Reading history file: %v", readErr)
 
-			break
+			return records
+		default:
+			records = u.appendHistoryLine(records, line)
 		}
 	}
-
-	return records
 }
 
 func (u *Unpackerr) appendHistoryLine(records []HistoryRecord, line []byte) []HistoryRecord {
 	line = bytes.TrimSpace(line)
 	if len(line) == 0 {
-		return records
-	}
-
-	if len(line) > historyScanMax {
-		u.Errorf("Skipping oversized history line")
-
 		return records
 	}
 
@@ -164,6 +159,38 @@ func (u *Unpackerr) appendHistoryLine(records []HistoryRecord, line []byte) []Hi
 	}
 
 	return append(records, rec)
+}
+
+func readBoundedLine(reader *bufio.Reader, maxLen int) ([]byte, error) {
+	var line []byte
+
+	for {
+		chunk, err := reader.ReadSlice('\n')
+		if len(line)+len(chunk) > maxLen {
+			for errors.Is(err, bufio.ErrBufferFull) {
+				_, err = reader.ReadSlice('\n')
+			}
+
+			if err == nil || errors.Is(err, io.EOF) {
+				return nil, errHistoryLineTooLong
+			}
+
+			return nil, fmt.Errorf("reading history line: %w", err)
+		}
+
+		line = append(line, chunk...)
+
+		switch {
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case err == nil:
+			return bytes.TrimSpace(line), nil
+		case errors.Is(err, io.EOF):
+			return bytes.TrimSpace(line), io.EOF
+		default:
+			return nil, fmt.Errorf("reading history line: %w", err)
+		}
+	}
 }
 
 func (u *Unpackerr) maybeRecordHistory(itemID string, item *Extract) {

--- a/pkg/unpackerr/historyfile_test.go
+++ b/pkg/unpackerr/historyfile_test.go
@@ -174,3 +174,24 @@ func TestLoadHistoryKeepsRecordsAfterBadLine(t *testing.T) {
 		t.Fatalf("%+v", got)
 	}
 }
+
+func TestLoadHistorySkipsOversizedLineWithoutNewline(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), historyFileName)
+	body := `{"id":"a","path":"a","status":"imported"}` + "\n" + strings.Repeat("x", historyScanMax+16)
+
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := New()
+	unpack.KeepHistory = 10
+	unpack.histPath = path
+	unpack.loadHistory()
+
+	got := unpack.historySnapshot()
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/pkg/unpackerr/historyfile_test.go
+++ b/pkg/unpackerr/historyfile_test.go
@@ -74,3 +74,103 @@ func TestQueueAndHistoryAPI(t *testing.T) {
 		t.Fatalf("history %d %s", histRec.Code, histRec.Body.String())
 	}
 }
+
+func TestHistoryFilePathSkipsUnopenedLog(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.LogFile = filepath.Join("missing", "unpackerr.log")
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+
+	got := unpack.historyFilePath()
+	want := filepath.Join(filepath.Dir(unpack.ConfigFile), historyFileName)
+
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestHistoryFilePathFallsBackToHome(t *testing.T) {
+	t.Parallel()
+
+	got := New().historyFilePath()
+	if !strings.Contains(got, historyFileName) || !strings.Contains(got, ".unpackerr") {
+		t.Fatalf("home fallback %q", got)
+	}
+}
+
+func TestHistoryIDMatchesQueueMapKey(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.KeepHistory = 10
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+
+	const title = "Show.S01E01"
+
+	path := "/downloads/Show.S01E01.Group"
+	unpack.maybeRecordHistory(title, &Extract{
+		App:     "Sonarr",
+		Path:    path,
+		Status:  IMPORTED,
+		Updated: time.Now(),
+	})
+
+	got := unpack.historySnapshot()
+	if len(got) != 1 || got[0].ID != title || got[0].Path != path {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestLoadHistoryRewritesFileCap(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.KeepHistory = 10
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+
+	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: IMPORTED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "c", Path: "c", Status: IMPORTED, Updated: time.Now()})
+
+	unpack.KeepHistory = 1
+	unpack.records = nil
+	unpack.loadHistory()
+
+	if got := unpack.historySnapshot(); len(got) != 1 || got[0].ID != "c" {
+		t.Fatalf("memory %+v", unpack.historySnapshot())
+	}
+
+	body, err := os.ReadFile(unpack.histPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Count(string(body), `"id":`) != 1 || !strings.Contains(string(body), `"id":"c"`) {
+		t.Fatalf("file %s", body)
+	}
+}
+
+func TestLoadHistoryKeepsRecordsAfterBadLine(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), historyFileName)
+	line := func(id string) string {
+		return `{"id":"` + id + `","path":"` + id + `","status":"imported"}` + "\n"
+	}
+
+	body := line("a") + strings.Repeat("x", historyScanMax+16) + "\n" + line("c")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := New()
+	unpack.KeepHistory = 10
+	unpack.histPath = path
+	unpack.loadHistory()
+
+	got := unpack.historySnapshot()
+	if len(got) != 2 || got[0].ID != "c" || got[1].ID != "a" {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/pkg/unpackerr/historyfile_test.go
+++ b/pkg/unpackerr/historyfile_test.go
@@ -1,0 +1,76 @@
+package unpackerr
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHistoryUpsertAndCap(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.KeepHistory = 2
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+
+	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: EXTRACTFAILED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: IMPORTED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "c", Path: "c", Status: DELETED, Updated: time.Now()})
+
+	got := unpack.historySnapshot()
+	if len(got) != 2 {
+		t.Fatalf("cap: %d", len(got))
+	}
+
+	if got[0].ID != "c" || got[1].ID != "b" {
+		t.Fatalf("newest first: %+v", got)
+	}
+
+	body, err := os.ReadFile(unpack.histPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(body)
+	if !strings.Contains(text, `"id":"c"`) || strings.Contains(text, `"id":"a"`) {
+		t.Fatalf("file %s", text)
+	}
+
+	unpack.records = nil
+	unpack.loadHistory()
+
+	if len(unpack.historySnapshot()) != 2 {
+		t.Fatal("reload")
+	}
+}
+
+func TestQueueAndHistoryAPI(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.KeepHistory = 10
+	unpack.Map["/dl/show"] = &Extract{
+		Path:    "/dl/show",
+		App:     "Sonarr",
+		Status:  EXTRACTING,
+		Updated: time.Now(),
+	}
+	unpack.upsertHistory(HistoryRecord{ID: "/dl/old", Path: "/dl/old", Status: IMPORTED})
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	queueRec := doAuth(t, unpack, http.MethodGet, "/api/queue", "", withKey)
+	if queueRec.Code != http.StatusOK || !strings.Contains(queueRec.Body.String(), `/dl/show`) {
+		t.Fatalf("queue %d %s", queueRec.Code, queueRec.Body.String())
+	}
+
+	histRec := doAuth(t, unpack, http.MethodGet, "/api/history", "", withKey)
+	if histRec.Code != http.StatusOK || !strings.Contains(histRec.Body.String(), `/dl/old`) {
+		t.Fatalf("history %d %s", histRec.Code, histRec.Body.String())
+	}
+}

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/ui"
@@ -70,6 +72,29 @@ func (status ExtractStatus) Desc() string {
 func (status ExtractStatus) MarshalText() ([]byte, error) {
 	return []byte(status.String()), nil
 }
+
+// UnmarshalText turns a json identifier or TOML event ID back into a status.
+func (status *ExtractStatus) UnmarshalText(text []byte) error {
+	name := strings.TrimSpace(string(text))
+	if parsed, err := strconv.ParseUint(name, 10, 8); err == nil {
+		got := ExtractStatus(parsed)
+		if got <= EXTRACTEDNOTHING {
+			*status = got
+			return nil
+		}
+	}
+
+	for candidate := WAITING; candidate <= EXTRACTEDNOTHING; candidate++ {
+		if candidate.String() == name {
+			*status = candidate
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: %s", errUnknownExtractStatus, name)
+}
+
+var errUnknownExtractStatus = errors.New("unknown extract status")
 
 // String turns a status into a short string.
 func (status ExtractStatus) String() string {

--- a/pkg/unpackerr/progress.go
+++ b/pkg/unpackerr/progress.go
@@ -56,6 +56,13 @@ func (u *Unpackerr) progressUpdateCallback(item *Extract) func(xtractr.Progress)
 // exp.Progress = also what just came in, must set it here.
 // exp.XProg = what is saved in the map, update this one.
 func (u *Unpackerr) handleProgress(exp *ExtractProgress) {
+	if exp == nil || exp.XProg == nil {
+		return
+	}
+
+	u.lockHistory()
+	defer u.unlockHistory()
+
 	if exp.XProg.Progress != nil && exp.XProg.XFile != exp.XFile {
 		exp.XProg.Extracted++
 	}

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -45,7 +45,8 @@ const (
 	minimumDeleteDelay      = time.Second
 	defaultDeleteDelay      = 5 * time.Minute
 	staleItemTimeout        = 24 * time.Hour // Safety net: items stuck at intermediate states are cleaned up.
-	defaultHistory          = 10             // items kept in history.
+	defaultHistory          = 200            // JSONL cap; tray still shows trayHistory names.
+	trayHistory             = 10             // items kept in the GUI history menu.
 	suffix                  = "_unpackerred" // suffix for unpacked folders.
 	updateChanBuf           = 100            // Size of xtractr callback update channels.
 	signalBuf               = 4              // Hold HUP/TERM until waitForExit starts.
@@ -84,6 +85,9 @@ type Unpackerr struct {
 	configWriteErr   error
 	adminKeyNotice   string
 	adminKeyErr      error
+	histPath         string
+	histMu           sync.Mutex
+	records          []HistoryRecord
 }
 
 type fileDeleteReq struct {
@@ -188,6 +192,8 @@ func Start() error {
 	if unpackerr.reset {
 		return nil
 	}
+
+	unpackerr.loadHistory()
 	// Parse filepath: strings from the config and read in extra config files.
 	output, err := cnfgfile.Parse(unpackerr.Config, &cnfgfile.Opts{
 		Name:          "Unpackerr",

--- a/pkg/unpackerr/tray.go
+++ b/pkg/unpackerr/tray.go
@@ -147,7 +147,7 @@ func (u *Unpackerr) watchGuiChannels() {
 }
 
 func (u *Unpackerr) makeHistoryChannels() {
-	history := systray.AddMenuItem("History", fmt.Sprintf("display last %d items queued", u.KeepHistory))
+	history := systray.AddMenuItem("History", fmt.Sprintf("display last %d items queued", len(u.Items)))
 	u.menu["history"] = ui.WrapMenu(history)
 	u.menu[histNone] = ui.WrapMenu(history.AddSubMenuItem("-- there is no history --", "nothing has been queued yet"))
 	u.menu[histNone].Disable()
@@ -157,7 +157,7 @@ func (u *Unpackerr) makeHistoryChannels() {
 		u.menu[histNone].SetTooltip("history is disabled in the config")
 	}
 
-	for i := range u.KeepHistory {
+	for i := range u.Items {
 		u.menu[hist+strconv.FormatUint(uint64(i), 10)] = ui.WrapMenu(history.AddSubMenuItem("", ""))
 		u.menu[hist+strconv.FormatUint(uint64(i), 10)].Disable()
 		u.menu[hist+strconv.FormatUint(uint64(i), 10)].Hide()


### PR DESCRIPTION
## Why

The live extract map is dropped after cleanup, and the tray only keeps 10 path strings. The UI and API need durable completed/failed records plus a snapshot of in-flight work.

## What

- Persist completed and failed items to `unpackerr.history.jsonl` next to the log file (or the config file if logs go to stdout).
- Cap the file and in-memory list with `keep_history` (default **200**; `0` disables). The tray menu still shows only the last 10 names.
- Record on `EXTRACTFAILED`, `EXTRACTEDNOTHING`, `IMPORTED`, `DELETED`, and `DELETEFAILED`. `EXTRACTED` stays queue-only.
- `GET /api/queue` (`read:system:queue`) and `GET /api/history` (`read:system:history`).

Retry, forget, and history delete/clear are the next PR.


Made with [Cursor](https://cursor.com)