### PR TITLE
Add queue retry/forget and history delete/clear API actions

### DIFF
--- a/pkg/configdef/live_test.go
+++ b/pkg/configdef/live_test.go
@@ -409,6 +409,34 @@ func TestAtomicWriteBackup(t *testing.T) {
 	}
 }
 
+func TestAtomicReplaceNoBackup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unpackerr.history.jsonl")
+
+	if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AtomicReplace(path, []byte("new\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != "new\n" {
+		t.Fatalf("got %q", got)
+	}
+
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("backup should not exist: %v", err)
+	}
+}
+
 func MustLoad(t *testing.T) *Config {
 	t.Helper()
 

--- a/pkg/configdef/live_test.go
+++ b/pkg/configdef/live_test.go
@@ -437,6 +437,39 @@ func TestAtomicReplaceNoBackup(t *testing.T) {
 	}
 }
 
+func TestAtomicReplaceRemovesStaleBackup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unpackerr.history.jsonl")
+	bak := path + ".bak"
+
+	if err := os.WriteFile(path, []byte("keep-me\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(bak, []byte("drop-me\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AtomicReplace(path, []byte("new\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != "new\n" {
+		t.Fatalf("got %q", got)
+	}
+
+	if _, err := os.Stat(bak); !os.IsNotExist(err) {
+		t.Fatalf("stale backup should not exist: %v", err)
+	}
+}
+
 func MustLoad(t *testing.T) *Config {
 	t.Helper()
 

--- a/pkg/configdef/write.go
+++ b/pkg/configdef/write.go
@@ -17,6 +17,15 @@ const (
 
 // AtomicWrite writes data to path by temp file + rename, keeping path.bak.
 func AtomicWrite(path string, data []byte) error {
+	return atomicWrite(path, data, true)
+}
+
+// AtomicReplace writes data to path by temp file + rename without creating path.bak.
+func AtomicReplace(path string, data []byte) error {
+	return atomicWrite(path, data, false)
+}
+
+func atomicWrite(path string, data []byte, backup bool) error {
 	if path == "" {
 		return errEmptyConfigPath
 	}
@@ -57,7 +66,7 @@ func AtomicWrite(path string, data []byte) error {
 		return fmt.Errorf("closing temp config: %w", err)
 	}
 
-	if err := replaceFile(path, tmpName, mode); err != nil {
+	if err := replaceFile(path, tmpName, mode, backup); err != nil {
 		return err
 	}
 
@@ -66,12 +75,14 @@ func AtomicWrite(path string, data []byte) error {
 	return nil
 }
 
-func replaceFile(path, tmpName string, mode os.FileMode) error {
+func replaceFile(path, tmpName string, mode os.FileMode, backup bool) error {
 	bak := path + backupSuffix
 
-	if _, err := os.Stat(path); err == nil {
-		if err := copyFile(path, bak, mode); err != nil {
-			return fmt.Errorf("backing up config: %w", err)
+	if backup {
+		if _, err := os.Stat(path); err == nil {
+			if err := copyFile(path, bak, mode); err != nil {
+				return fmt.Errorf("backing up config: %w", err)
+			}
 		}
 	}
 
@@ -82,7 +93,9 @@ func replaceFile(path, tmpName string, mode os.FileMode) error {
 	_ = os.Remove(path)
 
 	if err := os.Rename(tmpName, path); err != nil {
-		_ = copyFile(bak, path, mode)
+		if backup {
+			_ = copyFile(bak, path, mode)
+		}
 
 		return fmt.Errorf("replacing config: %w", err)
 	}

--- a/pkg/configdef/write.go
+++ b/pkg/configdef/write.go
@@ -87,7 +87,16 @@ func replaceFile(path, tmpName string, mode os.FileMode, backup bool) error {
 	}
 
 	if err := os.Rename(tmpName, path); err == nil {
+		if !backup {
+			_ = os.Remove(bak)
+		}
+
 		return nil
+	}
+
+	rollback, err := stashExisting(path, tmpName, mode, backup)
+	if err != nil {
+		return err
 	}
 
 	_ = os.Remove(path)
@@ -95,12 +104,46 @@ func replaceFile(path, tmpName string, mode os.FileMode, backup bool) error {
 	if err := os.Rename(tmpName, path); err != nil {
 		if backup {
 			_ = copyFile(bak, path, mode)
+		} else if rollback != "" {
+			_ = copyFile(rollback, path, mode)
+			_ = os.Remove(rollback)
 		}
 
 		return fmt.Errorf("replacing config: %w", err)
 	}
 
+	if rollback != "" {
+		_ = os.Remove(rollback)
+	}
+
+	if !backup {
+		_ = os.Remove(bak)
+	}
+
 	return nil
+}
+
+// stashExisting copies dest aside before the Windows-style remove+rename fallback
+// so AtomicReplace can restore it if the second rename fails. The copy is not path.bak.
+func stashExisting(path, tmpName string, mode os.FileMode, backup bool) (string, error) {
+	if backup {
+		return "", nil
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("stat config: %w", err)
+	}
+
+	rollback := tmpName + ".prev"
+	if err := copyFile(path, rollback, mode); err != nil {
+		return "", fmt.Errorf("stashing config: %w", err)
+	}
+
+	return rollback, nil
 }
 
 func copyFile(srcPath, dstPath string, mode os.FileMode) error {

--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -25,7 +25,17 @@ func (u *Unpackerr) registerAPIRoutes() {
 	u.Webserver.router.GET(path.Join(base, "stats"), u.requirePerm(PermReadSystemStats, u.statsHandler))
 	u.Webserver.router.GET(path.Join(base, "system"), u.requirePerm(PermReadSystemInfo, u.systemHandler))
 	u.Webserver.router.GET(path.Join(base, "queue"), u.requirePerm(PermReadSystemQueue, u.queueHandler))
+	u.Webserver.router.POST(path.Join(base, "queue", "retry"), u.requirePerm(PermWriteSystemQueue, u.queueRetryHandler))
+	u.Webserver.router.POST(path.Join(base, "queue", "forget"), u.requirePerm(PermWriteSystemQueue, u.queueForgetHandler))
 	u.Webserver.router.GET(path.Join(base, "history"), u.requirePerm(PermReadSystemHistory, u.historyHandler))
+	u.Webserver.router.POST(
+		path.Join(base, "history", "clear"),
+		u.requirePerm(PermWriteSystemHistory, u.historyClearHandler),
+	)
+	u.Webserver.router.POST(
+		path.Join(base, "history", "delete"),
+		u.requirePerm(PermWriteSystemHistory, u.historyDeleteHandler),
+	)
 }
 
 func (u *Unpackerr) statsHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -131,6 +131,7 @@ func (u *Unpackerr) retrieveAppQueues(now time.Time) {
 	u.checkReadarrQueue(now)
 	u.checkSonarrQueue(now)
 	u.checkWhisparrQueue(now)
+	u.sweepForgotten()
 }
 
 // validateApps is broken-out into this file to make adding new apps easier.

--- a/pkg/unpackerr/auth_test.go
+++ b/pkg/unpackerr/auth_test.go
@@ -41,6 +41,7 @@ func testAuthUnpackerr(t *testing.T) *Unpackerr {
 	}
 
 	unpack.webRoutes()
+	go unpack.runQueueActions(t.Context())
 
 	return unpack
 }

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -14,15 +14,16 @@ const (
 )
 
 // History holds the history of extracted items.
-// mu guards Map, Finished, Retries, per-item Status/Updated, and XProg progress
-// so HTTP stats, queue snapshots, and Prometheus Collect cannot race the main loop.
-// It is not reentrant; do not lock inside a caller that already holds it.
+// mu guards Map, Finished, Retries, forgotten, per-item Status/Updated, and XProg
+// progress so HTTP stats, queue snapshots, and Prometheus Collect cannot race
+// the main loop. It is not reentrant; do not lock inside a caller that already holds it.
 type History struct {
-	mu       sync.RWMutex
-	Items    []string
-	Finished uint
-	Retries  uint
-	Map      map[string]*Extract
+	mu        sync.RWMutex
+	Items     []string
+	Finished  uint
+	Retries   uint
+	Map       map[string]*Extract
+	forgotten map[string]struct{}
 }
 
 func (h *History) lockHistory() {

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -358,3 +358,40 @@ func queueFromExtract(id string, item *Extract) QueueItem {
 
 	return queue
 }
+
+func (u *Unpackerr) deleteHistoryID(itemID string) bool {
+	u.histMu.Lock()
+	defer u.histMu.Unlock()
+
+	found := -1
+
+	for idx := range u.records {
+		if u.records[idx].ID == itemID {
+			found = idx
+			break
+		}
+	}
+
+	if found < 0 {
+		return false
+	}
+
+	u.records = append(u.records[:found], u.records[found+1:]...)
+
+	if err := u.writeHistoryLocked(); err != nil {
+		u.Errorf("Writing history file: %v", err)
+	}
+
+	return true
+}
+
+func (u *Unpackerr) clearHistory() {
+	u.histMu.Lock()
+	defer u.histMu.Unlock()
+
+	u.records = nil
+
+	if err := u.writeHistoryLocked(); err != nil {
+		u.Errorf("Writing history file: %v", err)
+	}
+}

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/configdef"
@@ -19,7 +20,10 @@ const (
 	historyScanMax  = 1024 * 1024
 )
 
-var errHistoryLineTooLong = errors.New("history line exceeds maximum")
+var (
+	errHistoryLineTooLong = errors.New("history line exceeds maximum")
+	errHistoryNotFound    = errors.New("not found")
+)
 
 // HistoryRecord is one completed or failed pipeline item (JSONL + API).
 type HistoryRecord struct {
@@ -302,7 +306,7 @@ func (u *Unpackerr) writeHistoryLocked() error {
 		}
 	}
 
-	if err := configdef.AtomicWrite(u.histPath, buf.Bytes()); err != nil {
+	if err := configdef.AtomicReplace(u.histPath, buf.Bytes()); err != nil {
 		return fmt.Errorf("writing history file: %w", err)
 	}
 
@@ -359,7 +363,7 @@ func queueFromExtract(id string, item *Extract) QueueItem {
 	return queue
 }
 
-func (u *Unpackerr) deleteHistoryID(itemID string) bool {
+func (u *Unpackerr) deleteHistoryID(itemID string) error {
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
@@ -373,25 +377,31 @@ func (u *Unpackerr) deleteHistoryID(itemID string) bool {
 	}
 
 	if found < 0 {
-		return false
+		return errHistoryNotFound
 	}
 
-	u.records = append(u.records[:found], u.records[found+1:]...)
+	saved := u.records[found]
+	u.records = slices.Delete(u.records, found, found+1)
 
 	if err := u.writeHistoryLocked(); err != nil {
-		u.Errorf("Writing history file: %v", err)
+		u.records = slices.Insert(u.records, found, saved)
+		return err
 	}
 
-	return true
+	return nil
 }
 
-func (u *Unpackerr) clearHistory() {
+func (u *Unpackerr) clearHistory() error {
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
+	saved := u.records
 	u.records = nil
 
 	if err := u.writeHistoryLocked(); err != nil {
-		u.Errorf("Writing history file: %v", err)
+		u.records = saved
+		return err
 	}
+
+	return nil
 }

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -98,7 +98,7 @@ func (u *Unpackerr) checkLidarrQueue(now time.Time) {
 			switch x, ok := u.Map[record.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Lidarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols):
+			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
 				u.Map[record.Title] = &Extract{
 					App:         starr.Lidarr,
 					URL:         server.URL,

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -1,0 +1,137 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+const maxActionBody = 4096
+
+var (
+	errQueueNotFound  = errors.New("queue item not found")
+	errQueueNotFailed = errors.New("queue item is not extractfailed")
+	errMissingID      = errors.New("id is required")
+)
+
+type idRequest struct {
+	ID string `json:"id"`
+}
+
+func readIDRequest(response http.ResponseWriter, request *http.Request) (string, bool) {
+	var body idRequest
+	if err := json.NewDecoder(io.LimitReader(request.Body, maxActionBody)).Decode(&body); err != nil {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return "", false
+	}
+
+	body.ID = strings.TrimSpace(body.ID)
+	if body.ID == "" {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errMissingID.Error()})
+		return "", false
+	}
+
+	return body.ID, true
+}
+
+func (u *Unpackerr) queueRetryHandler(response http.ResponseWriter, request *http.Request, _ httprouter.Params) {
+	itemID, ok := readIDRequest(response, request)
+	if !ok {
+		return
+	}
+
+	if err := u.retryQueueID(itemID); err != nil {
+		writeQueueActionError(response, err)
+		return
+	}
+
+	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
+}
+
+func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *http.Request, _ httprouter.Params) {
+	itemID, ok := readIDRequest(response, request)
+	if !ok {
+		return
+	}
+
+	if err := u.forgetQueueID(itemID); err != nil {
+		writeQueueActionError(response, err)
+		return
+	}
+
+	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
+}
+
+func (u *Unpackerr) historyClearHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	u.clearHistory()
+	writeJSON(response, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (u *Unpackerr) historyDeleteHandler(response http.ResponseWriter, request *http.Request, _ httprouter.Params) {
+	itemID, ok := readIDRequest(response, request)
+	if !ok {
+		return
+	}
+
+	if !u.deleteHistoryID(itemID) {
+		writeJSON(response, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
+}
+
+func writeQueueActionError(response http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errQueueNotFound):
+		writeJSON(response, http.StatusNotFound, map[string]string{"error": err.Error()})
+	case errors.Is(err, errQueueNotFailed):
+		writeJSON(response, http.StatusConflict, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+}
+
+func (u *Unpackerr) retryQueueID(itemID string) error {
+	u.lockHistory()
+	defer u.unlockHistory()
+
+	item, ok := u.Map[itemID]
+	if !ok || item == nil {
+		return errQueueNotFound
+	}
+
+	if item.Status != EXTRACTFAILED {
+		return errQueueNotFailed
+	}
+
+	u.Retries++
+	item.Retries++
+	item.NoRetry = false
+	item.Status = WAITING
+	item.Updated = time.Now()
+
+	return nil
+}
+
+func (u *Unpackerr) forgetQueueID(itemID string) error {
+	u.lockHistory()
+	defer u.unlockHistory()
+
+	if _, ok := u.Map[itemID]; !ok {
+		return errQueueNotFound
+	}
+
+	delete(u.Map, itemID)
+
+	if u.folders != nil {
+		delete(u.folders.Folders, itemID)
+	}
+
+	return nil
+}

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -1,8 +1,10 @@
 package unpackerr
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -13,10 +15,25 @@ import (
 
 const maxActionBody = 4096
 
+type queueActionKind byte
+
+const (
+	queueRetry queueActionKind = iota + 1
+	queueForget
+)
+
+type queueAction struct {
+	kind   queueActionKind
+	id     string
+	result chan error
+}
+
 var (
-	errQueueNotFound  = errors.New("queue item not found")
-	errQueueNotFailed = errors.New("queue item is not extractfailed")
-	errMissingID      = errors.New("id is required")
+	errQueueNotFound       = errors.New("queue item not found")
+	errQueueNotFailed      = errors.New("queue item is not extractfailed")
+	errQueueNotForgettable = errors.New("queue item is still in progress")
+	errUnknownQueueAction  = errors.New("unknown queue action")
+	errMissingID           = errors.New("id is required")
 )
 
 type idRequest struct {
@@ -25,13 +42,27 @@ type idRequest struct {
 
 func readIDRequest(response http.ResponseWriter, request *http.Request) (string, bool) {
 	var body idRequest
-	if err := json.NewDecoder(io.LimitReader(request.Body, maxActionBody)).Decode(&body); err != nil {
+
+	decoder := json.NewDecoder(http.MaxBytesReader(response, request.Body, maxActionBody))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&body); err != nil {
 		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 		return "", false
 	}
 
-	body.ID = strings.TrimSpace(body.ID)
-	if body.ID == "" {
+	err := decoder.Decode(&struct{}{})
+	if err != nil && !errors.Is(err, io.EOF) {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return "", false
+	}
+
+	if err == nil {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errExtraJSON.Error()})
+		return "", false
+	}
+
+	if strings.TrimSpace(body.ID) == "" {
 		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errMissingID.Error()})
 		return "", false
 	}
@@ -45,7 +76,7 @@ func (u *Unpackerr) queueRetryHandler(response http.ResponseWriter, request *htt
 		return
 	}
 
-	if err := u.retryQueueID(itemID); err != nil {
+	if err := u.dispatchQueueAction(request.Context(), queueRetry, itemID); err != nil {
 		writeQueueActionError(response, err)
 		return
 	}
@@ -59,7 +90,7 @@ func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *ht
 		return
 	}
 
-	if err := u.forgetQueueID(itemID); err != nil {
+	if err := u.dispatchQueueAction(request.Context(), queueForget, itemID); err != nil {
 		writeQueueActionError(response, err)
 		return
 	}
@@ -68,7 +99,11 @@ func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *ht
 }
 
 func (u *Unpackerr) historyClearHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	u.clearHistory()
+	if err := u.clearHistory(); err != nil {
+		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
 	writeJSON(response, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -78,26 +113,77 @@ func (u *Unpackerr) historyDeleteHandler(response http.ResponseWriter, request *
 		return
 	}
 
-	if !u.deleteHistoryID(itemID) {
-		writeJSON(response, http.StatusNotFound, map[string]string{"error": "not found"})
+	if err := u.deleteHistoryID(itemID); err != nil {
+		writeJSON(response, historyDeleteCode(err), map[string]string{"error": err.Error()})
 		return
 	}
 
 	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
 }
 
+func historyDeleteCode(err error) int {
+	if errors.Is(err, errHistoryNotFound) {
+		return http.StatusNotFound
+	}
+
+	return http.StatusInternalServerError
+}
+
 func writeQueueActionError(response http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, errQueueNotFound):
 		writeJSON(response, http.StatusNotFound, map[string]string{"error": err.Error()})
-	case errors.Is(err, errQueueNotFailed):
+	case errors.Is(err, errQueueNotFailed), errors.Is(err, errQueueNotForgettable):
 		writeJSON(response, http.StatusConflict, map[string]string{"error": err.Error()})
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		writeJSON(response, http.StatusGatewayTimeout, map[string]string{"error": err.Error()})
 	default:
 		writeJSON(response, http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 }
 
+func (u *Unpackerr) dispatchQueueAction(ctx context.Context, kind queueActionKind, id string) error {
+	action := &queueAction{kind: kind, id: id, result: make(chan error, 1)}
+
+	select {
+	case u.queueActChan <- action:
+	case <-ctx.Done():
+		return fmt.Errorf("queue action: %w", ctx.Err())
+	}
+
+	select {
+	case err := <-action.result:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("queue action: %w", ctx.Err())
+	}
+}
+
+func (u *Unpackerr) runQueueActions(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case action := <-u.queueActChan:
+			action.result <- u.applyQueueAction(action)
+		}
+	}
+}
+
+func (u *Unpackerr) applyQueueAction(action *queueAction) error {
+	switch action.kind {
+	case queueRetry:
+		return u.retryQueueID(action.id)
+	case queueForget:
+		return u.forgetQueueID(action.id)
+	default:
+		return errUnknownQueueAction
+	}
+}
+
 func (u *Unpackerr) retryQueueID(itemID string) error {
+	now := time.Now()
+
 	u.lockHistory()
 	defer u.unlockHistory()
 
@@ -110,11 +196,36 @@ func (u *Unpackerr) retryQueueID(itemID string) error {
 		return errQueueNotFailed
 	}
 
+	if item.App == FolderString {
+		return u.retryFolderLocked(itemID, item, now)
+	}
+
 	u.Retries++
 	item.Retries++
 	item.NoRetry = false
 	item.Status = WAITING
-	item.Updated = time.Now()
+	item.Updated = now
+
+	return nil
+}
+
+func (u *Unpackerr) retryFolderLocked(itemID string, item *Extract, now time.Time) error {
+	if u.folders == nil {
+		return errQueueNotFound
+	}
+
+	folder, ok := u.folders.Folders[itemID]
+	if !ok || folder == nil {
+		return errQueueNotFound
+	}
+
+	folder.status = WAITING
+	folder.noRetry = false
+	folder.retries = 0
+	folder.updated = now
+	item.NoRetry = false
+	item.Status = WAITING
+	item.Updated = now
 
 	return nil
 }
@@ -123,15 +234,46 @@ func (u *Unpackerr) forgetQueueID(itemID string) error {
 	u.lockHistory()
 	defer u.unlockHistory()
 
-	if _, ok := u.Map[itemID]; !ok {
+	item, ok := u.Map[itemID]
+	if !ok || item == nil {
 		return errQueueNotFound
+	}
+
+	if !item.Status.isDurableHistory() {
+		return errQueueNotForgettable
 	}
 
 	delete(u.Map, itemID)
 
+	if item.App != FolderString {
+		u.forgotten[itemID] = struct{}{}
+	}
+
 	if u.folders != nil {
-		delete(u.folders.Folders, itemID)
+		if _, exists := u.folders.Folders[itemID]; exists {
+			u.folders.Remove(itemID)
+			delete(u.folders.Folders, itemID)
+		}
 	}
 
 	return nil
+}
+
+func (u *Unpackerr) isForgotten(id string) bool {
+	_, ok := u.forgotten[id]
+	return ok
+}
+
+func (u *Unpackerr) sweepForgotten() {
+	u.lockHistory()
+	defer u.unlockHistory()
+
+	for itemID := range u.forgotten {
+		if u.haveLidarrQitem(itemID) || u.haveRadarrQitem(itemID) ||
+			u.haveReadarrQitem(itemID) || u.haveSonarrQitem(itemID) || u.haveWhisparrQitem(itemID) {
+			continue
+		}
+
+		delete(u.forgotten, itemID)
+	}
 }

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -25,6 +25,7 @@ const (
 type queueAction struct {
 	kind   queueActionKind
 	id     string
+	errFn  func() error
 	result chan error
 }
 
@@ -141,7 +142,7 @@ func writeQueueActionError(response http.ResponseWriter, err error) {
 }
 
 func (u *Unpackerr) dispatchQueueAction(ctx context.Context, kind queueActionKind, id string) error {
-	action := &queueAction{kind: kind, id: id, result: make(chan error, 1)}
+	action := &queueAction{kind: kind, id: id, errFn: ctx.Err, result: make(chan error, 1)}
 
 	select {
 	case u.queueActChan <- action:
@@ -169,6 +170,12 @@ func (u *Unpackerr) runQueueActions(ctx context.Context) {
 }
 
 func (u *Unpackerr) applyQueueAction(action *queueAction) error {
+	if action.errFn != nil {
+		if err := action.errFn(); err != nil {
+			return fmt.Errorf("queue action: %w", err)
+		}
+	}
+
 	switch action.kind {
 	case queueRetry:
 		return u.retryQueueID(action.id)

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -51,23 +51,21 @@ func readIDRequest(response http.ResponseWriter, request *http.Request) (string,
 		return "", false
 	}
 
-	err := decoder.Decode(&struct{}{})
-	if err != nil && !errors.Is(err, io.EOF) {
+	switch err := decoder.Decode(&struct{}{}); {
+	case errors.Is(err, io.EOF):
+		if strings.TrimSpace(body.ID) == "" {
+			writeJSON(response, http.StatusBadRequest, map[string]string{"error": errMissingID.Error()})
+			return "", false
+		}
+
+		return body.ID, true
+	case err != nil:
 		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 		return "", false
-	}
-
-	if err == nil {
+	default:
 		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errExtraJSON.Error()})
 		return "", false
 	}
-
-	if strings.TrimSpace(body.ID) == "" {
-		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errMissingID.Error()})
-		return "", false
-	}
-
-	return body.ID, true
 }
 
 func (u *Unpackerr) queueRetryHandler(response http.ResponseWriter, request *http.Request, _ httprouter.Params) {
@@ -230,6 +228,9 @@ func (u *Unpackerr) retryFolderLocked(itemID string, item *Extract, now time.Tim
 	return nil
 }
 
+// forgetQueueID drops a terminal queue item. In-progress extracts return
+// errQueueNotForgettable (HTTP 409); Starr titles get a tombstone until they
+// leave the upstream queue so a poll cannot recreate them.
 func (u *Unpackerr) forgetQueueID(itemID string) error {
 	u.lockHistory()
 	defer u.unlockHistory()

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -1,0 +1,103 @@
+package unpackerr
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQueueRetryAndForget(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Map["/dl/fail"] = &Extract{Path: "/dl/fail", Status: EXTRACTFAILED, NoRetry: true}
+	unpack.Map["/dl/live"] = &Extract{Path: "/dl/live", Status: EXTRACTING}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	retryOK := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/dl/fail"}`, withKey)
+	if retryOK.Code != http.StatusOK {
+		t.Fatalf("retry %d %s", retryOK.Code, retryOK.Body.String())
+	}
+
+	if item := unpack.Map["/dl/fail"]; item.Status != WAITING || item.NoRetry || item.Retries != 1 {
+		t.Fatalf("retry state %+v", item)
+	}
+
+	conflict := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/dl/live"}`, withKey)
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("retry live %d", conflict.Code)
+	}
+
+	forgetOK := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/live"}`, withKey)
+	if forgetOK.Code != http.StatusOK {
+		t.Fatalf("forget %d %s", forgetOK.Code, forgetOK.Body.String())
+	}
+
+	if _, exists := unpack.Map["/dl/live"]; exists {
+		t.Fatal("forgotten item still in map")
+	}
+
+	missing := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/nope"}`, withKey)
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("forget missing %d", missing.Code)
+	}
+}
+
+func TestHistoryDeleteAndClear(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.KeepHistory = 10
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: DELETED, Updated: time.Now()})
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	del := doAuth(t, unpack, http.MethodPost, "/api/history/delete", `{"id":"a"}`, withKey)
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete %d %s", del.Code, del.Body.String())
+	}
+
+	left := unpack.historySnapshot()
+	if len(left) != 1 || left[0].ID != "b" {
+		t.Fatalf("after delete %+v", left)
+	}
+
+	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
+	if cleared.Code != http.StatusOK {
+		t.Fatalf("clear %d", cleared.Code)
+	}
+
+	if len(unpack.historySnapshot()) != 0 {
+		t.Fatal("history not cleared")
+	}
+}
+
+func TestQueueWritePermission(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	statKey := strings.Repeat("Q", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"stats": {Permissions: []string{PermReadSystemStats}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "home",
+		Key:   statKey,
+		Roles: []string{"stats"},
+	})
+
+	if rec := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"x"}`, func(req *http.Request) {
+		req.Header.Set(headerAPIKey, statKey)
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("stats key retry %d", rec.Code)
+	}
+}

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -1,11 +1,17 @@
 package unpackerr
 
 import (
+	"errors"
 	"net/http"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"golift.io/starr"
+	"golift.io/starr/radarr"
 )
 
 func TestQueueRetryAndForget(t *testing.T) {
@@ -14,6 +20,7 @@ func TestQueueRetryAndForget(t *testing.T) {
 	unpack := testAuthUnpackerr(t)
 	unpack.Map["/dl/fail"] = &Extract{Path: "/dl/fail", Status: EXTRACTFAILED, NoRetry: true}
 	unpack.Map["/dl/live"] = &Extract{Path: "/dl/live", Status: EXTRACTING}
+	unpack.Map["/dl/done"] = &Extract{Path: "/dl/done", Status: EXTRACTFAILED, NoRetry: true}
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
@@ -33,18 +40,179 @@ func TestQueueRetryAndForget(t *testing.T) {
 		t.Fatalf("retry live %d", conflict.Code)
 	}
 
-	forgetOK := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/live"}`, withKey)
+	forgetLive := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/live"}`, withKey)
+	if forgetLive.Code != http.StatusConflict {
+		t.Fatalf("forget live %d %s", forgetLive.Code, forgetLive.Body.String())
+	}
+
+	if _, exists := unpack.Map["/dl/live"]; !exists {
+		t.Fatal("in-progress item should remain until it is terminal")
+	}
+
+	forgetOK := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/done"}`, withKey)
 	if forgetOK.Code != http.StatusOK {
 		t.Fatalf("forget %d %s", forgetOK.Code, forgetOK.Body.String())
 	}
 
-	if _, exists := unpack.Map["/dl/live"]; exists {
+	if _, exists := unpack.Map["/dl/done"]; exists {
 		t.Fatal("forgotten item still in map")
 	}
 
 	missing := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/nope"}`, withKey)
 	if missing.Code != http.StatusNotFound {
 		t.Fatalf("forget missing %d", missing.Code)
+	}
+}
+
+func TestQueueRetryFolder(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Map["/watch/fail"] = &Extract{
+		App:     FolderString,
+		Path:    "/watch/fail",
+		Status:  EXTRACTFAILED,
+		NoRetry: true,
+		Retries: 3,
+	}
+	unpack.folders = &Folders{Folders: map[string]*Folder{
+		"/watch/fail": {status: EXTRACTFAILED, noRetry: true, retries: 99, updated: time.Now()},
+	}}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	retryOK := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/watch/fail"}`, withKey)
+	if retryOK.Code != http.StatusOK {
+		t.Fatalf("retry %d %s", retryOK.Code, retryOK.Body.String())
+	}
+
+	item := unpack.Map["/watch/fail"]
+	if item.Status != WAITING || item.NoRetry || item.Retries != 3 || unpack.Retries != 0 {
+		t.Fatalf("folder extract retry %+v totals %d", item, unpack.Retries)
+	}
+
+	folder := unpack.folders.Folders["/watch/fail"]
+	if folder == nil || folder.status != WAITING || folder.noRetry || folder.retries != 0 {
+		t.Fatalf("folder retry %+v", folder)
+	}
+}
+
+func TestQueueForgetFolder(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Map["/watch/gone"] = &Extract{App: FolderString, Path: "/watch/gone", Status: EXTRACTFAILED}
+	unpack.folders = &Folders{Folders: map[string]*Folder{
+		"/watch/gone": {status: EXTRACTFAILED},
+	}}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	forgetOK := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/watch/gone"}`, withKey)
+	if forgetOK.Code != http.StatusOK {
+		t.Fatalf("forget %d %s", forgetOK.Code, forgetOK.Body.String())
+	}
+
+	if _, exists := unpack.Map["/watch/gone"]; exists {
+		t.Fatal("forgotten folder still in map")
+	}
+
+	if _, exists := unpack.folders.Folders["/watch/gone"]; exists {
+		t.Fatal("forgotten folder still tracked")
+	}
+
+	if unpack.isForgotten("/watch/gone") {
+		t.Fatal("folder forget should not tombstone")
+	}
+}
+
+func TestQueueIDJSON(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Map[" /dl/spaced "] = &Extract{Path: " /dl/spaced ", Status: EXTRACTFAILED}
+	unpack.Map["/dl/fail"] = &Extract{Path: "/dl/fail", Status: EXTRACTFAILED}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	extra := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/dl/fail"}{"id":"y"}`, withKey)
+	if extra.Code != http.StatusBadRequest {
+		t.Fatalf("extra json %d %s", extra.Code, extra.Body.String())
+	}
+
+	if unpack.Map["/dl/fail"].Status != EXTRACTFAILED {
+		t.Fatal("extra json should not retry")
+	}
+
+	unknown := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/dl/fail","x":1}`, withKey)
+	if unknown.Code != http.StatusBadRequest {
+		t.Fatalf("unknown field %d", unknown.Code)
+	}
+
+	blank := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"   "}`, withKey)
+	if blank.Code != http.StatusBadRequest {
+		t.Fatalf("whitespace id %d", blank.Code)
+	}
+
+	spaced := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":" /dl/spaced "}`, withKey)
+	if spaced.Code != http.StatusOK {
+		t.Fatalf("spaced id %d %s", spaced.Code, spaced.Body.String())
+	}
+
+	if unpack.Map[" /dl/spaced "].Status != WAITING {
+		t.Fatal("path with spaces should retry using the original id")
+	}
+}
+
+func TestForgottenStarrTitle(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Radarr = []*RadarrConfig{{
+		Protocols: defaultProtocol,
+		Queue: &radarr.Queue{Records: []*radarr.QueueRecord{{
+			Title:      "Movie",
+			Status:     "completed",
+			Protocol:   starr.Protocol("torrent"),
+			OutputPath: "/dl/Movie",
+		}}},
+	}}
+	unpack.Map["Movie"] = &Extract{App: starr.Radarr, Path: "/dl/Movie", Status: EXTRACTFAILED, NoRetry: true}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	forgetOK := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"Movie"}`, withKey)
+	if forgetOK.Code != http.StatusOK {
+		t.Fatalf("forget %d %s", forgetOK.Code, forgetOK.Body.String())
+	}
+
+	unpack.checkRadarrQueue(time.Now())
+
+	if _, exists := unpack.Map["Movie"]; exists {
+		t.Fatal("forgotten title recreated from Starr queue")
+	}
+
+	unpack.Radarr[0].Queue.Records = nil
+	unpack.sweepForgotten()
+
+	unpack.Radarr[0].Queue.Records = []*radarr.QueueRecord{{
+		Title:      "Movie",
+		Status:     "completed",
+		Protocol:   starr.Protocol("torrent"),
+		OutputPath: "/dl/Movie",
+	}}
+	unpack.checkRadarrQueue(time.Now())
+
+	if _, exists := unpack.Map["Movie"]; !exists {
+		t.Fatal("title should track again after leaving the Starr queue")
 	}
 }
 
@@ -71,6 +239,10 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 		t.Fatalf("after delete %+v", left)
 	}
 
+	if _, err := os.Stat(unpack.histPath + ".bak"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("history bak: %v", err)
+	}
+
 	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
 	if cleared.Code != http.StatusOK {
 		t.Fatalf("clear %d", cleared.Code)
@@ -78,6 +250,57 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 
 	if len(unpack.historySnapshot()) != 0 {
 		t.Fatal("history not cleared")
+	}
+}
+
+func TestHistoryWriteFailureRestores(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("unix directory permissions")
+	}
+
+	unpack := testAuthUnpackerr(t)
+	unpack.KeepHistory = 10
+
+	dir := t.TempDir()
+
+	sub := filepath.Join(dir, "hist")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.histPath = filepath.Join(sub, historyFileName)
+	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
+	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: DELETED, Updated: time.Now()})
+
+	if err := os.Chmod(sub, 0o555); err != nil { //nolint:gosec // need a read-only dir
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) }) //nolint:gosec // restore after the read-only test
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	del := doAuth(t, unpack, http.MethodPost, "/api/history/delete", `{"id":"a"}`, withKey)
+	if del.Code != http.StatusInternalServerError {
+		t.Fatalf("delete fail %d %s", del.Code, del.Body.String())
+	}
+
+	left := unpack.historySnapshot()
+	if len(left) != 2 {
+		t.Fatalf("delete should restore %+v", left)
+	}
+
+	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
+	if cleared.Code != http.StatusInternalServerError {
+		t.Fatalf("clear fail %d %s", cleared.Code, cleared.Body.String())
+	}
+
+	if len(unpack.historySnapshot()) != 2 {
+		t.Fatal("clear should restore")
 	}
 }
 

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -13,6 +14,36 @@ import (
 	"golift.io/starr"
 	"golift.io/starr/radarr"
 )
+
+func TestQueueActionSkipsCanceled(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.queueActChan = make(chan *queueAction)
+	unpack.Map["/dl/fail"] = &Extract{Path: "/dl/fail", Status: EXTRACTFAILED, NoRetry: true}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errc := make(chan error, 1)
+
+	go func() {
+		errc <- unpack.dispatchQueueAction(ctx, queueRetry, "/dl/fail")
+	}()
+
+	action := <-unpack.queueActChan
+
+	cancel()
+
+	action.result <- unpack.applyQueueAction(action)
+
+	if err := <-errc; !errors.Is(err, context.Canceled) {
+		t.Fatalf("dispatch %v", err)
+	}
+
+	item := unpack.Map["/dl/fail"]
+	if item.Status != EXTRACTFAILED || item.Retries != 0 {
+		t.Fatalf("canceled retry applied %+v", item)
+	}
+}
 
 func TestQueueRetryAndForget(t *testing.T) {
 	t.Parallel()

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -150,6 +150,13 @@ func TestQueueIDJSON(t *testing.T) {
 		t.Fatal("extra json should not retry")
 	}
 
+	oversized := `{"id":"` + strings.Repeat("x", maxActionBody) + `"}`
+
+	tooBig := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", oversized, withKey)
+	if tooBig.Code != http.StatusBadRequest {
+		t.Fatalf("oversized json %d %s", tooBig.Code, tooBig.Body.String())
+	}
+
 	unknown := doAuth(t, unpack, http.MethodPost, "/api/queue/retry", `{"id":"/dl/fail","x":1}`, withKey)
 	if unknown.Code != http.StatusBadRequest {
 		t.Fatalf("unknown field %d", unknown.Code)

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -232,6 +232,10 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
 	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: DELETED, Updated: time.Now()})
 
+	if err := os.WriteFile(unpack.histPath+".bak", []byte(`{"id":"stale"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
 	}
@@ -265,6 +269,10 @@ func TestHistoryWriteFailureRestores(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		t.Skip("unix directory permissions")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
 	}
 
 	unpack := testAuthUnpackerr(t)

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -89,7 +89,7 @@ func (u *Unpackerr) checkRadarrQueue(now time.Time) {
 			switch x, ok := u.Map[record.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Radarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols):
+			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
 				u.Map[record.Title] = &Extract{ // Save the download to our map.
 					App:         starr.Radarr,
 					URL:         server.URL,

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -89,7 +89,7 @@ func (u *Unpackerr) checkReadarrQueue(now time.Time) {
 			switch x, ok := u.Map[record.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Readarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols):
+			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
 				u.Map[record.Title] = &Extract{
 					App:         starr.Readarr,
 					URL:         server.URL,

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -89,7 +89,7 @@ func (u *Unpackerr) checkSonarrQueue(now time.Time) {
 			switch x, ok := u.Map[record.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import: %v", starr.Sonarr, server.URL, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols):
+			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
 				u.Map[record.Title] = &Extract{
 					App:         starr.Sonarr,
 					URL:         server.URL,

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -66,14 +66,15 @@ type Unpackerr struct {
 	*Config
 	*History
 	*xtractr.Xtractr
-	metrics  *metrics
-	folders  *Folders
-	sigChan  chan os.Signal
-	updates  chan *xtractr.Response
-	progChan chan *ExtractProgress
-	hookChan chan *hookQueueItem
-	delChan  chan *fileDeleteReq
-	workChan chan []func()
+	metrics      *metrics
+	folders      *Folders
+	sigChan      chan os.Signal
+	updates      chan *xtractr.Response
+	progChan     chan *ExtractProgress
+	hookChan     chan *hookQueueItem
+	delChan      chan *fileDeleteReq
+	queueActChan chan *queueAction
+	workChan     chan []func()
 	*Logger
 	rotatorr         *rotatorr.Logger
 	httpLog          *rotatorr.Logger
@@ -119,15 +120,16 @@ type Flags struct {
 // An empty struct will surely cause you pain, so use this!
 func New() *Unpackerr {
 	return &Unpackerr{
-		Flags:    &Flags{EnvPrefix: "UN"},
-		hookChan: make(chan *hookQueueItem, updateChanBuf),
-		delChan:  make(chan *fileDeleteReq, updateChanBuf),
-		sigChan:  make(chan os.Signal, signalBuf),
-		workChan: make(chan []func(), 1),
-		History:  &History{Map: make(map[string]*Extract)},
-		updates:  make(chan *xtractr.Response, updateChanBuf),
-		progChan: make(chan *ExtractProgress),
-		menu:     make(map[string]ui.MenuItem),
+		Flags:        &Flags{EnvPrefix: "UN"},
+		hookChan:     make(chan *hookQueueItem, updateChanBuf),
+		delChan:      make(chan *fileDeleteReq, updateChanBuf),
+		queueActChan: make(chan *queueAction, updateChanBuf),
+		sigChan:      make(chan os.Signal, signalBuf),
+		workChan:     make(chan []func(), 1),
+		History:      &History{Map: make(map[string]*Extract), forgotten: make(map[string]struct{})},
+		updates:      make(chan *xtractr.Response, updateChanBuf),
+		progChan:     make(chan *ExtractProgress),
+		menu:         make(map[string]ui.MenuItem),
 		Config: &Config{
 			KeepHistory:   defaultHistory,
 			LogQueues:     cnfg.Duration{Duration: time.Minute + time.Second},
@@ -423,6 +425,9 @@ func (u *Unpackerr) Run() {
 		case event := <-u.folders.Events:
 			// file system event for watched folder.
 			u.processEvent(event, now)
+		case action := <-u.queueActChan:
+			// HTTP retry/forget must mutate Map and Folders on this goroutine.
+			action.result <- u.applyQueueAction(action)
 		case now := <-logger:
 			// Log/print current queue counts once in a while.
 			u.logCurrentQueue(now)

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -98,7 +98,7 @@ func (u *Unpackerr) checkWhisparrQueue(now time.Time) {
 			switch x, ok := u.Map[record.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Whisparr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols):
+			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
 				u.Map[record.Title] = &Extract{
 					App:         starr.Whisparr,
 					URL:         server.URL,


### PR DESCRIPTION
## Why

The dashboard needs to retry a failed extract, forget a completed queue item, and clear durable history rows without restarting the process.

## What

- `POST /api/queue/retry` `{id}` (`write:system:queue`) — only `extractfailed`. Starr items go back to `WAITING`. Folder items reset `Folder` status/retries on the main loop.
- `POST /api/queue/forget` `{id}` (`write:system:queue`) — only terminal/durable statuses (`extractfailed`, `extractednothing`, `imported`, `deleted`, `deletefailed`). In-progress items return **409**. Starr titles get a tombstone until they leave the upstream queue so a poll cannot recreate them. Folder items are untracked (`folders.Remove`) and are not tombstoned.
- Retry/forget are applied on the main loop. If the request is already canceled when the loop picks the action up, the mutation is skipped so a 504 cannot still retry/forget.
- `POST /api/history/delete` `{id}` and `POST /api/history/clear` (`write:system:history`) — persist with `AtomicReplace` (no `.bak` of deleted rows; leftover `.bak` from older installs is removed on success). Write failures restore memory and return **500**. If Windows cannot rename over the live file, the previous JSONL is copied aside first so a failed replace can restore it.

IDs stay in the JSON body because they are filesystem paths (whitespace is significant). Bodies use `MaxBytesReader` and reject extra JSON the same way login does.

Retry/forget run on the main `Run` loop so they do not race `u.folders.Folders`.

Made with [Cursor](https://cursor.com)