### PR TITLE
Add per-section GET /api/config/{section}

### DIFF
--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -37,6 +37,10 @@ func (u *Unpackerr) registerAPIRoutes() {
 		u.requirePerm(PermWriteSystemHistory, u.historyDeleteHandler),
 	)
 	u.Webserver.router.GET(
+		path.Join(base, "config", ":section", "live"),
+		u.requireConfigPerm(false, u.configGetLiveHandler),
+	)
+	u.Webserver.router.GET(
 		path.Join(base, "config", ":section"),
 		u.requireConfigPerm(false, u.configGetHandler),
 	)

--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -36,6 +36,10 @@ func (u *Unpackerr) registerAPIRoutes() {
 		path.Join(base, "history", "delete"),
 		u.requirePerm(PermWriteSystemHistory, u.historyDeleteHandler),
 	)
+	u.Webserver.router.GET(
+		path.Join(base, "config", ":section"),
+		u.requireConfigPerm(false, u.configGetHandler),
+	)
 }
 
 func (u *Unpackerr) statsHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -291,7 +291,9 @@ func (u *Unpackerr) syncFileUIPassword() {
 		u.fileConfig.Webserver = &WebServer{}
 	}
 
-	u.fileConfig.Webserver.UIPassword = u.uiPassword()
+	u.uiPassMu.Lock()
+	u.fileConfig.Webserver.UIPassword = u.Webserver.UIPassword
+	u.uiPassMu.Unlock()
 }
 
 func (u *Unpackerr) appendFileAPIKey(key APIKey) {

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -72,6 +72,8 @@ func (u *Unpackerr) unmarshalConfig() (uint64, uint64, string, error) {
 		return 0, 0, msg, fmt.Errorf("environment variables: %w", err)
 	}
 
+	u.snapshotLivePasswords()
+
 	if err := u.setPasswords(); err != nil {
 		return 0, 0, msg, err
 	}
@@ -309,9 +311,16 @@ func (u *Unpackerr) appendFileAPIKey(key APIKey) {
 	u.fileConfig.Webserver.APIKeys = append(u.fileConfig.Webserver.APIKeys, cloned...)
 }
 
+func (u *Unpackerr) snapshotLivePasswords() {
+	u.livePasswords = make(StringSlice, len(u.Passwords))
+	copy(u.livePasswords, u.Passwords)
+}
+
 // This function checks if rar passwords need to be read from a file path.
 // Only runs once at startup to load passwords into memory.
 func (u *Unpackerr) setPasswords() error {
+	u.snapshotLivePasswords()
+
 	newPasswords := []string{}
 
 	for _, pass := range u.Passwords {

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -64,11 +64,23 @@ func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httpro
 }
 
 func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
-	writeConfigSection(response, u.fileConfigOrLive(), ConfigSection(params.ByName("section")))
+	section := ConfigSection(params.ByName("section"))
+	if section == SectionWebserver && u.fileConfig == nil {
+		writeJSON(response, http.StatusOK, u.cloneLiveWebserver())
+		return
+	}
+
+	writeConfigSection(response, u.fileConfigOrLive(), section)
 }
 
 func (u *Unpackerr) configGetLiveHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
-	writeConfigSection(response, u.Config, ConfigSection(params.ByName("section")))
+	section := ConfigSection(params.ByName("section"))
+	if section == SectionWebserver {
+		writeJSON(response, http.StatusOK, u.cloneLiveWebserver())
+		return
+	}
+
+	writeConfigSection(response, u.Config, section)
 }
 
 func (u *Unpackerr) fileConfigOrLive() *Config {

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -1,0 +1,144 @@
+package unpackerr
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"golift.io/cnfg"
+)
+
+// generalConfig is the top-level Config fields that are not nested app lists.
+type generalConfig struct {
+	Debug         bool          `json:"debug"`
+	Quiet         bool          `json:"quiet"`
+	Activity      bool          `json:"activity"`
+	Parallel      uint          `json:"parallel"`
+	ErrorStdErr   bool          `json:"errorStderr"`
+	LogFile       string        `json:"logFile"`
+	LogFiles      int           `json:"logFiles"`
+	LogFileMb     int           `json:"logFileMb"`
+	LogFileMode   string        `json:"logFileMode"`
+	MaxRetries    uint          `json:"maxRetries"`
+	RemnantAction string        `json:"remnantAction"`
+	FileMode      string        `json:"fileMode"`
+	DirMode       string        `json:"dirMode"`
+	LogQueues     cnfg.Duration `json:"logQueues"`
+	Interval      cnfg.Duration `json:"interval"`
+	Timeout       cnfg.Duration `json:"timeout"`
+	DeleteDelay   cnfg.Duration `json:"deleteDelay"`
+	StartDelay    cnfg.Duration `json:"startDelay"`
+	RetryDelay    cnfg.Duration `json:"retryDelay"`
+	Progress      cnfg.Duration `json:"progress"`
+	KeepHistory   uint          `json:"keepHistory"`
+	Passwords     StringSlice   `json:"passwords"`
+}
+
+// foldersConfigAPI is global folder poller settings plus the watch list.
+type foldersConfigAPI struct {
+	Interval cnfg.Duration   `json:"interval"`
+	Buffer   uint            `json:"buffer"`
+	Folder   []*FolderConfig `json:"folder"`
+}
+
+func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httprouter.Handle {
+	return u.requireAuth(func(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
+		section := ConfigSection(params.ByName("section"))
+		if !KnownSection(section) {
+			writeJSON(response, http.StatusNotFound, map[string]string{"error": "unknown section"})
+			return
+		}
+
+		perm := PermReadConfig(section)
+		if write {
+			perm = PermWriteConfig(section)
+		}
+
+		info, _ := request.Context().Value(authCtxKey).(authInfo)
+		if !info.allows(perm) {
+			writeJSON(response, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			return
+		}
+
+		next(response, request, params)
+	})
+}
+
+func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
+	payload, ok := u.configSection(ConfigSection(params.ByName("section")))
+	if !ok {
+		writeJSON(response, http.StatusNotFound, map[string]string{"error": "unknown section"})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, payload)
+}
+
+func (u *Unpackerr) configSection(section ConfigSection) (any, bool) {
+	switch section {
+	case SectionGeneral:
+		return u.generalConfig(), true
+	case SectionWebserver:
+		return u.Webserver, true
+	case SectionSonarr:
+		return emptyIfNil(u.Sonarr), true
+	case SectionRadarr:
+		return emptyIfNil(u.Radarr), true
+	case SectionLidarr:
+		return emptyIfNil(u.Lidarr), true
+	case SectionReadarr:
+		return emptyIfNil(u.Readarr), true
+	case SectionWhisparr:
+		return emptyIfNil(u.Whisparr), true
+	case SectionFolders:
+		return u.foldersConfig(), true
+	case SectionWebhooks:
+		return emptyIfNil(u.Webhook), true
+	case SectionCmdhooks:
+		return emptyIfNil(u.Cmdhook), true
+	default:
+		return nil, false
+	}
+}
+
+func (u *Unpackerr) generalConfig() generalConfig {
+	return generalConfig{
+		Debug:         u.Config.Debug,
+		Quiet:         u.Quiet,
+		Activity:      u.Activity,
+		Parallel:      u.Parallel,
+		ErrorStdErr:   u.ErrorStdErr,
+		LogFile:       u.LogFile,
+		LogFiles:      u.LogFiles,
+		LogFileMb:     u.LogFileMb,
+		LogFileMode:   u.LogFileMode,
+		MaxRetries:    u.MaxRetries,
+		RemnantAction: u.RemnantAction,
+		FileMode:      u.FileMode,
+		DirMode:       u.DirMode,
+		LogQueues:     u.LogQueues,
+		Interval:      u.Interval,
+		Timeout:       u.Timeout,
+		DeleteDelay:   u.DeleteDelay,
+		StartDelay:    u.StartDelay,
+		RetryDelay:    u.RetryDelay,
+		Progress:      u.Progress,
+		KeepHistory:   u.KeepHistory,
+		Passwords:     emptyIfNil(u.Passwords),
+	}
+}
+
+func (u *Unpackerr) foldersConfig() foldersConfigAPI {
+	return foldersConfigAPI{
+		Interval: u.Folder.Interval,
+		Buffer:   u.Folder.Buffer,
+		Folder:   emptyIfNil(u.Folders),
+	}
+}
+
+func emptyIfNil[T any](list []T) []T {
+	if list == nil {
+		return []T{}
+	}
+
+	return list
+}

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -64,7 +64,23 @@ func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httpro
 }
 
 func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
-	payload, ok := u.configSection(ConfigSection(params.ByName("section")))
+	writeConfigSection(response, u.fileConfigOrLive(), ConfigSection(params.ByName("section")))
+}
+
+func (u *Unpackerr) configGetLiveHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
+	writeConfigSection(response, u.Config, ConfigSection(params.ByName("section")))
+}
+
+func (u *Unpackerr) fileConfigOrLive() *Config {
+	if u.fileConfig != nil {
+		return u.fileConfig
+	}
+
+	return u.Config
+}
+
+func writeConfigSection(response http.ResponseWriter, cfg *Config, section ConfigSection) {
+	payload, ok := configSectionFrom(cfg, section)
 	if !ok {
 		writeJSON(response, http.StatusNotFound, map[string]string{"error": "unknown section"})
 		return
@@ -73,65 +89,73 @@ func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Reque
 	writeJSON(response, http.StatusOK, payload)
 }
 
-func (u *Unpackerr) configSection(section ConfigSection) (any, bool) {
+func configSectionFrom(cfg *Config, section ConfigSection) (any, bool) {
+	if cfg == nil {
+		return nil, false
+	}
+
 	switch section {
 	case SectionGeneral:
-		return u.generalConfig(), true
+		return generalConfigFrom(cfg), true
 	case SectionWebserver:
-		return u.Webserver, true
+		if cfg.Webserver == nil {
+			return &WebServer{}, true
+		}
+
+		return cfg.Webserver, true
 	case SectionSonarr:
-		return emptyIfNil(u.Sonarr), true
+		return emptyIfNil(cfg.Sonarr), true
 	case SectionRadarr:
-		return emptyIfNil(u.Radarr), true
+		return emptyIfNil(cfg.Radarr), true
 	case SectionLidarr:
-		return emptyIfNil(u.Lidarr), true
+		return emptyIfNil(cfg.Lidarr), true
 	case SectionReadarr:
-		return emptyIfNil(u.Readarr), true
+		return emptyIfNil(cfg.Readarr), true
 	case SectionWhisparr:
-		return emptyIfNil(u.Whisparr), true
+		return emptyIfNil(cfg.Whisparr), true
 	case SectionFolders:
-		return u.foldersConfig(), true
+		return foldersConfigFrom(cfg), true
 	case SectionWebhooks:
-		return emptyIfNil(u.Webhook), true
+		return emptyIfNil(cfg.Webhook), true
 	case SectionCmdhooks:
-		return emptyIfNil(u.Cmdhook), true
+		return emptyIfNil(cfg.Cmdhook), true
 	default:
 		return nil, false
 	}
 }
 
-func (u *Unpackerr) generalConfig() generalConfig {
+func generalConfigFrom(cfg *Config) generalConfig {
 	return generalConfig{
-		Debug:         u.Config.Debug,
-		Quiet:         u.Quiet,
-		Activity:      u.Activity,
-		Parallel:      u.Parallel,
-		ErrorStdErr:   u.ErrorStdErr,
-		LogFile:       u.LogFile,
-		LogFiles:      u.LogFiles,
-		LogFileMb:     u.LogFileMb,
-		LogFileMode:   u.LogFileMode,
-		MaxRetries:    u.MaxRetries,
-		RemnantAction: u.RemnantAction,
-		FileMode:      u.FileMode,
-		DirMode:       u.DirMode,
-		LogQueues:     u.LogQueues,
-		Interval:      u.Interval,
-		Timeout:       u.Timeout,
-		DeleteDelay:   u.DeleteDelay,
-		StartDelay:    u.StartDelay,
-		RetryDelay:    u.RetryDelay,
-		Progress:      u.Progress,
-		KeepHistory:   u.KeepHistory,
-		Passwords:     emptyIfNil(u.Passwords),
+		Debug:         cfg.Debug,
+		Quiet:         cfg.Quiet,
+		Activity:      cfg.Activity,
+		Parallel:      cfg.Parallel,
+		ErrorStdErr:   cfg.ErrorStdErr,
+		LogFile:       cfg.LogFile,
+		LogFiles:      cfg.LogFiles,
+		LogFileMb:     cfg.LogFileMb,
+		LogFileMode:   cfg.LogFileMode,
+		MaxRetries:    cfg.MaxRetries,
+		RemnantAction: cfg.RemnantAction,
+		FileMode:      cfg.FileMode,
+		DirMode:       cfg.DirMode,
+		LogQueues:     cfg.LogQueues,
+		Interval:      cfg.Interval,
+		Timeout:       cfg.Timeout,
+		DeleteDelay:   cfg.DeleteDelay,
+		StartDelay:    cfg.StartDelay,
+		RetryDelay:    cfg.RetryDelay,
+		Progress:      cfg.Progress,
+		KeepHistory:   cfg.KeepHistory,
+		Passwords:     emptyIfNil(cfg.Passwords),
 	}
 }
 
-func (u *Unpackerr) foldersConfig() foldersConfigAPI {
+func foldersConfigFrom(cfg *Config) foldersConfigAPI {
 	return foldersConfigAPI{
-		Interval: u.Folder.Interval,
-		Buffer:   u.Folder.Buffer,
-		Folder:   emptyIfNil(u.Folders),
+		Interval: cfg.Folder.Interval,
+		Buffer:   cfg.Folder.Buffer,
+		Folder:   emptyIfNil(cfg.Folders),
 	}
 }
 

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -66,7 +66,9 @@ func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httpro
 func (u *Unpackerr) configGetHandler(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
 	section := ConfigSection(params.ByName("section"))
 	if section == SectionWebserver {
-		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, u.cloneFileWebserver()))
+		web := publicWebserver(u.cloneFileWebserver())
+		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, web))
+
 		return
 	}
 
@@ -78,7 +80,9 @@ func (u *Unpackerr) configGetLiveHandler(
 ) {
 	section := ConfigSection(params.ByName("section"))
 	if section == SectionWebserver {
-		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, u.cloneLiveWebserver()))
+		web := publicWebserver(u.cloneLiveWebserver())
+		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, web))
+
 		return
 	}
 
@@ -190,6 +194,16 @@ func redactAPIKeysUnlessAll(request *http.Request, web *WebServer) *WebServer {
 	for idx := range web.APIKeys {
 		web.APIKeys[idx].Key = ""
 	}
+
+	return web
+}
+
+func publicWebserver(web *WebServer) *WebServer {
+	if web == nil {
+		return web
+	}
+
+	web.UIPassword = publicCryptPass(web.UIPassword)
 
 	return web
 }

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -2,7 +2,6 @@ package unpackerr
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"golift.io/cnfg"
@@ -64,20 +63,22 @@ func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httpro
 	})
 }
 
-func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
+func (u *Unpackerr) configGetHandler(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
 	section := ConfigSection(params.ByName("section"))
 	if section == SectionWebserver {
-		writeJSON(response, http.StatusOK, u.cloneFileWebserver())
+		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, u.cloneFileWebserver()))
 		return
 	}
 
 	writeConfigSection(response, u.fileConfigOrLive(), section)
 }
 
-func (u *Unpackerr) configGetLiveHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
+func (u *Unpackerr) configGetLiveHandler(
+	response http.ResponseWriter, request *http.Request, params httprouter.Params,
+) {
 	section := ConfigSection(params.ByName("section"))
 	if section == SectionWebserver {
-		writeJSON(response, http.StatusOK, u.cloneLiveWebserver())
+		writeJSON(response, http.StatusOK, redactAPIKeysUnlessAll(request, u.cloneLiveWebserver()))
 		return
 	}
 
@@ -171,23 +172,26 @@ func generalConfigFrom(cfg *Config) generalConfig {
 
 func (u *Unpackerr) liveGeneralConfig() generalConfig {
 	cfg := generalConfigFrom(u.Config)
-	if u.fileConfig != nil {
-		cfg.Passwords = passwordsForLive(u.fileConfig.Passwords, u.Passwords)
+	if u.livePasswords != nil {
+		cfg.Passwords = emptyIfNil(append(StringSlice(nil), u.livePasswords...))
 	}
 
 	return cfg
 }
 
-// passwordsForLive keeps filepath: archive passwords from the file snapshot so
-// /live does not serialize secret-file contents. Inline and env-only values stay live.
-func passwordsForLive(file, live StringSlice) StringSlice {
-	for _, pass := range file {
-		if strings.HasPrefix(pass, filePrefix) {
-			return emptyIfNil(append(StringSlice(nil), file...))
-		}
+// redactAPIKeysUnlessAll blanks webserver API key secrets unless the caller has *.
+// Starr API keys are not webserver.APIKeys and stay visible to read:config:*.
+func redactAPIKeysUnlessAll(request *http.Request, web *WebServer) *WebServer {
+	info, _ := request.Context().Value(authCtxKey).(authInfo)
+	if web == nil || info.allows(PermAll) {
+		return web
 	}
 
-	return emptyIfNil(append(StringSlice(nil), live...))
+	for idx := range web.APIKeys {
+		web.APIKeys[idx].Key = ""
+	}
+
+	return web
 }
 
 func foldersConfigFrom(cfg *Config) foldersConfigAPI {

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -2,6 +2,7 @@ package unpackerr
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"golift.io/cnfg"
@@ -65,8 +66,8 @@ func (u *Unpackerr) requireConfigPerm(write bool, next httprouter.Handle) httpro
 
 func (u *Unpackerr) configGetHandler(response http.ResponseWriter, _ *http.Request, params httprouter.Params) {
 	section := ConfigSection(params.ByName("section"))
-	if section == SectionWebserver && u.fileConfig == nil {
-		writeJSON(response, http.StatusOK, u.cloneLiveWebserver())
+	if section == SectionWebserver {
+		writeJSON(response, http.StatusOK, u.cloneFileWebserver())
 		return
 	}
 
@@ -77,6 +78,11 @@ func (u *Unpackerr) configGetLiveHandler(response http.ResponseWriter, _ *http.R
 	section := ConfigSection(params.ByName("section"))
 	if section == SectionWebserver {
 		writeJSON(response, http.StatusOK, u.cloneLiveWebserver())
+		return
+	}
+
+	if section == SectionGeneral {
+		writeJSON(response, http.StatusOK, u.liveGeneralConfig())
 		return
 	}
 
@@ -161,6 +167,27 @@ func generalConfigFrom(cfg *Config) generalConfig {
 		KeepHistory:   cfg.KeepHistory,
 		Passwords:     emptyIfNil(cfg.Passwords),
 	}
+}
+
+func (u *Unpackerr) liveGeneralConfig() generalConfig {
+	cfg := generalConfigFrom(u.Config)
+	if u.fileConfig != nil {
+		cfg.Passwords = passwordsForLive(u.fileConfig.Passwords, u.Passwords)
+	}
+
+	return cfg
+}
+
+// passwordsForLive keeps filepath: archive passwords from the file snapshot so
+// /live does not serialize secret-file contents. Inline and env-only values stay live.
+func passwordsForLive(file, live StringSlice) StringSlice {
+	for _, pass := range file {
+		if strings.HasPrefix(pass, filePrefix) {
+			return emptyIfNil(append(StringSlice(nil), file...))
+		}
+	}
+
+	return emptyIfNil(append(StringSlice(nil), live...))
 }
 
 func foldersConfigFrom(cfg *Config) foldersConfigAPI {

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -1,0 +1,87 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestConfigGetSection(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Config.Debug = true
+	unpack.KeepHistory = 200
+	unpack.Sonarr = []*SonarrConfig{{}}
+	unpack.Sonarr[0].Path = "/downloads"
+	unpack.Sonarr[0].URL = "http://127.0.0.1:8989"
+	unpack.Sonarr[0].APIKey = strings.Repeat("k", apiKeyMinLength)
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/config/nope", "", withKey); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown %d", rec.Code)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth %d", rec.Code)
+	}
+
+	genRec := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if genRec.Code != http.StatusOK {
+		t.Fatalf("general %d %s", genRec.Code, genRec.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(genRec.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	if !general.Debug || general.KeepHistory != 200 {
+		t.Fatalf("general %+v", general)
+	}
+
+	webRec := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
+	if webRec.Code != http.StatusOK {
+		t.Fatalf("webserver %d %s", webRec.Code, webRec.Body.String())
+	}
+
+	if !strings.Contains(webRec.Body.String(), `"uiPassword":"!!cryptd!!`) {
+		t.Fatalf("password not stored hash: %s", webRec.Body.String())
+	}
+
+	starrRec := doAuth(t, unpack, http.MethodGet, "/api/config/sonarr", "", withKey)
+	if starrRec.Code != http.StatusOK || !strings.Contains(starrRec.Body.String(), strings.Repeat("k", apiKeyMinLength)) {
+		t.Fatalf("sonarr %d %s", starrRec.Code, starrRec.Body.String())
+	}
+}
+
+func TestConfigGetPermission(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	readKey := strings.Repeat("G", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"general": {Permissions: []string{PermReadConfig(SectionGeneral)}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "cfg",
+		Key:   readKey,
+		Roles: []string{"general"},
+	})
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, readKey)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey); rec.Code != http.StatusOK {
+		t.Fatalf("general %d", rec.Code)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey); rec.Code != http.StatusForbidden {
+		t.Fatalf("webserver %d", rec.Code)
+	}
+}

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -84,4 +84,50 @@ func TestConfigGetPermission(t *testing.T) {
 	if rec := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey); rec.Code != http.StatusForbidden {
 		t.Fatalf("webserver %d", rec.Code)
 	}
+
+	liveRec := doAuth(t, unpack, http.MethodGet, "/api/config/webserver/live", "", withKey)
+	if liveRec.Code != http.StatusForbidden {
+		t.Fatalf("webserver live %d", liveRec.Code)
+	}
+}
+
+func TestConfigGetFileVsLive(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Passwords = StringSlice{"filepath:/secrets"}
+	unpack.snapshotFileConfig()
+	unpack.Passwords = StringSlice{"expanded-secret"}
+	unpack.fileConfig.Webserver.UIPassword = CryptPass(filePrefix + "/ui.pass")
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	fileGen := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	liveGen := doAuth(t, unpack, http.MethodGet, "/api/config/general/live", "", withKey)
+
+	if fileGen.Code != http.StatusOK || liveGen.Code != http.StatusOK {
+		t.Fatalf("file %d live %d", fileGen.Code, liveGen.Code)
+	}
+
+	if !strings.Contains(fileGen.Body.String(), "filepath:/secrets") {
+		t.Fatalf("file general %s", fileGen.Body.String())
+	}
+
+	if !strings.Contains(liveGen.Body.String(), "expanded-secret") ||
+		strings.Contains(liveGen.Body.String(), "filepath:/secrets") {
+		t.Fatalf("live general %s", liveGen.Body.String())
+	}
+
+	fileWeb := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
+	liveWeb := doAuth(t, unpack, http.MethodGet, "/api/config/webserver/live", "", withKey)
+
+	if !strings.Contains(fileWeb.Body.String(), filePrefix+"/ui.pass") {
+		t.Fatalf("file webserver %s", fileWeb.Body.String())
+	}
+
+	if !strings.Contains(liveWeb.Body.String(), `"uiPassword":"!!cryptd!!`) {
+		t.Fatalf("live webserver %s", liveWeb.Body.String())
+	}
 }

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -115,9 +115,9 @@ func TestConfigGetFileVsLive(t *testing.T) {
 		t.Fatalf("file general %s", fileGen.Body.String())
 	}
 
-	if !strings.Contains(liveGen.Body.String(), "expanded-secret") ||
-		strings.Contains(liveGen.Body.String(), "filepath:/secrets") {
-		t.Fatalf("live general %s", liveGen.Body.String())
+	if !strings.Contains(liveGen.Body.String(), "filepath:/secrets") ||
+		strings.Contains(liveGen.Body.String(), "expanded-secret") {
+		t.Fatalf("live general must not expand filepath: passwords: %s", liveGen.Body.String())
 	}
 
 	fileWeb := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
@@ -129,5 +129,27 @@ func TestConfigGetFileVsLive(t *testing.T) {
 
 	if !strings.Contains(liveWeb.Body.String(), `"uiPassword":"!!cryptd!!`) {
 		t.Fatalf("live webserver %s", liveWeb.Body.String())
+	}
+}
+
+func TestConfigGetLiveInlinePasswords(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Passwords = StringSlice{"inline-secret"}
+	unpack.snapshotFileConfig()
+	unpack.Passwords = StringSlice{"env-overlay-secret"}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	liveGen := doAuth(t, unpack, http.MethodGet, "/api/config/general/live", "", withKey)
+	if liveGen.Code != http.StatusOK {
+		t.Fatalf("live %d %s", liveGen.Code, liveGen.Body.String())
+	}
+
+	if !strings.Contains(liveGen.Body.String(), "env-overlay-secret") {
+		t.Fatalf("live inline/env passwords %s", liveGen.Body.String())
 	}
 }

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -3,6 +3,7 @@ package unpackerr
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -53,6 +54,10 @@ func TestConfigGetSection(t *testing.T) {
 		t.Fatalf("password not stored hash: %s", webRec.Body.String())
 	}
 
+	if !strings.Contains(webRec.Body.String(), unpack.Webserver.adminAPIKey()) {
+		t.Fatalf("admin must see api keys: %s", webRec.Body.String())
+	}
+
 	starrRec := doAuth(t, unpack, http.MethodGet, "/api/config/sonarr", "", withKey)
 	if starrRec.Code != http.StatusOK || !strings.Contains(starrRec.Body.String(), strings.Repeat("k", apiKeyMinLength)) {
 		t.Fatalf("sonarr %d %s", starrRec.Code, starrRec.Body.String())
@@ -97,6 +102,7 @@ func TestConfigGetFileVsLive(t *testing.T) {
 	unpack := testAuthUnpackerr(t)
 	unpack.Passwords = StringSlice{"filepath:/secrets"}
 	unpack.snapshotFileConfig()
+	unpack.snapshotLivePasswords()
 	unpack.Passwords = StringSlice{"expanded-secret"}
 	unpack.fileConfig.Webserver.UIPassword = CryptPass(filePrefix + "/ui.pass")
 
@@ -139,6 +145,7 @@ func TestConfigGetLiveInlinePasswords(t *testing.T) {
 	unpack.Passwords = StringSlice{"inline-secret"}
 	unpack.snapshotFileConfig()
 	unpack.Passwords = StringSlice{"env-overlay-secret"}
+	unpack.snapshotLivePasswords()
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
@@ -151,5 +158,149 @@ func TestConfigGetLiveInlinePasswords(t *testing.T) {
 
 	if !strings.Contains(liveGen.Body.String(), "env-overlay-secret") {
 		t.Fatalf("live inline/env passwords %s", liveGen.Body.String())
+	}
+}
+
+func TestConfigGetLiveEnvFilepathPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Passwords = StringSlice{"inline-from-file"}
+	unpack.snapshotFileConfig()
+	unpack.Passwords = StringSlice{"filepath:/run/secrets/pw"}
+	unpack.snapshotLivePasswords()
+	unpack.Passwords = StringSlice{"secretA", "secretB"}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	fileGen := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	liveGen := doAuth(t, unpack, http.MethodGet, "/api/config/general/live", "", withKey)
+
+	if fileGen.Code != http.StatusOK || liveGen.Code != http.StatusOK {
+		t.Fatalf("file %d live %d", fileGen.Code, liveGen.Code)
+	}
+
+	if !strings.Contains(fileGen.Body.String(), "inline-from-file") {
+		t.Fatalf("file general %s", fileGen.Body.String())
+	}
+
+	if !strings.Contains(liveGen.Body.String(), "filepath:/run/secrets/pw") ||
+		strings.Contains(liveGen.Body.String(), "secretA") ||
+		strings.Contains(liveGen.Body.String(), "secretB") {
+		t.Fatalf("live must keep env filepath: passwords: %s", liveGen.Body.String())
+	}
+}
+
+func TestConfigGetLiveEnvOverridesFilepath(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.Passwords = StringSlice{"filepath:/secrets"}
+	unpack.snapshotFileConfig()
+	unpack.Passwords = StringSlice{"env-inline"}
+	unpack.snapshotLivePasswords()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	fileGen := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	liveGen := doAuth(t, unpack, http.MethodGet, "/api/config/general/live", "", withKey)
+
+	if fileGen.Code != http.StatusOK || liveGen.Code != http.StatusOK {
+		t.Fatalf("file %d live %d", fileGen.Code, liveGen.Code)
+	}
+
+	if !strings.Contains(fileGen.Body.String(), "filepath:/secrets") {
+		t.Fatalf("file general %s", fileGen.Body.String())
+	}
+
+	if !strings.Contains(liveGen.Body.String(), "env-inline") ||
+		strings.Contains(liveGen.Body.String(), "filepath:/secrets") {
+		t.Fatalf("live must show env overlay passwords: %s", liveGen.Body.String())
+	}
+}
+
+func TestConfigGetWebserverKeysNeedStar(t *testing.T) {
+	t.Parallel()
+
+	unpack, adminKey, readKey := testWebserverReadUnpackerr(t)
+
+	withRead := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, readKey)
+	}
+
+	for _, path := range []string{"/api/config/webserver", "/api/config/webserver/live"} {
+		assertWebserverKeysRedacted(t, doAuth(t, unpack, http.MethodGet, path, "", withRead), adminKey, readKey)
+	}
+
+	withAdmin := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, adminKey)
+	}
+
+	adminFile := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withAdmin)
+	adminLive := doAuth(t, unpack, http.MethodGet, "/api/config/webserver/live", "", withAdmin)
+
+	if !strings.Contains(adminFile.Body.String(), adminKey) {
+		t.Fatalf("admin file GET %s", adminFile.Body.String())
+	}
+
+	if !strings.Contains(adminLive.Body.String(), adminKey) {
+		t.Fatalf("admin live GET %s", adminLive.Body.String())
+	}
+}
+
+func testWebserverReadUnpackerr(t *testing.T) (*Unpackerr, string, string) {
+	t.Helper()
+
+	unpack := testAuthUnpackerr(t)
+	adminKey := unpack.Webserver.adminAPIKey()
+	readKey := strings.Repeat("W", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"webread": {Permissions: []string{PermReadConfig(SectionWebserver)}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "webread",
+		Key:   readKey,
+		Roles: []string{"webread"},
+	})
+	unpack.snapshotFileConfig()
+
+	return unpack, adminKey, readKey
+}
+
+func assertWebserverKeysRedacted(t *testing.T, rec *httptest.ResponseRecorder, adminKey, readKey string) {
+	t.Helper()
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("webserver %d %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, adminKey) || strings.Contains(body, readKey) {
+		t.Fatalf("leaked api key: %s", body)
+	}
+
+	var payload struct {
+		APIKeys []APIKey `json:"apiKeys"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(payload.APIKeys) == 0 {
+		t.Fatalf("missing apiKeys: %s", body)
+	}
+
+	for _, key := range payload.APIKeys {
+		if key.Key != "" {
+			t.Fatalf("key not redacted: %+v", key)
+		}
+
+		if key.Name == "" || len(key.Roles) == 0 {
+			t.Fatalf("expected name and roles: %+v", key)
+		}
 	}
 }

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -138,6 +138,40 @@ func TestConfigGetFileVsLive(t *testing.T) {
 	}
 }
 
+func TestConfigGetFileHidesPlainUIPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.snapshotFileConfig()
+	unpack.fileConfig.Webserver.UIPassword = CryptPass("fileuser:filepass99")
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	fileWeb := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
+	if fileWeb.Code != http.StatusOK {
+		t.Fatalf("file %d %s", fileWeb.Code, fileWeb.Body.String())
+	}
+
+	if strings.Contains(fileWeb.Body.String(), "filepass99") {
+		t.Fatalf("file GET leaked plaintext ui_password: %s", fileWeb.Body.String())
+	}
+
+	if unpack.fileConfig.Webserver.UIPassword.Val() != "fileuser:filepass99" {
+		t.Fatal("sanitizing GET must not rewrite the file snapshot")
+	}
+
+	liveWeb := doAuth(t, unpack, http.MethodGet, "/api/config/webserver/live", "", withKey)
+	if !strings.Contains(liveWeb.Body.String(), `"uiPassword":"!!cryptd!!`) {
+		t.Fatalf("live webserver %s", liveWeb.Body.String())
+	}
+
+	if strings.Contains(liveWeb.Body.String(), "filepass99") {
+		t.Fatalf("live GET leaked file password: %s", liveWeb.Body.String())
+	}
+}
+
 func TestConfigGetLiveInlinePasswords(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -431,3 +431,16 @@ func (u *Unpackerr) mutateUIPassword(mutate func(*CryptPass) error) error {
 
 	return mutate(&u.Webserver.UIPassword)
 }
+
+// cloneLiveWebserver copies the running webserver under the password mutex so
+// HTTP GETs cannot race tray updates of UIPassword.
+func (u *Unpackerr) cloneLiveWebserver() *WebServer {
+	if u == nil || u.Webserver == nil {
+		return &WebServer{}
+	}
+
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return cloneWebserver(u.Webserver)
+}

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -106,6 +106,18 @@ func (p CryptPass) Webauth() bool {
 	return p == authHeader || strings.HasPrefix(p.Val(), authHeader+":") || p.Noauth()
 }
 
+// publicCryptPass is the GET form of ui_password: hash, webauth, noauth, and
+// filepath: stay; plaintext user:pass is blanked so env-overlaid file snapshots
+// cannot leak the on-disk secret.
+func publicCryptPass(pass CryptPass) CryptPass {
+	raw := pass.Val()
+	if raw == "" || pass.IsCrypted() || pass.Webauth() || strings.HasPrefix(raw, filePrefix) {
+		return pass
+	}
+
+	return ""
+}
+
 func (p CryptPass) Type() AuthType {
 	switch {
 	case p.Noauth():

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -444,3 +444,16 @@ func (u *Unpackerr) cloneLiveWebserver() *WebServer {
 
 	return cloneWebserver(u.Webserver)
 }
+
+// cloneFileWebserver copies the on-disk webserver snapshot under the same mutex
+// that syncFileUIPassword uses, so GET /api/config/webserver cannot race the tray.
+func (u *Unpackerr) cloneFileWebserver() *WebServer {
+	if u == nil || u.fileConfig == nil || u.fileConfig.Webserver == nil {
+		return u.cloneLiveWebserver()
+	}
+
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return cloneWebserver(u.fileConfig.Webserver)
+}

--- a/pkg/unpackerr/password_test.go
+++ b/pkg/unpackerr/password_test.go
@@ -406,3 +406,25 @@ func TestUIPasswordConcurrentReplace(t *testing.T) {
 
 	wait.Wait()
 }
+
+func TestPublicCryptPass(t *testing.T) {
+	t.Parallel()
+
+	hashed := CryptPass(authPassword + "admin:$2a$10$notahash")
+	tests := []struct {
+		in, out CryptPass
+	}{
+		{"fileuser:filepass99", ""},
+		{hashed, hashed},
+		{"webauth:X-Remote-User", "webauth:X-Remote-User"},
+		{authNone, authNone},
+		{filePrefix + "/ui.pass", filePrefix + "/ui.pass"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		if got := publicCryptPass(test.in); got != test.out {
+			t.Fatalf("%q -> %q, want %q", test.in, got, test.out)
+		}
+	}
+}

--- a/pkg/unpackerr/permissions.go
+++ b/pkg/unpackerr/permissions.go
@@ -49,6 +49,10 @@ func PermWriteConfig(section ConfigSection) string {
 	return "write:config:" + string(section)
 }
 
+func KnownSection(name ConfigSection) bool {
+	return slices.Contains(ConfigSections(), name)
+}
+
 // AllPermissions is every known permission, including per-section config ones.
 func AllPermissions() []string {
 	sections := ConfigSections()

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -80,6 +80,7 @@ type Unpackerr struct {
 	httpLog          *rotatorr.Logger
 	menu             map[string]ui.MenuItem
 	fileConfig       *Config      // on-disk shape (filepath: values). Config is the live expanded copy.
+	livePasswords    StringSlice  // post-env, pre-expansion; GET /live uses this
 	uiPassMu         sync.RWMutex // guards Webserver.UIPassword
 	uiPasswordNotice string
 	uiPasswordGenErr error


### PR DESCRIPTION
## Why

The settings UI needs to read one config section at a time with matching `read:config:{section}` permissions.

## What

- `GET /api/config/{section}` for `general`, `webserver`, `sonarr`, `radarr`, `lidarr`, `readarr`, `whisparr`, `folders`, `webhooks`, `cmdhooks`.
- `GET /api/config/{section}/live` is the expanded running copy (env overlays, hashed UI password). Archive passwords on `/live` are the post-env, pre-expansion slice, so `filepath:` from the file or `UN_PASSWORDS` is not replaced with secret-file contents.
- `general` is the top-level keys (interval, logs, passwords, keep_history, …).
- `folders` includes poller buffer/interval plus the watch list.
- Starr keys stay visible to anyone with that section read perm. Unpackerr `webserver.apiKeys[].key` is returned only to callers with `*`; other `read:config:webserver` keys get name and roles.
- `ui_password` is `!!cryptd!!` / `webauth` / `noauth` / `filepath:` — never a plaintext `user:pass`. If the on-disk snapshot still has plaintext because `UN_WEBSERVER_UI_PASSWORD` skipped hashing the file, GET blanks it.
- File and live webserver GETs clone under the UI-password mutex so the tray cannot race `json.Marshal`.

PUT and subsystem reload are the next PR.

Made with [Cursor](https://cursor.com)