### PR TITLE
Add per-section PUT /api/config/{section} with subsystem reload

### DIFF
--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -44,6 +44,10 @@ func (u *Unpackerr) registerAPIRoutes() {
 		path.Join(base, "config", ":section"),
 		u.requireConfigPerm(false, u.configGetHandler),
 	)
+	u.Webserver.router.PUT(
+		path.Join(base, "config", ":section"),
+		u.requireConfigPerm(true, u.configPutHandler),
+	)
 }
 
 func (u *Unpackerr) statsHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/pkg/unpackerr/applied.go
+++ b/pkg/unpackerr/applied.go
@@ -1,0 +1,65 @@
+package unpackerr
+
+import "time"
+
+// appliedGeneral is an immutable copy of live-applied general settings.
+// PUT publishes a new pointer so extract/history/folder readers never take
+// configMu (that lock already nests with histMu the other way).
+type appliedGeneral struct {
+	Activity      bool
+	MaxRetries    uint
+	KeepHistory   uint
+	RemnantAction string
+	Timeout       time.Duration
+	DeleteDelay   time.Duration
+	StartDelay    time.Duration
+	RetryDelay    time.Duration
+	Passwords     StringSlice
+}
+
+func (u *Unpackerr) publishAppliedGeneral() {
+	if u == nil || u.Config == nil {
+		return
+	}
+
+	u.rtGeneral.Store(&appliedGeneral{
+		Activity:      u.Activity,
+		MaxRetries:    u.MaxRetries,
+		KeepHistory:   u.KeepHistory,
+		RemnantAction: remnantAction(u.RemnantAction),
+		Timeout:       u.Timeout.Duration,
+		DeleteDelay:   u.DeleteDelay.Duration,
+		StartDelay:    u.StartDelay.Duration,
+		RetryDelay:    u.RetryDelay.Duration,
+		Passwords:     append(StringSlice(nil), u.Passwords...),
+	})
+}
+
+func (u *Unpackerr) applied() *appliedGeneral {
+	if u == nil {
+		return &appliedGeneral{}
+	}
+
+	if snap := u.rtGeneral.Load(); snap != nil {
+		return snap
+	}
+
+	// Tests and startup before unmarshalConfig. Do not take configMu here:
+	// extract/history already nest histMu the other way.
+
+	if u.Config == nil {
+		return &appliedGeneral{}
+	}
+
+	return &appliedGeneral{
+		Activity:      u.Activity,
+		MaxRetries:    u.MaxRetries,
+		KeepHistory:   u.KeepHistory,
+		RemnantAction: remnantAction(u.RemnantAction),
+		Timeout:       u.Timeout.Duration,
+		DeleteDelay:   u.DeleteDelay.Duration,
+		StartDelay:    u.StartDelay.Duration,
+		RetryDelay:    u.RetryDelay.Duration,
+		Passwords:     u.Passwords,
+	}
+}

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -86,8 +86,12 @@ type FoldersConfig struct {
 }
 
 func (u *Unpackerr) watchWorkThread() {
-	// 1 worker for each app, so they poll quickly.
-	for range len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr) {
+	// At least one worker so a later config PUT that adds the first Starr app
+	// cannot stall retrieveAppQueues on wait.Wait(). Extra workers per app
+	// keep polling concurrent when several apps are already configured.
+	count := max(1, len(u.Lidarr)+len(u.Radarr)+len(u.Readarr)+len(u.Sonarr)+len(u.Whisparr))
+
+	for range count {
 		go func() {
 			for funcs := range u.workChan {
 				for _, fn := range funcs {
@@ -101,36 +105,53 @@ func (u *Unpackerr) watchWorkThread() {
 // retrieveAppQueues polls all the starr app queues. At the same time.
 // Then calls the check methods to scan their queue contents for changes.
 func (u *Unpackerr) retrieveAppQueues(now time.Time) {
+	u.configMu.RLock()
+	lidarrApps := u.Lidarr
+	radarrApps := u.Radarr
+	readarrApps := u.Readarr
+	sonarrApps := u.Sonarr
+	whisparrApps := u.Whisparr
+	u.configMu.RUnlock()
+
 	wait := sync.WaitGroup{}
-	wait.Add(len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr))
+	wait.Add(len(lidarrApps) + len(radarrApps) + len(readarrApps) + len(sonarrApps) + len(whisparrApps))
 	// Run each app's getQueue method in a go routine as a waitgroup.
-	for _, server := range u.Lidarr {
+	for _, server := range lidarrApps {
 		u.workChan <- []func(){func() { u.getLidarrQueue(server, now) }, wait.Done}
 	}
 
-	for _, server := range u.Radarr {
+	for _, server := range radarrApps {
 		u.workChan <- []func(){func() { u.getRadarrQueue(server, now) }, wait.Done}
 	}
 
-	for _, server := range u.Readarr {
+	for _, server := range readarrApps {
 		u.workChan <- []func(){func() { u.getReadarrQueue(server, now) }, wait.Done}
 	}
 
-	for _, server := range u.Sonarr {
+	for _, server := range sonarrApps {
 		u.workChan <- []func(){func() { u.getSonarrQueue(server, now) }, wait.Done}
 	}
 
-	for _, server := range u.Whisparr {
+	for _, server := range whisparrApps {
 		u.workChan <- []func(){func() { u.getWhisparrQueue(server, now) }, wait.Done}
 	}
 
 	wait.Wait()
 	// These are not thread safe because they call saveCompletedDownload.
+	// Check the snapshot that was polled, not a list a PUT may have swapped in.
+	u.configMu.Lock()
+	liveLidarr, liveRadarr, liveReadarr, liveSonarr, liveWhisparr :=
+		u.Lidarr, u.Radarr, u.Readarr, u.Sonarr, u.Whisparr
+	u.Lidarr, u.Radarr, u.Readarr, u.Sonarr, u.Whisparr =
+		lidarrApps, radarrApps, readarrApps, sonarrApps, whisparrApps
 	u.checkLidarrQueue(now)
 	u.checkRadarrQueue(now)
 	u.checkReadarrQueue(now)
 	u.checkSonarrQueue(now)
 	u.checkWhisparrQueue(now)
+	u.Lidarr, u.Radarr, u.Readarr, u.Sonarr, u.Whisparr =
+		liveLidarr, liveRadarr, liveReadarr, liveSonarr, liveWhisparr
+	u.configMu.Unlock()
 	u.sweepForgotten()
 }
 

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -86,12 +86,24 @@ type FoldersConfig struct {
 }
 
 func (u *Unpackerr) watchWorkThread() {
-	// At least one worker so a later config PUT that adds the first Starr app
-	// cannot stall retrieveAppQueues on wait.Wait(). Extra workers per app
-	// keep polling concurrent when several apps are already configured.
-	count := max(1, len(u.Lidarr)+len(u.Radarr)+len(u.Readarr)+len(u.Sonarr)+len(u.Whisparr))
+	u.ensureWorkThreads(u.starrAppCount())
+}
 
-	for range count {
+func (u *Unpackerr) starrAppCount() int {
+	return len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr)
+}
+
+func (u *Unpackerr) ensureWorkThreads(count int) {
+	if count < 1 {
+		count = 1
+	}
+
+	u.workThreadMu.Lock()
+	defer u.workThreadMu.Unlock()
+
+	for u.workThreads < count {
+		u.workThreads++
+
 		go func() {
 			for funcs := range u.workChan {
 				for _, fn := range funcs {
@@ -184,6 +196,9 @@ func (u *Unpackerr) validateApps() error {
 }
 
 func (u *Unpackerr) haveQitem(name string, app starr.App) bool {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
 	switch app {
 	case starr.Lidarr:
 		return u.haveLidarrQitem(name)

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -163,8 +163,8 @@ func (u *Unpackerr) retrieveAppQueues(now time.Time) {
 	u.checkWhisparrQueue(now)
 	u.Lidarr, u.Radarr, u.Readarr, u.Sonarr, u.Whisparr =
 		liveLidarr, liveRadarr, liveReadarr, liveSonarr, liveWhisparr
-	u.configMu.Unlock()
 	u.sweepForgotten()
+	u.configMu.Unlock()
 }
 
 // validateApps is broken-out into this file to make adding new apps easier.

--- a/pkg/unpackerr/auth.go
+++ b/pkg/unpackerr/auth.go
@@ -171,6 +171,7 @@ func (u *Unpackerr) authAPIKey(key string) (authInfo, bool) {
 	u.uiPassMu.RLock()
 	perms := u.Webserver.PermissionsForKey(key)
 	name := u.Webserver.keyName(key)
+	pass := u.Webserver.UIPassword
 	u.uiPassMu.RUnlock()
 
 	if perms == nil {
@@ -180,7 +181,7 @@ func (u *Unpackerr) authAPIKey(key string) (authInfo, bool) {
 	return authInfo{
 		Username:    name,
 		APIKey:      key,
-		Auth:        u.uiPassword().Type().String(),
+		Auth:        pass.Type().String(),
 		Via:         "key",
 		Permissions: perms,
 	}, true
@@ -206,17 +207,6 @@ func (u *Unpackerr) webAllowContains(addr string) bool {
 	defer u.uiPassMu.RUnlock()
 
 	return u.Webserver.allow.Contains(addr)
-}
-
-func (u *Unpackerr) webAdminAPIKey() string {
-	if u == nil || u.Webserver == nil {
-		return ""
-	}
-
-	u.uiPassMu.RLock()
-	defer u.uiPassMu.RUnlock()
-
-	return u.Webserver.adminAPIKey()
 }
 
 func (u *Unpackerr) authenticate(request *http.Request) (authInfo, bool) {
@@ -259,8 +249,16 @@ func requestBearer(request *http.Request) string {
 }
 
 func (u *Unpackerr) proxyAuth(request *http.Request) (authInfo, bool) {
-	pass := u.uiPassword()
-	if !pass.Webauth() || !u.webAllowContains(request.RemoteAddr) {
+	if u == nil || u.Webserver == nil {
+		return authInfo{}, false
+	}
+
+	u.uiPassMu.RLock()
+	pass := u.Webserver.UIPassword
+	allowed := u.Webserver.allow.Contains(request.RemoteAddr)
+	u.uiPassMu.RUnlock()
+
+	if !pass.Webauth() || !allowed {
 		return authInfo{}, false
 	}
 
@@ -278,11 +276,21 @@ func (u *Unpackerr) proxyAuth(request *http.Request) (authInfo, bool) {
 }
 
 func (u *Unpackerr) sessionAuth(user string) authInfo {
-	pass := u.uiPassword()
+	var (
+		pass  CryptPass
+		admin string
+	)
+
+	if u != nil && u.Webserver != nil {
+		u.uiPassMu.RLock()
+		pass = u.Webserver.UIPassword
+		admin = u.Webserver.adminAPIKey()
+		u.uiPassMu.RUnlock()
+	}
 
 	info := authInfo{
 		Username:    user,
-		APIKey:      u.webAdminAPIKey(),
+		APIKey:      admin,
 		Auth:        pass.Type().String(),
 		Via:         "session",
 		Permissions: AllPermissions(),

--- a/pkg/unpackerr/auth.go
+++ b/pkg/unpackerr/auth.go
@@ -145,7 +145,7 @@ func (u *Unpackerr) requirePermHTTP(perm string, next http.Handler) http.Handler
 			return
 		}
 
-		perms := u.Webserver.PermissionsForKey(key)
+		perms := u.webPermissionsForKey(key)
 		if perms == nil {
 			writeJSON(response, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 
@@ -164,22 +164,59 @@ func (u *Unpackerr) requirePermHTTP(perm string, next http.Handler) http.Handler
 }
 
 func (u *Unpackerr) authAPIKey(key string) (authInfo, bool) {
-	if key == "" {
+	if key == "" || u == nil || u.Webserver == nil {
 		return authInfo{}, false
 	}
 
+	u.uiPassMu.RLock()
 	perms := u.Webserver.PermissionsForKey(key)
+	name := u.Webserver.keyName(key)
+	u.uiPassMu.RUnlock()
+
 	if perms == nil {
 		return authInfo{}, false
 	}
 
 	return authInfo{
-		Username:    u.Webserver.keyName(key),
+		Username:    name,
 		APIKey:      key,
 		Auth:        u.uiPassword().Type().String(),
 		Via:         "key",
 		Permissions: perms,
 	}, true
+}
+
+func (u *Unpackerr) webPermissionsForKey(key string) []string {
+	if u == nil || u.Webserver == nil {
+		return nil
+	}
+
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return u.Webserver.PermissionsForKey(key)
+}
+
+func (u *Unpackerr) webAllowContains(addr string) bool {
+	if u == nil || u.Webserver == nil {
+		return false
+	}
+
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return u.Webserver.allow.Contains(addr)
+}
+
+func (u *Unpackerr) webAdminAPIKey() string {
+	if u == nil || u.Webserver == nil {
+		return ""
+	}
+
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return u.Webserver.adminAPIKey()
 }
 
 func (u *Unpackerr) authenticate(request *http.Request) (authInfo, bool) {
@@ -223,7 +260,7 @@ func requestBearer(request *http.Request) string {
 
 func (u *Unpackerr) proxyAuth(request *http.Request) (authInfo, bool) {
 	pass := u.uiPassword()
-	if !pass.Webauth() || !u.Webserver.allow.Contains(request.RemoteAddr) {
+	if !pass.Webauth() || !u.webAllowContains(request.RemoteAddr) {
 		return authInfo{}, false
 	}
 
@@ -245,7 +282,7 @@ func (u *Unpackerr) sessionAuth(user string) authInfo {
 
 	info := authInfo{
 		Username:    user,
-		APIKey:      u.Webserver.adminAPIKey(),
+		APIKey:      u.webAdminAPIKey(),
 		Auth:        pass.Type().String(),
 		Via:         "session",
 		Permissions: AllPermissions(),
@@ -338,7 +375,7 @@ func (u *Unpackerr) trustedForwardedHTTPS(request *http.Request) bool {
 		return false
 	}
 
-	if !u.Webserver.allow.Contains(request.RemoteAddr) {
+	if !u.webAllowContains(request.RemoteAddr) {
 		return false
 	}
 

--- a/pkg/unpackerr/cmdhook.go
+++ b/pkg/unpackerr/cmdhook.go
@@ -31,7 +31,7 @@ func (u *Unpackerr) validateCmdhookList(list []*WebhookConfig) error {
 
 		list[idx].URL = ""
 
-		list[idx].Command = expandHomedir(list[idx].Command)
+		list[idx].Command = strings.TrimSpace(expandHomedir(list[idx].Command))
 		if list[idx].Command == "" {
 			return ErrCmdhookNoCmd
 		}
@@ -41,7 +41,7 @@ func (u *Unpackerr) validateCmdhookList(list []*WebhookConfig) error {
 		}
 
 		if list[idx].Timeout.Duration == 0 {
-			list[idx].Timeout.Duration = u.Timeout.Duration
+			list[idx].Timeout.Duration = u.applied().Timeout
 		}
 
 		if len(list[idx].Events) == 0 {

--- a/pkg/unpackerr/cmdhook.go
+++ b/pkg/unpackerr/cmdhook.go
@@ -20,24 +20,32 @@ var (
 )
 
 func (u *Unpackerr) validateCmdhook() error {
-	for idx := range u.Cmdhook {
-		u.Cmdhook[idx].URL = ""
+	return u.validateCmdhookList(u.Cmdhook)
+}
 
-		u.Cmdhook[idx].Command = expandHomedir(u.Cmdhook[idx].Command)
-		if u.Cmdhook[idx].Command == "" {
+func (u *Unpackerr) validateCmdhookList(list []*WebhookConfig) error {
+	for idx := range list {
+		if list[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		list[idx].URL = ""
+
+		list[idx].Command = expandHomedir(list[idx].Command)
+		if list[idx].Command == "" {
 			return ErrCmdhookNoCmd
 		}
 
-		if u.Cmdhook[idx].Name == "" {
-			u.Cmdhook[idx].Name = strings.Fields(u.Cmdhook[idx].Command)[0]
+		if list[idx].Name == "" {
+			list[idx].Name = strings.Fields(list[idx].Command)[0]
 		}
 
-		if u.Cmdhook[idx].Timeout.Duration == 0 {
-			u.Cmdhook[idx].Timeout.Duration = u.Timeout.Duration
+		if list[idx].Timeout.Duration == 0 {
+			list[idx].Timeout.Duration = u.Timeout.Duration
 		}
 
-		if len(u.Cmdhook[idx].Events) == 0 {
-			u.Cmdhook[idx].Events = []ExtractStatus{WAITING}
+		if len(list[idx].Events) == 0 {
+			list[idx].Events = []ExtractStatus{WAITING}
 		}
 	}
 
@@ -140,7 +148,11 @@ func (u *Unpackerr) logCmdhook() {
 func (u *Unpackerr) CmdhookCounts() (uint, uint) {
 	var total, fails uint
 
-	for _, hook := range u.Cmdhook {
+	for _, hook := range u.cmdhookList() {
+		if hook == nil {
+			continue
+		}
+
 		posts, failures := hook.Counts()
 		total += posts
 		fails += failures

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -88,6 +88,7 @@ func (u *Unpackerr) unmarshalConfig() (uint64, uint64, string, error) {
 	}
 
 	fileMode, dirMode := u.validateConfig()
+	u.publishAppliedGeneral()
 
 	return fileMode, dirMode, msg, nil
 }

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -142,16 +142,14 @@ func configFileLocactions() (string, []string) {
 
 // validateConfig makes sure config file values are ok. Returns file and dir modes.
 func (u *Unpackerr) validateConfig() (uint64, uint64) {
-	fileMode, dirMode := u.clampConfig()
-
-	if u.KeepHistory != 0 {
-		u.Items = make([]string, min(u.KeepHistory, trayHistory))
-	}
-
-	return fileMode, dirMode
+	return u.clampConfig()
 }
 
 func (u *Unpackerr) clampConfig() (uint64, uint64) { //nolint:cyclop
+	if u.KeepHistory != 0 && len(u.Items) == 0 {
+		u.Items = make([]string, min(u.KeepHistory, trayHistory))
+	}
+
 	if u.DeleteDelay.Duration > 0 && u.DeleteDelay.Duration < minimumDeleteDelay {
 		u.DeleteDelay.Duration = minimumDeleteDelay
 	}
@@ -416,11 +414,11 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 	}
 
 	if conf.Timeout.Duration == 0 {
-		conf.Timeout.Duration = u.Timeout.Duration
+		conf.Timeout.Duration = u.applied().Timeout
 	}
 
 	if conf.DeleteDelay.Duration == 0 {
-		conf.DeleteDelay.Duration = u.DeleteDelay.Duration
+		conf.DeleteDelay.Duration = u.applied().DeleteDelay
 	}
 
 	if conf.Path != "" && !slices.Contains(conf.Paths, conf.Path) {

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -140,7 +140,17 @@ func configFileLocactions() (string, []string) {
 }
 
 // validateConfig makes sure config file values are ok. Returns file and dir modes.
-func (u *Unpackerr) validateConfig() (uint64, uint64) { //nolint:cyclop
+func (u *Unpackerr) validateConfig() (uint64, uint64) {
+	fileMode, dirMode := u.clampConfig()
+
+	if u.KeepHistory != 0 {
+		u.Items = make([]string, min(u.KeepHistory, trayHistory))
+	}
+
+	return fileMode, dirMode
+}
+
+func (u *Unpackerr) clampConfig() (uint64, uint64) { //nolint:cyclop
 	if u.DeleteDelay.Duration > 0 && u.DeleteDelay.Duration < minimumDeleteDelay {
 		u.DeleteDelay.Duration = minimumDeleteDelay
 	}
@@ -197,10 +207,6 @@ func (u *Unpackerr) validateConfig() (uint64, uint64) { //nolint:cyclop
 		u.LogFile = filepath.Join("~", ".unpackerr", "unpackerr.log")
 	}
 
-	if u.KeepHistory != 0 {
-		u.Items = make([]string, min(u.KeepHistory, trayHistory))
-	}
-
 	return fileMode, dirMode
 }
 
@@ -245,11 +251,10 @@ func (u *Unpackerr) createConfigFile(file string) (string, error) {
 
 // writeConfigFile atomically rewrites the active config file from the on-disk snapshot.
 func (u *Unpackerr) writeConfigFile() error {
-	u.configMu.RLock()
-	cfg := u.fileConfig
-	u.configMu.RUnlock()
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
 
-	return u.writeConfigFrom(cfg)
+	return u.writeConfigFrom(u.fileConfig)
 }
 
 func (u *Unpackerr) writeConfigFrom(cfg *Config) error {

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -244,23 +245,31 @@ func (u *Unpackerr) createConfigFile(file string) (string, error) {
 
 // writeConfigFile atomically rewrites the active config file from the on-disk snapshot.
 func (u *Unpackerr) writeConfigFile() error {
+	u.configMu.RLock()
+	cfg := u.fileConfig
+	u.configMu.RUnlock()
+
+	return u.writeConfigFrom(cfg)
+}
+
+func (u *Unpackerr) writeConfigFrom(cfg *Config) error {
 	if strings.TrimSpace(u.ConfigFile) == "" {
 		return errNoConfigFile
 	}
 
 	schema, err := configdef.Load()
 	if err != nil {
-		return fmt.Errorf("definitions: %w", err)
+		return fmt.Errorf("%w: %w", errPersistConfig, err)
 	}
 
-	if u.fileConfig == nil {
+	if cfg == nil {
 		return errNoFileSnapshot
 	}
 
-	body := schema.RenderTOML(u.fileConfig, configdef.RenderOpts{Mode: configdef.RenderLive})
+	body := schema.RenderTOML(cfg, configdef.RenderOpts{Mode: configdef.RenderLive})
 
 	if err := configdef.AtomicWrite(u.ConfigFile, []byte(body)); err != nil {
-		return fmt.Errorf("writing config file: %w", err)
+		return fmt.Errorf("%w: %w", errPersistConfig, err)
 	}
 
 	return nil
@@ -285,7 +294,12 @@ func (u *Unpackerr) snapshotFileConfig() {
 }
 
 func (u *Unpackerr) syncFileUIPassword() {
-	if u.fileConfig == nil || u.Webserver == nil {
+	pass := u.uiPassword()
+
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
+	if u.fileConfig == nil {
 		return
 	}
 
@@ -293,12 +307,13 @@ func (u *Unpackerr) syncFileUIPassword() {
 		u.fileConfig.Webserver = &WebServer{}
 	}
 
-	u.uiPassMu.Lock()
-	u.fileConfig.Webserver.UIPassword = u.Webserver.UIPassword
-	u.uiPassMu.Unlock()
+	u.fileConfig.Webserver.UIPassword = pass
 }
 
 func (u *Unpackerr) appendFileAPIKey(key APIKey) {
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
 	if u.fileConfig == nil {
 		return
 	}
@@ -316,14 +331,10 @@ func (u *Unpackerr) snapshotLivePasswords() {
 	copy(u.livePasswords, u.Passwords)
 }
 
-// This function checks if rar passwords need to be read from a file path.
-// Only runs once at startup to load passwords into memory.
-func (u *Unpackerr) setPasswords() error {
-	u.snapshotLivePasswords()
-
+func expandPasswords(passwords StringSlice) (StringSlice, error) {
 	newPasswords := []string{}
 
-	for _, pass := range u.Passwords {
+	for _, pass := range passwords {
 		if !strings.HasPrefix(pass, filePrefix) {
 			newPasswords = append(newPasswords, pass)
 			continue
@@ -331,7 +342,7 @@ func (u *Unpackerr) setPasswords() error {
 
 		fileContent, err := os.ReadFile(strings.TrimPrefix(pass, filePrefix))
 		if err != nil {
-			return fmt.Errorf("reading password file: %w", err)
+			return nil, fmt.Errorf("reading password file: %w", err)
 		}
 
 		filePasswords := strings.Split(string(fileContent), "\n")
@@ -343,7 +354,20 @@ func (u *Unpackerr) setPasswords() error {
 		newPasswords = append(newPasswords, filePasswords...)
 	}
 
-	u.Passwords = newPasswords
+	return newPasswords, nil
+}
+
+// This function checks if rar passwords need to be read from a file path.
+// Only runs once at startup to load passwords into memory.
+func (u *Unpackerr) setPasswords() error {
+	u.snapshotLivePasswords()
+
+	expanded, err := expandPasswords(u.Passwords)
+	if err != nil {
+		return err
+	}
+
+	u.Passwords = expanded
 
 	return nil
 }
@@ -393,7 +417,7 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 		conf.DeleteDelay.Duration = u.DeleteDelay.Duration
 	}
 
-	if conf.Path != "" {
+	if conf.Path != "" && !slices.Contains(conf.Paths, conf.Path) {
 		conf.Paths = append(conf.Paths, conf.Path)
 	}
 

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -72,6 +72,9 @@ func (u *Unpackerr) configGetHandler(response http.ResponseWriter, request *http
 		return
 	}
 
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
 	writeConfigSection(response, u.fileConfigOrLive(), section)
 }
 
@@ -85,6 +88,9 @@ func (u *Unpackerr) configGetLiveHandler(
 
 		return
 	}
+
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
 
 	if section == SectionGeneral {
 		writeJSON(response, http.StatusOK, u.liveGeneralConfig())

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -73,9 +73,10 @@ func (u *Unpackerr) configGetHandler(response http.ResponseWriter, request *http
 	}
 
 	u.configMu.RLock()
-	defer u.configMu.RUnlock()
+	cfg := cloneConfig(u.fileConfigOrLive())
+	u.configMu.RUnlock()
 
-	writeConfigSection(response, u.fileConfigOrLive(), section)
+	writeConfigSection(response, cfg, section)
 }
 
 func (u *Unpackerr) configGetLiveHandler(
@@ -90,14 +91,19 @@ func (u *Unpackerr) configGetLiveHandler(
 	}
 
 	u.configMu.RLock()
-	defer u.configMu.RUnlock()
 
 	if section == SectionGeneral {
-		writeJSON(response, http.StatusOK, u.liveGeneralConfig())
+		payload := u.liveGeneralConfig()
+		u.configMu.RUnlock()
+		writeJSON(response, http.StatusOK, payload)
+
 		return
 	}
 
-	writeConfigSection(response, u.Config, section)
+	cfg := cloneConfig(u.Config)
+	u.configMu.RUnlock()
+
+	writeConfigSection(response, cfg, section)
 }
 
 func (u *Unpackerr) fileConfigOrLive() *Config {

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"golift.io/starr"
@@ -114,9 +115,10 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 		next.failDelay = u.Webserver.failDelay
 	}
 
-	if next.UIPassword.Val() == "" && u.Webserver != nil {
-		next.UIPassword = u.Webserver.UIPassword
-	} else if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser()); err != nil {
+	omitted := next.UIPassword.Val() == ""
+
+	submitted, fromFile, err := u.prepareWebserverPassword(&next)
+	if err != nil {
 		return false, err
 	}
 
@@ -134,12 +136,46 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 		u.Webserver.Pprof != next.Pprof
 
 	u.Webserver = &next
-
-	if u.fileConfig != nil {
-		u.fileConfig.Webserver = cloneWebserver(&next)
-	}
+	u.storeFileWebserver(&next, submitted, fromFile, omitted)
 
 	return restart, nil
+}
+
+func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, error) {
+	submitted := next.UIPassword
+	fromFile := strings.HasPrefix(submitted.Val(), filePrefix)
+
+	if submitted.Val() == "" && u.Webserver != nil {
+		next.UIPassword = u.Webserver.UIPassword
+		return submitted, false, nil
+	}
+
+	if err := expandCryptPassFile(&next.UIPassword); err != nil {
+		return submitted, fromFile, err
+	}
+
+	if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser()); err != nil {
+		return submitted, fromFile, err
+	}
+
+	return submitted, fromFile, nil
+}
+
+func (u *Unpackerr) storeFileWebserver(live *WebServer, submitted CryptPass, fromFile, omitted bool) {
+	if u.fileConfig == nil {
+		return
+	}
+
+	cloned := cloneWebserver(live)
+
+	switch {
+	case omitted && u.fileConfig.Webserver != nil:
+		cloned.UIPassword = u.fileConfig.Webserver.UIPassword
+	case fromFile:
+		cloned.UIPassword = submitted
+	}
+
+	u.fileConfig.Webserver = cloned
 }
 
 func applyGeneral(dst *Config, next generalConfig) {

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -135,8 +135,10 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 		u.Webserver.Metrics != next.Metrics ||
 		u.Webserver.Pprof != next.Pprof
 
+	u.uiPassMu.Lock()
 	u.Webserver = &next
-	u.storeFileWebserver(&next, submitted, fromFile, omitted)
+	u.uiPassMu.Unlock()
+	u.storeFileWebserver(submitted, fromFile, omitted)
 
 	return restart, nil
 }
@@ -146,7 +148,7 @@ func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, 
 	fromFile := strings.HasPrefix(submitted.Val(), filePrefix)
 
 	if submitted.Val() == "" && u.Webserver != nil {
-		next.UIPassword = u.Webserver.UIPassword
+		next.UIPassword = u.uiPassword()
 		return submitted, false, nil
 	}
 
@@ -161,12 +163,12 @@ func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, 
 	return submitted, fromFile, nil
 }
 
-func (u *Unpackerr) storeFileWebserver(live *WebServer, submitted CryptPass, fromFile, omitted bool) {
+func (u *Unpackerr) storeFileWebserver(submitted CryptPass, fromFile, omitted bool) {
 	if u.fileConfig == nil {
 		return
 	}
 
-	cloned := cloneWebserver(live)
+	cloned := u.cloneLiveWebserver()
 
 	switch {
 	case omitted && u.fileConfig.Webserver != nil:
@@ -208,10 +210,8 @@ func applyGeneral(dst *Config, next generalConfig) {
 }
 
 func (u *Unpackerr) uiPasswordUser() string {
-	if u.Webserver != nil {
-		if name := u.Webserver.UIPassword.Username(); name != "" {
-			return name
-		}
+	if name := u.uiPassword().Username(); name != "" {
+		return name
 	}
 
 	return defaultUIUser

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -86,29 +86,8 @@ func (u *Unpackerr) putGeneral(request *http.Request) (bool, error) {
 		next.LogQueues != u.LogQueues ||
 		next.Parallel != u.Parallel
 
-	u.Config.Debug = next.Debug
-	u.Quiet = next.Quiet
-	u.Activity = next.Activity
-	u.Parallel = next.Parallel
-	u.ErrorStdErr = next.ErrorStdErr
-	u.LogFile = next.LogFile
-	u.LogFiles = next.LogFiles
-	u.LogFileMb = next.LogFileMb
-	u.LogFileMode = next.LogFileMode
-	u.MaxRetries = next.MaxRetries
-	u.RemnantAction = next.RemnantAction
-	u.FileMode = next.FileMode
-	u.DirMode = next.DirMode
-	u.LogQueues = next.LogQueues
-	u.Interval = next.Interval
-	u.Timeout = next.Timeout
-	u.DeleteDelay = next.DeleteDelay
-	u.StartDelay = next.StartDelay
-	u.RetryDelay = next.RetryDelay
-	u.Progress = next.Progress
-	u.KeepHistory = next.KeepHistory
-	u.Passwords = next.Passwords
-
+	applyGeneral(u.Config, next)
+	applyGeneral(u.fileConfig, next)
 	u.validateConfig()
 
 	if err := u.validateRemnantAction(); err != nil {
@@ -137,7 +116,7 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 
 	if next.UIPassword.Val() == "" && u.Webserver != nil {
 		next.UIPassword = u.Webserver.UIPassword
-	} else if err := normalizeStoredPassword(&next.UIPassword); err != nil {
+	} else if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser()); err != nil {
 		return false, err
 	}
 
@@ -156,15 +135,58 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 
 	u.Webserver = &next
 
+	if u.fileConfig != nil {
+		u.fileConfig.Webserver = cloneWebserver(&next)
+	}
+
 	return restart, nil
 }
 
-func normalizeStoredPassword(pass *CryptPass) error {
+func applyGeneral(dst *Config, next generalConfig) {
+	if dst == nil {
+		return
+	}
+
+	dst.Debug = next.Debug
+	dst.Quiet = next.Quiet
+	dst.Activity = next.Activity
+	dst.Parallel = next.Parallel
+	dst.ErrorStdErr = next.ErrorStdErr
+	dst.LogFile = next.LogFile
+	dst.LogFiles = next.LogFiles
+	dst.LogFileMb = next.LogFileMb
+	dst.LogFileMode = next.LogFileMode
+	dst.MaxRetries = next.MaxRetries
+	dst.RemnantAction = next.RemnantAction
+	dst.FileMode = next.FileMode
+	dst.DirMode = next.DirMode
+	dst.LogQueues = next.LogQueues
+	dst.Interval = next.Interval
+	dst.Timeout = next.Timeout
+	dst.DeleteDelay = next.DeleteDelay
+	dst.StartDelay = next.StartDelay
+	dst.RetryDelay = next.RetryDelay
+	dst.Progress = next.Progress
+	dst.KeepHistory = next.KeepHistory
+	dst.Passwords = append(StringSlice(nil), next.Passwords...)
+}
+
+func (u *Unpackerr) uiPasswordUser() string {
+	if u.Webserver != nil {
+		if name := u.Webserver.UIPassword.Username(); name != "" {
+			return name
+		}
+	}
+
+	return defaultUIUser
+}
+
+func normalizeStoredPassword(pass *CryptPass, fallback string) error {
 	if pass.Val() == "" || pass.IsCrypted() || pass.Webauth() {
 		return nil
 	}
 
-	user, plain := splitUserPass(pass.Val())
+	user, plain := splitUserPass(pass.Val(), fallback)
 
 	return pass.SetPlain(user, plain)
 }
@@ -185,6 +207,10 @@ func (u *Unpackerr) putSonarr(request *http.Request) error {
 
 	u.Sonarr = list
 
+	if u.fileConfig != nil {
+		u.fileConfig.Sonarr = cloneSonarrList(list)
+	}
+
 	return nil
 }
 
@@ -203,6 +229,10 @@ func (u *Unpackerr) putRadarr(request *http.Request) error {
 	}
 
 	u.Radarr = list
+
+	if u.fileConfig != nil {
+		u.fileConfig.Radarr = cloneRadarrList(list)
+	}
 
 	return nil
 }
@@ -223,6 +253,10 @@ func (u *Unpackerr) putLidarr(request *http.Request) error {
 
 	u.Lidarr = list
 
+	if u.fileConfig != nil {
+		u.fileConfig.Lidarr = cloneLidarrList(list)
+	}
+
 	return nil
 }
 
@@ -241,6 +275,10 @@ func (u *Unpackerr) putReadarr(request *http.Request) error {
 	}
 
 	u.Readarr = list
+
+	if u.fileConfig != nil {
+		u.fileConfig.Readarr = cloneReadarrList(list)
+	}
 
 	return nil
 }
@@ -261,6 +299,10 @@ func (u *Unpackerr) putWhisparr(request *http.Request) error {
 
 	u.Whisparr = list
 
+	if u.fileConfig != nil {
+		u.fileConfig.Whisparr = cloneRadarrList(list)
+	}
+
 	return nil
 }
 
@@ -274,6 +316,12 @@ func (u *Unpackerr) putFolders(request *http.Request) (bool, error) {
 	u.Folder.Buffer = next.Buffer
 	u.Folders = next.Folder
 
+	if u.fileConfig != nil {
+		u.fileConfig.Folder.Interval = next.Interval
+		u.fileConfig.Folder.Buffer = next.Buffer
+		u.fileConfig.Folders = cloneFolderList(next.Folder)
+	}
+
 	return true, u.validateFolders()
 }
 
@@ -285,6 +333,10 @@ func (u *Unpackerr) putWebhooks(request *http.Request) error {
 
 	u.Webhook = list
 
+	if u.fileConfig != nil {
+		u.fileConfig.Webhook = cloneHookList(list)
+	}
+
 	return u.validateWebhook()
 }
 
@@ -295,6 +347,10 @@ func (u *Unpackerr) putCmdhooks(request *http.Request) error {
 	}
 
 	u.Cmdhook = list
+
+	if u.fileConfig != nil {
+		u.fileConfig.Cmdhook = cloneHookList(list)
+	}
 
 	return u.validateCmdhook()
 }

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -1,0 +1,300 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/readarr"
+	"golift.io/starr/sonarr"
+)
+
+const maxConfigBody = 1 << 20
+
+var errInvalidJSON = errors.New("invalid json")
+
+type configWriteReply struct {
+	Status          string `json:"status"`
+	RestartRequired bool   `json:"restartRequired"`
+}
+
+func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	restart, err := u.replaceConfigSection(ConfigSection(params.ByName("section")), request)
+	if err != nil {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := u.writeConfigFile(); err != nil && !errors.Is(err, errNoConfigFile) {
+		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, configWriteReply{Status: "ok", RestartRequired: restart})
+}
+
+func (u *Unpackerr) replaceConfigSection(section ConfigSection, request *http.Request) (bool, error) {
+	switch section {
+	case SectionGeneral:
+		return u.putGeneral(request)
+	case SectionWebserver:
+		return u.putWebserver(request)
+	case SectionSonarr:
+		return false, u.putSonarr(request)
+	case SectionRadarr:
+		return false, u.putRadarr(request)
+	case SectionLidarr:
+		return false, u.putLidarr(request)
+	case SectionReadarr:
+		return false, u.putReadarr(request)
+	case SectionWhisparr:
+		return false, u.putWhisparr(request)
+	case SectionFolders:
+		return u.putFolders(request)
+	case SectionWebhooks:
+		return false, u.putWebhooks(request)
+	case SectionCmdhooks:
+		return false, u.putCmdhooks(request)
+	default:
+		return false, errInvalidJSON
+	}
+}
+
+func readJSONBody(request *http.Request, dest any) error {
+	if err := json.NewDecoder(io.LimitReader(request.Body, maxConfigBody)).Decode(dest); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidJSON, err)
+	}
+
+	return nil
+}
+
+func (u *Unpackerr) putGeneral(request *http.Request) (bool, error) {
+	var next generalConfig
+	if err := readJSONBody(request, &next); err != nil {
+		return false, err
+	}
+
+	restart := next.Interval != u.Interval ||
+		next.StartDelay != u.StartDelay ||
+		next.Progress != u.Progress ||
+		next.LogQueues != u.LogQueues ||
+		next.Parallel != u.Parallel
+
+	u.Config.Debug = next.Debug
+	u.Quiet = next.Quiet
+	u.Activity = next.Activity
+	u.Parallel = next.Parallel
+	u.ErrorStdErr = next.ErrorStdErr
+	u.LogFile = next.LogFile
+	u.LogFiles = next.LogFiles
+	u.LogFileMb = next.LogFileMb
+	u.LogFileMode = next.LogFileMode
+	u.MaxRetries = next.MaxRetries
+	u.RemnantAction = next.RemnantAction
+	u.FileMode = next.FileMode
+	u.DirMode = next.DirMode
+	u.LogQueues = next.LogQueues
+	u.Interval = next.Interval
+	u.Timeout = next.Timeout
+	u.DeleteDelay = next.DeleteDelay
+	u.StartDelay = next.StartDelay
+	u.RetryDelay = next.RetryDelay
+	u.Progress = next.Progress
+	u.KeepHistory = next.KeepHistory
+	u.Passwords = next.Passwords
+
+	u.validateConfig()
+
+	if err := u.validateRemnantAction(); err != nil {
+		return restart, err
+	}
+
+	if err := u.setPasswords(); err != nil {
+		return restart, err
+	}
+
+	return restart, nil
+}
+
+func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
+	var next WebServer
+	if err := readJSONBody(request, &next); err != nil {
+		return false, err
+	}
+
+	if u.Webserver != nil {
+		next.router = u.Webserver.router
+		next.server = u.Webserver.server
+		next.cookies = u.Webserver.cookies
+		next.failDelay = u.Webserver.failDelay
+	}
+
+	if next.UIPassword.Val() == "" && u.Webserver != nil {
+		next.UIPassword = u.Webserver.UIPassword
+	} else if err := normalizeStoredPassword(&next.UIPassword); err != nil {
+		return false, err
+	}
+
+	if err := next.validateAuth(); err != nil {
+		return false, err
+	}
+
+	next.allow = MakeIPs(next.Upstreams)
+
+	restart := u.Webserver.ListenAddr != next.ListenAddr ||
+		u.Webserver.URLBase != next.URLBase ||
+		u.Webserver.SSLCrtFile != next.SSLCrtFile ||
+		u.Webserver.SSLKeyFile != next.SSLKeyFile ||
+		u.Webserver.Metrics != next.Metrics ||
+		u.Webserver.Pprof != next.Pprof
+
+	u.Webserver = &next
+
+	return restart, nil
+}
+
+func normalizeStoredPassword(pass *CryptPass) error {
+	if pass.Val() == "" || pass.IsCrypted() || pass.Webauth() {
+		return nil
+	}
+
+	user, plain := splitUserPass(pass.Val())
+
+	return pass.SetPlain(user, plain)
+}
+
+func (u *Unpackerr) putSonarr(request *http.Request) error {
+	var list []*SonarrConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	for idx := range list {
+		if err := u.validateApp(&list[idx].StarrConfig, starr.Sonarr); err != nil {
+			return err
+		}
+
+		list[idx].Sonarr = sonarr.New(&list[idx].Config)
+	}
+
+	u.Sonarr = list
+
+	return nil
+}
+
+func (u *Unpackerr) putRadarr(request *http.Request) error {
+	var list []*RadarrConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	for idx := range list {
+		if err := u.validateApp(&list[idx].StarrConfig, starr.Radarr); err != nil {
+			return err
+		}
+
+		list[idx].Radarr = radarr.New(&list[idx].Config)
+	}
+
+	u.Radarr = list
+
+	return nil
+}
+
+func (u *Unpackerr) putLidarr(request *http.Request) error {
+	var list []*LidarrConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	for idx := range list {
+		if err := u.validateApp(&list[idx].StarrConfig, starr.Lidarr); err != nil {
+			return err
+		}
+
+		list[idx].Lidarr = lidarr.New(&list[idx].Config)
+	}
+
+	u.Lidarr = list
+
+	return nil
+}
+
+func (u *Unpackerr) putReadarr(request *http.Request) error {
+	var list []*ReadarrConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	for idx := range list {
+		if err := u.validateApp(&list[idx].StarrConfig, starr.Readarr); err != nil {
+			return err
+		}
+
+		list[idx].Readarr = readarr.New(&list[idx].Config)
+	}
+
+	u.Readarr = list
+
+	return nil
+}
+
+func (u *Unpackerr) putWhisparr(request *http.Request) error {
+	var list []*RadarrConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	for idx := range list {
+		if err := u.validateApp(&list[idx].StarrConfig, starr.Whisparr); err != nil {
+			return err
+		}
+
+		list[idx].Radarr = radarr.New(&list[idx].Config)
+	}
+
+	u.Whisparr = list
+
+	return nil
+}
+
+func (u *Unpackerr) putFolders(request *http.Request) (bool, error) {
+	var next foldersConfigAPI
+	if err := readJSONBody(request, &next); err != nil {
+		return true, err
+	}
+
+	u.Folder.Interval = next.Interval
+	u.Folder.Buffer = next.Buffer
+	u.Folders = next.Folder
+
+	return true, u.validateFolders()
+}
+
+func (u *Unpackerr) putWebhooks(request *http.Request) error {
+	var list []*WebhookConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	u.Webhook = list
+
+	return u.validateWebhook()
+}
+
+func (u *Unpackerr) putCmdhooks(request *http.Request) error {
+	var list []*WebhookConfig
+	if err := readJSONBody(request, &list); err != nil {
+		return err
+	}
+
+	u.Cmdhook = list
+
+	return u.validateCmdhook()
+}

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,7 +19,13 @@ import (
 
 const maxConfigBody = 1 << 20
 
-var errInvalidJSON = errors.New("invalid json")
+var (
+	errInvalidJSON          = errors.New("invalid json")
+	errEmptyConfigSection   = errors.New("empty config section")
+	errNilConfigEntry       = errors.New("nil config entry")
+	errUnknownConfigSection = errors.New("unknown section")
+	errPersistConfig        = errors.New("persisting config file")
+)
 
 type configWriteReply struct {
 	Status          string `json:"status"`
@@ -26,94 +33,206 @@ type configWriteReply struct {
 }
 
 func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
-	restart, err := u.replaceConfigSection(ConfigSection(params.ByName("section")), request)
+	restart, err := u.replaceConfigSection(ConfigSection(params.ByName("section")), response, request)
 	if err != nil {
-		writeJSON(response, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-
-	if err := u.writeConfigFile(); err != nil && !errors.Is(err, errNoConfigFile) {
-		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(response, statusForConfigPut(err), map[string]string{"error": err.Error()})
 		return
 	}
 
 	writeJSON(response, http.StatusOK, configWriteReply{Status: "ok", RestartRequired: restart})
 }
 
-func (u *Unpackerr) replaceConfigSection(section ConfigSection, request *http.Request) (bool, error) {
+func statusForConfigPut(err error) int {
+	if errors.Is(err, errPersistConfig) || errors.Is(err, errNoFileSnapshot) {
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusBadRequest
+}
+
+func (u *Unpackerr) replaceConfigSection(
+	section ConfigSection,
+	response http.ResponseWriter,
+	request *http.Request,
+) (bool, error) {
 	switch section {
 	case SectionGeneral:
-		return u.putGeneral(request)
+		return u.putGeneral(response, request)
 	case SectionWebserver:
-		return u.putWebserver(request)
+		return u.putWebserver(response, request)
 	case SectionSonarr:
-		return false, u.putSonarr(request)
+		return false, u.putSonarr(response, request)
 	case SectionRadarr:
-		return false, u.putRadarr(request)
+		return false, u.putRadarr(response, request)
 	case SectionLidarr:
-		return false, u.putLidarr(request)
+		return false, u.putLidarr(response, request)
 	case SectionReadarr:
-		return false, u.putReadarr(request)
+		return false, u.putReadarr(response, request)
 	case SectionWhisparr:
-		return false, u.putWhisparr(request)
+		return false, u.putWhisparr(response, request)
 	case SectionFolders:
-		return u.putFolders(request)
+		return u.putFolders(response, request)
 	case SectionWebhooks:
-		return false, u.putWebhooks(request)
+		return false, u.putWebhooks(response, request)
 	case SectionCmdhooks:
-		return false, u.putCmdhooks(request)
+		return false, u.putCmdhooks(response, request)
 	default:
-		return false, errInvalidJSON
+		return false, errUnknownConfigSection
 	}
 }
 
-func readJSONBody(request *http.Request, dest any) error {
-	if err := json.NewDecoder(io.LimitReader(request.Body, maxConfigBody)).Decode(dest); err != nil {
-		return fmt.Errorf("%w: %w", errInvalidJSON, err)
+func decodeJSONBody(response http.ResponseWriter, request *http.Request) (json.RawMessage, error) {
+	decoder := json.NewDecoder(http.MaxBytesReader(response, request.Body, maxConfigBody))
+
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, wrapJSONErr(err)
+	}
+
+	switch err := decoder.Decode(&struct{}{}); {
+	case errors.Is(err, io.EOF):
+	case err != nil:
+		return nil, wrapJSONErr(err)
+	default:
+		return nil, errExtraJSON
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, errEmptyConfigSection
+	}
+
+	return raw, nil
+}
+
+func unmarshalConfigJSON(raw json.RawMessage, dest any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dest); err != nil {
+		return wrapJSONErr(err)
 	}
 
 	return nil
 }
 
-func (u *Unpackerr) putGeneral(request *http.Request) (bool, error) {
-	var next generalConfig
-	if err := readJSONBody(request, &next); err != nil {
-		return false, err
-	}
-
-	restart := next.Interval != u.Interval ||
-		next.StartDelay != u.StartDelay ||
-		next.Progress != u.Progress ||
-		next.LogQueues != u.LogQueues ||
-		next.Parallel != u.Parallel
-
-	applyGeneral(u.Config, next)
-	applyGeneral(u.fileConfig, next)
-	u.validateConfig()
-
-	if err := u.validateRemnantAction(); err != nil {
-		return restart, err
-	}
-
-	if err := u.setPasswords(); err != nil {
-		return restart, err
-	}
-
-	return restart, nil
+func wrapJSONErr(err error) error {
+	return fmt.Errorf("%w: %w", errInvalidJSON, err)
 }
 
-func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
-	var next WebServer
-	if err := readJSONBody(request, &next); err != nil {
+func readJSONBody(response http.ResponseWriter, request *http.Request, dest any) error {
+	raw, err := decodeJSONBody(response, request)
+	if err != nil {
+		return err
+	}
+
+	return unmarshalConfigJSON(raw, dest)
+}
+
+func readJSONObject(response http.ResponseWriter, request *http.Request, dest any) error {
+	raw, err := decodeJSONBody(response, request)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("{}")) {
+		return errEmptyConfigSection
+	}
+
+	return unmarshalConfigJSON(raw, dest)
+}
+
+func rejectNilPointers[T any](list []*T) error {
+	for _, item := range list {
+		if item == nil {
+			return errNilConfigEntry
+		}
+	}
+
+	return nil
+}
+
+// commitConfig writes a staged file snapshot, then publishes live state.
+// A write failure leaves live and fileConfig unchanged. Env-only (no config
+// path) still applies live.
+func (u *Unpackerr) commitConfig(mutateFile func(*Config), applyLive func()) error {
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
+	if u.fileConfig != nil {
+		staged := cloneConfig(u.fileConfig)
+		mutateFile(staged)
+
+		if err := u.writeConfigFrom(staged); err != nil && !errors.Is(err, errNoConfigFile) {
+			return err
+		}
+
+		u.fileConfig = staged
+	}
+
+	applyLive()
+
+	return nil
+}
+
+func (u *Unpackerr) putGeneral(response http.ResponseWriter, request *http.Request) (bool, error) {
+	var next generalConfig
+	if err := readJSONObject(response, request, &next); err != nil {
 		return false, err
 	}
 
-	if u.Webserver != nil {
-		next.router = u.Webserver.router
-		next.server = u.Webserver.server
-		next.cookies = u.Webserver.cookies
-		next.failDelay = u.Webserver.failDelay
+	if err := remnantActionError(next.RemnantAction); err != nil {
+		return false, err
 	}
+
+	expanded, err := expandPasswords(next.Passwords)
+	if err != nil {
+		return false, err
+	}
+
+	submittedPasswords := append(StringSlice(nil), next.Passwords...)
+	restart := generalRestartRequired(u.Config, next)
+
+	return restart, u.commitConfig(func(cfg *Config) {
+		applyGeneral(cfg, next)
+	}, func() {
+		applyGeneral(u.Config, next)
+		u.livePasswords = submittedPasswords
+		u.Passwords = expanded
+		u.RemnantAction = remnantAction(next.RemnantAction)
+		u.validateConfig()
+	})
+}
+
+func generalRestartRequired(cur *Config, next generalConfig) bool {
+	if cur == nil {
+		return true
+	}
+
+	return next.Interval != cur.Interval ||
+		next.StartDelay != cur.StartDelay ||
+		next.Progress != cur.Progress ||
+		next.LogQueues != cur.LogQueues ||
+		next.Parallel != cur.Parallel ||
+		next.LogFile != cur.LogFile ||
+		next.LogFiles != cur.LogFiles ||
+		next.LogFileMb != cur.LogFileMb ||
+		next.LogFileMode != cur.LogFileMode ||
+		next.ErrorStdErr != cur.ErrorStdErr ||
+		next.FileMode != cur.FileMode ||
+		next.DirMode != cur.DirMode
+}
+
+func (u *Unpackerr) putWebserver(response http.ResponseWriter, request *http.Request) (bool, error) {
+	var next WebServer
+	if err := readJSONObject(response, request, &next); err != nil {
+		return false, err
+	}
+
+	next.normalizeURLBase()
+
+	prevFile := u.cloneStoredFileWebserver()
+	keepNamedAPIKeys(&next, u.Webserver, prevFile)
 
 	omitted := next.UIPassword.Val() == ""
 
@@ -127,20 +246,103 @@ func (u *Unpackerr) putWebserver(request *http.Request) (bool, error) {
 	}
 
 	next.allow = MakeIPs(next.Upstreams)
+	restart := webserverRestartRequired(u.Webserver, &next)
+	fileWeb := fileWebserverFromPut(&next, submitted, fromFile, omitted, prevFile)
 
-	restart := u.Webserver.ListenAddr != next.ListenAddr ||
-		u.Webserver.URLBase != next.URLBase ||
-		u.Webserver.SSLCrtFile != next.SSLCrtFile ||
-		u.Webserver.SSLKeyFile != next.SSLKeyFile ||
-		u.Webserver.Metrics != next.Metrics ||
-		u.Webserver.Pprof != next.Pprof
+	if err := u.commitConfig(func(cfg *Config) {
+		cfg.Webserver = fileWeb
+	}, func() {}); err != nil {
+		return false, err
+	}
 
-	u.uiPassMu.Lock()
-	u.Webserver = &next
-	u.uiPassMu.Unlock()
-	u.storeFileWebserver(submitted, fromFile, omitted)
+	u.applyLiveWebserverAuth(&next)
 
 	return restart, nil
+}
+
+func webserverRestartRequired(cur, next *WebServer) bool {
+	if cur == nil || next == nil {
+		return true
+	}
+
+	return cur.ListenAddr != next.ListenAddr ||
+		cur.URLBase != next.URLBase ||
+		cur.SSLCrtFile != next.SSLCrtFile ||
+		cur.SSLKeyFile != next.SSLKeyFile ||
+		cur.Metrics != next.Metrics ||
+		cur.Pprof != next.Pprof ||
+		cur.LogFile != next.LogFile ||
+		cur.LogFiles != next.LogFiles ||
+		cur.LogFileMb != next.LogFileMb
+}
+
+func fileWebserverFromPut(
+	next *WebServer,
+	submitted CryptPass,
+	fromFile, omitted bool,
+	prevFile *WebServer,
+) *WebServer {
+	cloned := cloneWebserver(next)
+
+	switch {
+	case omitted && prevFile != nil:
+		cloned.UIPassword = prevFile.UIPassword
+	case fromFile:
+		cloned.UIPassword = submitted
+	}
+
+	return cloned
+}
+
+// keepNamedAPIKeys fills a blank apiKeys[].key from an existing key of the same
+// name so a redacted GET can round-trip without requiring PermAll.
+func keepNamedAPIKeys(next *WebServer, sources ...*WebServer) {
+	if next == nil {
+		return
+	}
+
+	byName := make(map[string]string)
+
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+
+		for idx := range src.APIKeys {
+			name := src.APIKeys[idx].Name
+			if name == "" || src.APIKeys[idx].Key == "" {
+				continue
+			}
+
+			if _, exists := byName[name]; !exists {
+				byName[name] = src.APIKeys[idx].Key
+			}
+		}
+	}
+
+	for idx := range next.APIKeys {
+		if strings.TrimSpace(next.APIKeys[idx].Key) != "" {
+			continue
+		}
+
+		next.APIKeys[idx].Key = byName[next.APIKeys[idx].Name]
+	}
+}
+
+func (u *Unpackerr) applyLiveWebserverAuth(next *WebServer) {
+	if u == nil || u.Webserver == nil || next == nil {
+		return
+	}
+
+	u.uiPassMu.Lock()
+	defer u.uiPassMu.Unlock()
+
+	u.Webserver.APIKeys = cloneAPIKeys(next.APIKeys)
+	u.Webserver.Roles = cloneRoles(next.Roles)
+	u.Webserver.UIPassword = next.UIPassword
+	u.Webserver.Upstreams = append(StringSlice(nil), next.Upstreams...)
+	u.Webserver.allow = next.allow
+	u.Webserver.keyPerms = next.keyPerms
 }
 
 func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, error) {
@@ -149,6 +351,7 @@ func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, 
 
 	if submitted.Val() == "" && u.Webserver != nil {
 		next.UIPassword = u.uiPassword()
+
 		return submitted, false, nil
 	}
 
@@ -161,23 +364,6 @@ func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, 
 	}
 
 	return submitted, fromFile, nil
-}
-
-func (u *Unpackerr) storeFileWebserver(submitted CryptPass, fromFile, omitted bool) {
-	if u.fileConfig == nil {
-		return
-	}
-
-	cloned := u.cloneLiveWebserver()
-
-	switch {
-	case omitted && u.fileConfig.Webserver != nil:
-		cloned.UIPassword = u.fileConfig.Webserver.UIPassword
-	case fromFile:
-		cloned.UIPassword = submitted
-	}
-
-	u.fileConfig.Webserver = cloned
 }
 
 func applyGeneral(dst *Config, next generalConfig) {
@@ -227,11 +413,17 @@ func normalizeStoredPassword(pass *CryptPass, fallback string) error {
 	return pass.SetPlain(user, plain)
 }
 
-func (u *Unpackerr) putSonarr(request *http.Request) error {
+func (u *Unpackerr) putSonarr(response http.ResponseWriter, request *http.Request) error {
 	var list []*SonarrConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
+
+	if err := rejectNilPointers(list); err != nil {
+		return err
+	}
+
+	fileList := cloneSonarrList(list)
 
 	for idx := range list {
 		if err := u.validateApp(&list[idx].StarrConfig, starr.Sonarr); err != nil {
@@ -241,20 +433,26 @@ func (u *Unpackerr) putSonarr(request *http.Request) error {
 		list[idx].Sonarr = sonarr.New(&list[idx].Config)
 	}
 
-	u.Sonarr = list
+	carrySonarrQueues(u.Sonarr, list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Sonarr = cloneSonarrList(list)
-	}
-
-	return nil
+	return u.commitConfig(func(cfg *Config) {
+		cfg.Sonarr = fileList
+	}, func() {
+		u.Sonarr = list
+	})
 }
 
-func (u *Unpackerr) putRadarr(request *http.Request) error {
+func (u *Unpackerr) putRadarr(response http.ResponseWriter, request *http.Request) error {
 	var list []*RadarrConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
+
+	if err := rejectNilPointers(list); err != nil {
+		return err
+	}
+
+	fileList := cloneRadarrList(list)
 
 	for idx := range list {
 		if err := u.validateApp(&list[idx].StarrConfig, starr.Radarr); err != nil {
@@ -264,20 +462,26 @@ func (u *Unpackerr) putRadarr(request *http.Request) error {
 		list[idx].Radarr = radarr.New(&list[idx].Config)
 	}
 
-	u.Radarr = list
+	carryRadarrQueues(u.Radarr, list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Radarr = cloneRadarrList(list)
-	}
-
-	return nil
+	return u.commitConfig(func(cfg *Config) {
+		cfg.Radarr = fileList
+	}, func() {
+		u.Radarr = list
+	})
 }
 
-func (u *Unpackerr) putLidarr(request *http.Request) error {
+func (u *Unpackerr) putLidarr(response http.ResponseWriter, request *http.Request) error {
 	var list []*LidarrConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
+
+	if err := rejectNilPointers(list); err != nil {
+		return err
+	}
+
+	fileList := cloneLidarrList(list)
 
 	for idx := range list {
 		if err := u.validateApp(&list[idx].StarrConfig, starr.Lidarr); err != nil {
@@ -287,20 +491,26 @@ func (u *Unpackerr) putLidarr(request *http.Request) error {
 		list[idx].Lidarr = lidarr.New(&list[idx].Config)
 	}
 
-	u.Lidarr = list
+	carryLidarrQueues(u.Lidarr, list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Lidarr = cloneLidarrList(list)
-	}
-
-	return nil
+	return u.commitConfig(func(cfg *Config) {
+		cfg.Lidarr = fileList
+	}, func() {
+		u.Lidarr = list
+	})
 }
 
-func (u *Unpackerr) putReadarr(request *http.Request) error {
+func (u *Unpackerr) putReadarr(response http.ResponseWriter, request *http.Request) error {
 	var list []*ReadarrConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
+
+	if err := rejectNilPointers(list); err != nil {
+		return err
+	}
+
+	fileList := cloneReadarrList(list)
 
 	for idx := range list {
 		if err := u.validateApp(&list[idx].StarrConfig, starr.Readarr); err != nil {
@@ -310,20 +520,26 @@ func (u *Unpackerr) putReadarr(request *http.Request) error {
 		list[idx].Readarr = readarr.New(&list[idx].Config)
 	}
 
-	u.Readarr = list
+	carryReadarrQueues(u.Readarr, list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Readarr = cloneReadarrList(list)
-	}
-
-	return nil
+	return u.commitConfig(func(cfg *Config) {
+		cfg.Readarr = fileList
+	}, func() {
+		u.Readarr = list
+	})
 }
 
-func (u *Unpackerr) putWhisparr(request *http.Request) error {
+func (u *Unpackerr) putWhisparr(response http.ResponseWriter, request *http.Request) error {
 	var list []*RadarrConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
+
+	if err := rejectNilPointers(list); err != nil {
+		return err
+	}
+
+	fileList := cloneRadarrList(list)
 
 	for idx := range list {
 		if err := u.validateApp(&list[idx].StarrConfig, starr.Whisparr); err != nil {
@@ -333,60 +549,172 @@ func (u *Unpackerr) putWhisparr(request *http.Request) error {
 		list[idx].Radarr = radarr.New(&list[idx].Config)
 	}
 
-	u.Whisparr = list
+	carryRadarrQueues(u.Whisparr, list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Whisparr = cloneRadarrList(list)
+	return u.commitConfig(func(cfg *Config) {
+		cfg.Whisparr = fileList
+	}, func() {
+		u.Whisparr = list
+	})
+}
+
+func starrIdentity(url, apiKey string) string {
+	return url + "\x00" + apiKey
+}
+
+func carrySonarrQueues(prev, next []*SonarrConfig) {
+	seen := make(map[string]*SonarrConfig, len(prev))
+
+	for _, app := range prev {
+		if app != nil {
+			seen[starrIdentity(app.URL, app.APIKey)] = app
+		}
 	}
+
+	for _, app := range next {
+		if app == nil {
+			continue
+		}
+
+		if old := seen[starrIdentity(app.URL, app.APIKey)]; old != nil {
+			app.Queue = old.Queue
+		}
+	}
+}
+
+func carryRadarrQueues(prev, next []*RadarrConfig) {
+	seen := make(map[string]*RadarrConfig, len(prev))
+
+	for _, app := range prev {
+		if app != nil {
+			seen[starrIdentity(app.URL, app.APIKey)] = app
+		}
+	}
+
+	for _, app := range next {
+		if app == nil {
+			continue
+		}
+
+		if old := seen[starrIdentity(app.URL, app.APIKey)]; old != nil {
+			app.Queue = old.Queue
+		}
+	}
+}
+
+func carryLidarrQueues(prev, next []*LidarrConfig) {
+	seen := make(map[string]*LidarrConfig, len(prev))
+
+	for _, app := range prev {
+		if app != nil {
+			seen[starrIdentity(app.URL, app.APIKey)] = app
+		}
+	}
+
+	for _, app := range next {
+		if app == nil {
+			continue
+		}
+
+		if old := seen[starrIdentity(app.URL, app.APIKey)]; old != nil {
+			app.Queue = old.Queue
+		}
+	}
+}
+
+func carryReadarrQueues(prev, next []*ReadarrConfig) {
+	seen := make(map[string]*ReadarrConfig, len(prev))
+
+	for _, app := range prev {
+		if app != nil {
+			seen[starrIdentity(app.URL, app.APIKey)] = app
+		}
+	}
+
+	for _, app := range next {
+		if app == nil {
+			continue
+		}
+
+		if old := seen[starrIdentity(app.URL, app.APIKey)]; old != nil {
+			app.Queue = old.Queue
+		}
+	}
+}
+
+func (u *Unpackerr) putFolders(response http.ResponseWriter, request *http.Request) (bool, error) {
+	var next foldersConfigAPI
+	if err := readJSONObject(response, request, &next); err != nil {
+		return false, err
+	}
+
+	if err := rejectNilPointers(next.Folder); err != nil {
+		return false, err
+	}
+
+	if err := validateFolderList(next.Folder); err != nil {
+		return false, err
+	}
+
+	fileList := cloneFolderList(next.Folder)
+
+	return true, u.commitConfig(func(cfg *Config) {
+		cfg.Folder.Interval = next.Interval
+		cfg.Folder.Buffer = next.Buffer
+		cfg.Folders = fileList
+	}, func() {
+		u.Folder.Interval = next.Interval
+		u.Folder.Buffer = next.Buffer
+		u.Folders = next.Folder
+	})
+}
+
+func (u *Unpackerr) putWebhooks(response http.ResponseWriter, request *http.Request) error {
+	var list []*WebhookConfig
+	if err := readJSONBody(response, request, &list); err != nil {
+		return err
+	}
+
+	if err := u.validateWebhookList(list); err != nil {
+		return err
+	}
+
+	fileList := cloneHookList(list)
+
+	if err := u.commitConfig(func(cfg *Config) {
+		cfg.Webhook = fileList
+	}, func() {
+		u.Webhook = list
+	}); err != nil {
+		return err
+	}
+
+	u.ensureHookWorker()
 
 	return nil
 }
 
-func (u *Unpackerr) putFolders(request *http.Request) (bool, error) {
-	var next foldersConfigAPI
-	if err := readJSONBody(request, &next); err != nil {
-		return true, err
-	}
-
-	u.Folder.Interval = next.Interval
-	u.Folder.Buffer = next.Buffer
-	u.Folders = next.Folder
-
-	if u.fileConfig != nil {
-		u.fileConfig.Folder.Interval = next.Interval
-		u.fileConfig.Folder.Buffer = next.Buffer
-		u.fileConfig.Folders = cloneFolderList(next.Folder)
-	}
-
-	return true, u.validateFolders()
-}
-
-func (u *Unpackerr) putWebhooks(request *http.Request) error {
+func (u *Unpackerr) putCmdhooks(response http.ResponseWriter, request *http.Request) error {
 	var list []*WebhookConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := readJSONBody(response, request, &list); err != nil {
 		return err
 	}
 
-	u.Webhook = list
-
-	if u.fileConfig != nil {
-		u.fileConfig.Webhook = cloneHookList(list)
-	}
-
-	return u.validateWebhook()
-}
-
-func (u *Unpackerr) putCmdhooks(request *http.Request) error {
-	var list []*WebhookConfig
-	if err := readJSONBody(request, &list); err != nil {
+	if err := u.validateCmdhookList(list); err != nil {
 		return err
 	}
 
-	u.Cmdhook = list
+	fileList := cloneHookList(list)
 
-	if u.fileConfig != nil {
-		u.fileConfig.Cmdhook = cloneHookList(list)
+	if err := u.commitConfig(func(cfg *Config) {
+		cfg.Cmdhook = fileList
+	}, func() {
+		u.Cmdhook = list
+	}); err != nil {
+		return err
 	}
 
-	return u.validateCmdhook()
+	u.ensureHookWorker()
+
+	return nil
 }

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -170,8 +170,18 @@ func rejectNilPointers[T any](list []*T) error {
 // A write failure leaves live and fileConfig unchanged. Env-only (no config
 // path) still applies live.
 func (u *Unpackerr) commitConfig(mutateFile func(*Config), applyLive func()) error {
+	return u.commitPrepared(nil, mutateFile, applyLive)
+}
+
+func (u *Unpackerr) commitPrepared(prepare func() error, mutateFile func(*Config), applyLive func()) error {
 	u.configMu.Lock()
 	defer u.configMu.Unlock()
+
+	if prepare != nil {
+		if err := prepare(); err != nil {
+			return err
+		}
+	}
 
 	if u.fileConfig != nil {
 		staged := cloneConfig(u.fileConfig)
@@ -217,6 +227,7 @@ func (u *Unpackerr) putGeneral(response http.ResponseWriter, request *http.Reque
 		u.Passwords = expanded
 		u.RemnantAction = remnantAction(next.RemnantAction)
 		u.clampConfig()
+		u.publishAppliedGeneral()
 	})
 
 	return restart, err
@@ -251,14 +262,6 @@ func (u *Unpackerr) putWebserver(response http.ResponseWriter, request *http.Req
 
 	next.normalizeURLBase()
 
-	liveSnap := u.cloneLiveWebserver()
-	fileSnap := u.cloneStoredFileWebserver()
-
-	fileOnly := &WebServer{APIKeys: cloneAPIKeys(next.APIKeys)}
-	keepNamedAPIKeys(fileOnly, fileSnap)
-	dropEmptyAPIKeys(fileOnly)
-	keepNamedAPIKeys(&next, liveSnap, fileSnap)
-
 	omitted := next.UIPassword.Val() == ""
 
 	submitted, fromFile, err := u.prepareWebserverPassword(&next)
@@ -266,20 +269,51 @@ func (u *Unpackerr) putWebserver(response http.ResponseWriter, request *http.Req
 		return false, err
 	}
 
-	if err := next.validateAuth(); err != nil {
-		return false, err
-	}
+	var (
+		fileWeb *WebServer
+		restart bool
+	)
 
-	next.allow = MakeIPs(next.Upstreams)
-	restart := webserverRestartRequired(liveSnap, &next)
-	fileWeb := fileWebserverFromPut(&next, submitted, fromFile, omitted, fileSnap)
-	fileWeb.APIKeys = cloneAPIKeys(fileOnly.APIKeys)
+	err = u.commitPrepared(func() error {
+		var prepErr error
 
-	return restart, u.commitConfig(func(cfg *Config) {
+		fileWeb, restart, prepErr = u.prepareWebserverPut(&next, submitted, fromFile, omitted)
+
+		return prepErr
+	}, func(cfg *Config) {
 		cfg.Webserver = fileWeb
 	}, func() {
 		u.applyLiveWebserverAuth(&next)
 	})
+
+	return restart, err
+}
+
+func (u *Unpackerr) prepareWebserverPut(
+	next *WebServer,
+	submitted CryptPass,
+	fromFile, omitted bool,
+) (*WebServer, bool, error) {
+	liveSnap := u.cloneLiveWebserver()
+	fileSnap := u.fileWebserverLocked()
+	fileOnly := &WebServer{APIKeys: cloneAPIKeys(next.APIKeys)}
+	keepNamedAPIKeys(fileOnly, fileSnap)
+	dropEmptyAPIKeys(fileOnly)
+	keepNamedAPIKeys(next, liveSnap, fileSnap)
+
+	if omitted && liveSnap != nil {
+		next.UIPassword = liveSnap.UIPassword
+	}
+
+	if err := next.validateAuth(); err != nil {
+		return nil, false, err
+	}
+
+	next.allow = MakeIPs(next.Upstreams)
+	fileWeb := fileWebserverFromPut(next, submitted, fromFile, omitted, fileSnap)
+	fileWeb.APIKeys = cloneAPIKeys(fileOnly.APIKeys)
+
+	return fileWeb, webserverRestartRequired(liveSnap, next), nil
 }
 
 func webserverRestartRequired(cur, next *WebServer) bool {
@@ -388,9 +422,7 @@ func (u *Unpackerr) prepareWebserverPassword(next *WebServer) (CryptPass, bool, 
 	submitted := next.UIPassword
 	fromFile := strings.HasPrefix(submitted.Val(), filePrefix)
 
-	if submitted.Val() == "" && u.Webserver != nil {
-		next.UIPassword = u.uiPassword()
-
+	if submitted.Val() == "" {
 		return submitted, false, nil
 	}
 

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -135,11 +135,25 @@ func readJSONObject(response http.ResponseWriter, request *http.Request, dest an
 		return err
 	}
 
-	if bytes.Equal(bytes.TrimSpace(raw), []byte("{}")) {
+	if isEmptyJSONObject(raw) {
 		return errEmptyConfigSection
 	}
 
 	return unmarshalConfigJSON(raw, dest)
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+
+	return len(obj) == 0
 }
 
 func rejectNilPointers[T any](list []*T) error {
@@ -200,7 +214,7 @@ func (u *Unpackerr) putGeneral(response http.ResponseWriter, request *http.Reque
 		u.livePasswords = submittedPasswords
 		u.Passwords = expanded
 		u.RemnantAction = remnantAction(next.RemnantAction)
-		u.validateConfig()
+		u.clampConfig()
 	})
 }
 
@@ -209,7 +223,9 @@ func generalRestartRequired(cur *Config, next generalConfig) bool {
 		return true
 	}
 
-	return next.Interval != cur.Interval ||
+	return next.Debug != cur.Debug ||
+		next.Quiet != cur.Quiet ||
+		next.Interval != cur.Interval ||
 		next.StartDelay != cur.StartDelay ||
 		next.Progress != cur.Progress ||
 		next.LogQueues != cur.LogQueues ||
@@ -231,8 +247,13 @@ func (u *Unpackerr) putWebserver(response http.ResponseWriter, request *http.Req
 
 	next.normalizeURLBase()
 
-	prevFile := u.cloneStoredFileWebserver()
-	keepNamedAPIKeys(&next, u.Webserver, prevFile)
+	liveSnap := u.cloneLiveWebserver()
+	fileSnap := u.cloneStoredFileWebserver()
+
+	fileOnly := &WebServer{APIKeys: cloneAPIKeys(next.APIKeys)}
+	keepNamedAPIKeys(fileOnly, fileSnap)
+	dropEmptyAPIKeys(fileOnly)
+	keepNamedAPIKeys(&next, liveSnap, fileSnap)
 
 	omitted := next.UIPassword.Val() == ""
 
@@ -246,18 +267,15 @@ func (u *Unpackerr) putWebserver(response http.ResponseWriter, request *http.Req
 	}
 
 	next.allow = MakeIPs(next.Upstreams)
-	restart := webserverRestartRequired(u.Webserver, &next)
-	fileWeb := fileWebserverFromPut(&next, submitted, fromFile, omitted, prevFile)
+	restart := webserverRestartRequired(liveSnap, &next)
+	fileWeb := fileWebserverFromPut(&next, submitted, fromFile, omitted, fileSnap)
+	fileWeb.APIKeys = cloneAPIKeys(fileOnly.APIKeys)
 
-	if err := u.commitConfig(func(cfg *Config) {
+	return restart, u.commitConfig(func(cfg *Config) {
 		cfg.Webserver = fileWeb
-	}, func() {}); err != nil {
-		return false, err
-	}
-
-	u.applyLiveWebserverAuth(&next)
-
-	return restart, nil
+	}, func() {
+		u.applyLiveWebserverAuth(&next)
+	})
 }
 
 func webserverRestartRequired(cur, next *WebServer) bool {
@@ -294,8 +312,25 @@ func fileWebserverFromPut(
 	return cloned
 }
 
+func dropEmptyAPIKeys(web *WebServer) {
+	if web == nil {
+		return
+	}
+
+	out := make([]APIKey, 0, len(web.APIKeys))
+	for _, key := range web.APIKeys {
+		if strings.TrimSpace(key.Key) != "" {
+			out = append(out, key)
+		}
+	}
+
+	web.APIKeys = out
+}
+
 // keepNamedAPIKeys fills a blank apiKeys[].key from an existing key of the same
 // name so a redacted GET can round-trip without requiring PermAll.
+// Callers pass file snapshots first when persisting, and live then file when
+// applying runtime auth, so environment overlays never become the file value.
 func keepNamedAPIKeys(next *WebServer, sources ...*WebServer) {
 	if next == nil {
 		return
@@ -433,12 +468,12 @@ func (u *Unpackerr) putSonarr(response http.ResponseWriter, request *http.Reques
 		list[idx].Sonarr = sonarr.New(&list[idx].Config)
 	}
 
-	carrySonarrQueues(u.Sonarr, list)
-
 	return u.commitConfig(func(cfg *Config) {
 		cfg.Sonarr = fileList
 	}, func() {
+		carrySonarrQueues(u.Sonarr, list)
 		u.Sonarr = list
+		u.ensureWorkThreads(u.starrAppCount())
 	})
 }
 
@@ -462,12 +497,12 @@ func (u *Unpackerr) putRadarr(response http.ResponseWriter, request *http.Reques
 		list[idx].Radarr = radarr.New(&list[idx].Config)
 	}
 
-	carryRadarrQueues(u.Radarr, list)
-
 	return u.commitConfig(func(cfg *Config) {
 		cfg.Radarr = fileList
 	}, func() {
+		carryRadarrQueues(u.Radarr, list)
 		u.Radarr = list
+		u.ensureWorkThreads(u.starrAppCount())
 	})
 }
 
@@ -491,12 +526,12 @@ func (u *Unpackerr) putLidarr(response http.ResponseWriter, request *http.Reques
 		list[idx].Lidarr = lidarr.New(&list[idx].Config)
 	}
 
-	carryLidarrQueues(u.Lidarr, list)
-
 	return u.commitConfig(func(cfg *Config) {
 		cfg.Lidarr = fileList
 	}, func() {
+		carryLidarrQueues(u.Lidarr, list)
 		u.Lidarr = list
+		u.ensureWorkThreads(u.starrAppCount())
 	})
 }
 
@@ -520,12 +555,12 @@ func (u *Unpackerr) putReadarr(response http.ResponseWriter, request *http.Reque
 		list[idx].Readarr = readarr.New(&list[idx].Config)
 	}
 
-	carryReadarrQueues(u.Readarr, list)
-
 	return u.commitConfig(func(cfg *Config) {
 		cfg.Readarr = fileList
 	}, func() {
+		carryReadarrQueues(u.Readarr, list)
 		u.Readarr = list
+		u.ensureWorkThreads(u.starrAppCount())
 	})
 }
 
@@ -549,12 +584,12 @@ func (u *Unpackerr) putWhisparr(response http.ResponseWriter, request *http.Requ
 		list[idx].Radarr = radarr.New(&list[idx].Config)
 	}
 
-	carryRadarrQueues(u.Whisparr, list)
-
 	return u.commitConfig(func(cfg *Config) {
 		cfg.Whisparr = fileList
 	}, func() {
+		carryRadarrQueues(u.Whisparr, list)
 		u.Whisparr = list
+		u.ensureWorkThreads(u.starrAppCount())
 	})
 }
 
@@ -681,17 +716,12 @@ func (u *Unpackerr) putWebhooks(response http.ResponseWriter, request *http.Requ
 
 	fileList := cloneHookList(list)
 
-	if err := u.commitConfig(func(cfg *Config) {
+	return u.commitConfig(func(cfg *Config) {
 		cfg.Webhook = fileList
 	}, func() {
 		u.Webhook = list
-	}); err != nil {
-		return err
-	}
-
-	u.ensureHookWorker()
-
-	return nil
+		u.ensureHookWorker()
+	})
 }
 
 func (u *Unpackerr) putCmdhooks(response http.ResponseWriter, request *http.Request) error {
@@ -706,15 +736,10 @@ func (u *Unpackerr) putCmdhooks(response http.ResponseWriter, request *http.Requ
 
 	fileList := cloneHookList(list)
 
-	if err := u.commitConfig(func(cfg *Config) {
+	return u.commitConfig(func(cfg *Config) {
 		cfg.Cmdhook = fileList
 	}, func() {
 		u.Cmdhook = list
-	}); err != nil {
-		return err
-	}
-
-	u.ensureHookWorker()
-
-	return nil
+		u.ensureHookWorker()
+	})
 }

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -205,17 +205,21 @@ func (u *Unpackerr) putGeneral(response http.ResponseWriter, request *http.Reque
 	}
 
 	submittedPasswords := append(StringSlice(nil), next.Passwords...)
-	restart := generalRestartRequired(u.Config, next)
 
-	return restart, u.commitConfig(func(cfg *Config) {
+	var restart bool
+
+	err = u.commitConfig(func(cfg *Config) {
 		applyGeneral(cfg, next)
 	}, func() {
+		restart = generalRestartRequired(u.Config, next)
 		applyGeneral(u.Config, next)
 		u.livePasswords = submittedPasswords
 		u.Passwords = expanded
 		u.RemnantAction = remnantAction(next.RemnantAction)
 		u.clampConfig()
 	})
+
+	return restart, err
 }
 
 func generalRestartRequired(cur *Config, next generalConfig) bool {

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -313,6 +313,10 @@ func (u *Unpackerr) prepareWebserverPut(
 	fileWeb := fileWebserverFromPut(next, submitted, fromFile, omitted, fileSnap)
 	fileWeb.APIKeys = cloneAPIKeys(fileOnly.APIKeys)
 
+	if err := fileWeb.validateAuth(); err != nil {
+		return nil, false, err
+	}
+
 	return fileWeb, webserverRestartRequired(liveSnap, next), nil
 }
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -116,3 +116,62 @@ func TestConfigPutNeedsWritePerm(t *testing.T) {
 		t.Fatalf("readonly put %d", rec.Code)
 	}
 }
+
+func TestConfigPutWebserverFilepathPassword(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	passFile := filepath.Join(dir, "ui.pass")
+
+	if err := os.WriteFile(passFile, []byte("correct-horse\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	web.UIPassword = CryptPass(filePrefix + passFile)
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain(defaultUIUser, "correct-horse") {
+		t.Fatal("live password must expand filepath:")
+	}
+
+	stored := unpack.fileConfig.Webserver.UIPassword.Val()
+	if stored != filePrefix+passFile {
+		t.Fatalf("file snapshot must keep filepath:, got %q", stored)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(written), `filepath:`) {
+		t.Fatalf("config write dropped filepath:\n%s", written)
+	}
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -3,6 +3,7 @@ package unpackerr
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 	unpack := testAuthUnpackerr(t)
 	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
 	unpack.KeepHistory = 200
+	unpack.snapshotFileConfig()
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
@@ -45,6 +47,16 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 	if unpack.KeepHistory != 50 || !unpack.Config.Debug {
 		t.Fatalf("applied %+v debug %v", unpack.KeepHistory, unpack.Config.Debug)
 	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(written)
+	if !strings.Contains(text, "keep_history = 50") || !strings.Contains(text, "debug = true") {
+		t.Fatalf("fileConfig write missed PUT:\n%s", text)
+	}
 }
 
 func TestConfigPutSonarrValidates(t *testing.T) {
@@ -52,6 +64,7 @@ func TestConfigPutSonarrValidates(t *testing.T) {
 
 	unpack := testAuthUnpackerr(t)
 	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
@@ -71,6 +84,15 @@ func TestConfigPutSonarrValidates(t *testing.T) {
 
 	if len(unpack.Sonarr) != 1 || unpack.Sonarr[0].URL != "http://127.0.0.1:8989" {
 		t.Fatalf("sonarr %+v", unpack.Sonarr)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(written), "http://127.0.0.1:8989") {
+		t.Fatalf("sonarr PUT missed fileConfig:\n%s", written)
 	}
 }
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -1,0 +1,96 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigPutGeneralRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 200
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 50
+	general.Debug = true
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.KeepHistory != 50 || !unpack.Config.Debug {
+		t.Fatalf("applied %+v debug %v", unpack.KeepHistory, unpack.Config.Debug)
+	}
+}
+
+func TestConfigPutSonarrValidates(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	bad := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr",
+		`[{"url":"not-a-url","apiKey":"`+strings.Repeat("k", apiKeyMinLength)+`"}]`, withKey)
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("bad url %d %s", bad.Code, bad.Body.String())
+	}
+
+	good := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr",
+		`[{"url":"http://127.0.0.1:8989","apiKey":"`+strings.Repeat("k", apiKeyMinLength)+`","path":"/dl"}]`, withKey)
+	if good.Code != http.StatusOK {
+		t.Fatalf("good %d %s", good.Code, good.Body.String())
+	}
+
+	if len(unpack.Sonarr) != 1 || unpack.Sonarr[0].URL != "http://127.0.0.1:8989" {
+		t.Fatalf("sonarr %+v", unpack.Sonarr)
+	}
+}
+
+func TestConfigPutNeedsWritePerm(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	readKey := strings.Repeat("P", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"general": {Permissions: []string{PermReadConfig(SectionGeneral)}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "ro",
+		Key:   readKey,
+		Roles: []string{"general"},
+	})
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", `{}`, func(req *http.Request) {
+		req.Header.Set(headerAPIKey, readKey)
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("readonly put %d", rec.Code)
+	}
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -3,6 +3,7 @@ package unpackerr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,8 +53,8 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 		t.Fatalf("put %d %s", put.Code, put.Body.String())
 	}
 
-	if unpack.KeepHistory != 50 || !unpack.Config.Debug {
-		t.Fatalf("applied %+v debug %v", unpack.KeepHistory, unpack.Config.Debug)
+	if unpack.KeepHistory != 50 || unpack.applied().KeepHistory != 50 || !unpack.Config.Debug {
+		t.Fatalf("applied %+v snap %v debug %v", unpack.KeepHistory, unpack.applied().KeepHistory, unpack.Config.Debug)
 	}
 
 	if len(unpack.Items) != 0 {
@@ -814,7 +815,35 @@ func TestConfigPutSonarrDoesNotRacePoller(t *testing.T) {
 	wait.Wait()
 }
 
-func TestConfigGetDoesNotRacePut(t *testing.T) {
+type holdResponseWriter struct {
+	http.ResponseWriter
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *holdResponseWriter) hold() {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+}
+
+func (w *holdResponseWriter) WriteHeader(code int) {
+	w.hold()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *holdResponseWriter) Write(p []byte) (int, error) {
+	w.hold()
+
+	wrote, err := w.ResponseWriter.Write(p)
+	if err != nil {
+		return wrote, fmt.Errorf("write response: %w", err)
+	}
+
+	return wrote, nil
+}
+
+func TestConfigGetReleasesLockBeforeWrite(t *testing.T) {
 	t.Parallel()
 
 	unpack := testAuthUnpackerr(t)
@@ -822,7 +851,76 @@ func TestConfigGetDoesNotRacePut(t *testing.T) {
 	unpack.snapshotFileConfig()
 
 	admin := unpack.Webserver.adminAPIKey()
-	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+	hold := &holdResponseWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		started:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+
+	var finished sync.WaitGroup
+
+	finished.Go(func() {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/config/sonarr", nil)
+		req.Header.Set(headerAPIKey, admin)
+		unpack.Webserver.router.ServeHTTP(hold, req)
+	})
+
+	select {
+	case <-hold.started:
+	case <-time.After(2 * time.Second):
+		close(hold.release)
+		finished.Wait()
+		t.Fatal("GET never reached response write")
+	}
+
+	putBody := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+	putDone := make(chan int, 1)
+
+	go func() {
+		body := strings.NewReader(putBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/config/sonarr", body)
+		req.Header.Set(headerAPIKey, admin)
+
+		rec := httptest.NewRecorder()
+		unpack.Webserver.router.ServeHTTP(rec, req)
+
+		putDone <- rec.Code
+	}()
+
+	select {
+	case code := <-putDone:
+		if code != http.StatusOK {
+			close(hold.release)
+			finished.Wait()
+			t.Fatalf("PUT during GET write: %d", code)
+		}
+	case <-time.After(2 * time.Second):
+		close(hold.release)
+		finished.Wait()
+		t.Fatal("PUT blocked while GET held the response writer; configMu is still held across encode")
+	}
+
+	close(hold.release)
+	finished.Wait()
+}
+
+func TestAppliedGeneralDoesNotRacePut(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	unpack.publishAppliedGeneral()
+
+	admin := unpack.Webserver.adminAPIKey()
+	got := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/config/general", nil)
+	req.Header.Set(headerAPIKey, admin)
+	unpack.Webserver.router.ServeHTTP(got, req)
+
+	if got.Code != http.StatusOK {
+		t.Fatalf("get general %d %s", got.Code, got.Body.String())
+	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
 	defer cancel()
@@ -834,11 +932,10 @@ func TestConfigGetDoesNotRacePut(t *testing.T) {
 		defer wait.Done()
 
 		for ctx.Err() == nil {
-			for _, target := range []string{"/api/config/sonarr", "/api/config/sonarr/live", "/api/config/general"} {
-				req := httptest.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-				req.Header.Set(headerAPIKey, admin)
-				unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
-			}
+			body := strings.NewReader(got.Body.String())
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/general", body)
+			req.Header.Set(headerAPIKey, admin)
+			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
 		}
 	}()
 
@@ -846,9 +943,16 @@ func TestConfigGetDoesNotRacePut(t *testing.T) {
 		defer wait.Done()
 
 		for ctx.Err() == nil {
-			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/sonarr", strings.NewReader(body))
-			req.Header.Set(headerAPIKey, admin)
-			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+			snap := unpack.applied()
+			_ = snap.Activity
+			_ = snap.MaxRetries
+			_ = snap.KeepHistory
+			_ = snap.RemnantAction
+			_ = snap.Timeout
+			_ = snap.DeleteDelay
+			_ = snap.StartDelay
+			_ = snap.RetryDelay
+			_ = len(snap.Passwords)
 		}
 	}()
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -813,3 +813,44 @@ func TestConfigPutSonarrDoesNotRacePoller(t *testing.T) {
 
 	wait.Wait()
 }
+
+func TestConfigGetDoesNotRacePut(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	admin := unpack.Webserver.adminAPIKey()
+	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			for _, target := range []string{"/api/config/sonarr", "/api/config/sonarr/live", "/api/config/general"} {
+				req := httptest.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+				req.Header.Set(headerAPIKey, admin)
+				unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/sonarr", strings.NewReader(body))
+			req.Header.Set(headerAPIKey, admin)
+			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+		}
+	}()
+
+	wait.Wait()
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -56,6 +56,10 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 		t.Fatalf("applied %+v debug %v", unpack.KeepHistory, unpack.Config.Debug)
 	}
 
+	if len(unpack.Items) != 0 {
+		t.Fatalf("PUT resized history items: %+v", unpack.Items)
+	}
+
 	written, err := os.ReadFile(unpack.ConfigFile)
 	if err != nil {
 		t.Fatal(err)
@@ -201,6 +205,14 @@ func TestConfigPutRejectsUnknownAndEmptyJSON(t *testing.T) {
 
 	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", `{}`, key); rec.Code != http.StatusBadRequest {
 		t.Fatalf("empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", "{ }", key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("whitespace empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", "{\n}", key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("newline empty object %d %s", rec.Code, rec.Body.String())
 	}
 
 	if unpack.KeepHistory != 200 {
@@ -517,6 +529,205 @@ func TestConfigPutWebserverDoesNotRaceAuth(t *testing.T) {
 
 		for ctx.Err() == nil {
 			hit(http.MethodPut, "/api/config/webserver", body)
+		}
+	}()
+
+	wait.Wait()
+}
+
+func TestConfigPutDebugQuietRequiresRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.Config.Debug = false
+	unpack.Quiet = false
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.Debug = true
+	general.Quiet = true
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reply.RestartRequired {
+		t.Fatal("debug/quiet must require restart")
+	}
+
+	if !unpack.Config.Debug || !unpack.Quiet {
+		t.Fatal("debug/quiet must still apply live")
+	}
+}
+
+func TestConfigPutWebserverKeepsFileKeysOffLiveOverlay(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	fileKey, liveKey := splitFileAndLiveAdminKeys(t, unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	for idx := range web.APIKeys {
+		web.APIKeys[idx].Key = ""
+	}
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	assertFileAndLiveAdminKeys(t, unpack, fileKey, liveKey)
+}
+
+func splitFileAndLiveAdminKeys(t *testing.T, unpack *Unpackerr) (string, string) {
+	t.Helper()
+
+	fileKey := strings.Repeat("F", apiKeyMinLen)
+	liveKey := strings.Repeat("L", apiKeyMinLen)
+	unpack.Webserver.APIKeys = []APIKey{{
+		Name:  defaultAdminKeyName,
+		Key:   liveKey,
+		Roles: []string{RoleAdmin},
+	}}
+
+	if err := unpack.Webserver.validateAuth(); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.snapshotFileConfig()
+	unpack.fileConfig.Webserver.APIKeys = []APIKey{{
+		Name:  defaultAdminKeyName,
+		Key:   fileKey,
+		Roles: []string{RoleAdmin},
+	}}
+
+	return fileKey, liveKey
+}
+
+func assertFileAndLiveAdminKeys(t *testing.T, unpack *Unpackerr, fileKey, liveKey string) {
+	t.Helper()
+
+	if unpack.Webserver.adminAPIKey() != liveKey {
+		t.Fatal("live overlay key must remain the runtime secret")
+	}
+
+	if unpack.fileConfig.Webserver.APIKeys[0].Key != fileKey {
+		t.Fatalf("file key %q", unpack.fileConfig.Webserver.APIKeys[0].Key)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(written)
+	if strings.Contains(text, liveKey) {
+		t.Fatalf("live overlay leaked into the config file:\n%s", text)
+	}
+
+	if !strings.Contains(text, fileKey) {
+		t.Fatalf("file key missing from config file:\n%s", text)
+	}
+}
+
+func TestEnsureWorkThreadsGrowsWithApps(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.watchWorkThread()
+
+	if unpack.workThreads != 1 {
+		t.Fatalf("floor workers %d", unpack.workThreads)
+	}
+
+	unpack.Sonarr = []*SonarrConfig{{}, {}, {}}
+	unpack.ensureWorkThreads(unpack.starrAppCount())
+
+	if unpack.workThreads != 3 {
+		t.Fatalf("grown workers %d", unpack.workThreads)
+	}
+
+	unpack.ensureWorkThreads(1)
+
+	if unpack.workThreads != 3 {
+		t.Fatalf("pool shrank to %d", unpack.workThreads)
+	}
+}
+
+func TestConfigPutSonarrDoesNotRacePoller(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	unpack.watchWorkThread()
+
+	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			now := time.Now()
+			unpack.retrieveAppQueues(now)
+			unpack.checkQueueChanges(now)
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/sonarr", strings.NewReader(body))
+			req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
 		}
 	}()
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -582,6 +582,85 @@ func TestConfigPutDebugQuietRequiresRestart(t *testing.T) {
 	}
 }
 
+func TestConfigPutGeneralDoesNotRaceRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	admin := unpack.Webserver.adminAPIKey()
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, admin)
+	})
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	body := got.Body.String()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(4)
+
+	hit := func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/general", strings.NewReader(body))
+			req.Header.Set(headerAPIKey, admin)
+			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+		}
+	}
+
+	go hit()
+	go hit()
+	go hit()
+	go hit()
+
+	wait.Wait()
+}
+
+func TestConfigPutLidarrDoesNotRaceServerLookup(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	url := "http://127.0.0.1:8686"
+	body := `[{"url":"` + url + `","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+	admin := unpack.Webserver.adminAPIKey()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/api/config/lidarr", strings.NewReader(body))
+			req.Header.Set(headerAPIKey, admin)
+			unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			_ = unpack.lidarrServerByURL(url)
+		}
+	}()
+
+	wait.Wait()
+}
+
 func TestConfigPutWebserverKeepsFileKeysOffLiveOverlay(t *testing.T) {
 	t.Parallel()
 
@@ -702,6 +781,7 @@ func TestConfigPutSonarrDoesNotRacePoller(t *testing.T) {
 	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
 	unpack.snapshotFileConfig()
 	unpack.watchWorkThread()
+	unpack.forgotten = map[string]struct{}{"queued-title": {}}
 
 	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -24,6 +24,8 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 	unpack := testAuthUnpackerr(t)
 	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
 	unpack.KeepHistory = 200
+	unpack.Items = make([]string, trayHistory)
+	unpack.Items[0] = "queued"
 	unpack.snapshotFileConfig()
 
 	withKey := func(req *http.Request) {
@@ -57,7 +59,7 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 		t.Fatalf("applied %+v snap %v debug %v", unpack.KeepHistory, unpack.applied().KeepHistory, unpack.Config.Debug)
 	}
 
-	if len(unpack.Items) != 0 {
+	if len(unpack.Items) != trayHistory || unpack.Items[0] != "queued" {
 		t.Fatalf("PUT resized history items: %+v", unpack.Items)
 	}
 
@@ -69,6 +71,123 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 	text := string(written)
 	if !strings.Contains(text, "keep_history = 50") || !strings.Contains(text, "debug = true") {
 		t.Fatalf("fileConfig write missed PUT:\n%s", text)
+	}
+}
+
+func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 0
+	unpack.snapshotFileConfig()
+	unpack.publishAppliedGeneral()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 50
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.applied().KeepHistory != 50 {
+		t.Fatalf("applied keep_history %d", unpack.applied().KeepHistory)
+	}
+
+	if len(unpack.Items) != trayHistory {
+		t.Fatalf("tray items after enabling history: %d", len(unpack.Items))
+	}
+
+	unpack.updateHistory("queued")
+
+	if unpack.Items[0] != "queued" {
+		t.Fatalf("updateHistory after enable: %+v", unpack.Items)
+	}
+}
+
+func TestConfigPutCmdhookRejectsWhitespaceCommand(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodPut, "/api/config/cmdhooks", `[{"command":"   "}]`, withKey)
+	if got.Code != http.StatusBadRequest {
+		t.Fatalf("whitespace cmdhook %d %s", got.Code, got.Body.String())
+	}
+}
+
+func TestConfigPutWebserverRejectsFileKeyCollision(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	fileKey, liveKey := splitFileAndLiveAdminKeys(t, unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	for idx := range web.APIKeys {
+		web.APIKeys[idx].Key = ""
+	}
+
+	web.APIKeys = append(web.APIKeys, APIKey{
+		Name:  "extra",
+		Key:   fileKey,
+		Roles: []string{RoleAdmin},
+	})
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if put.Code != http.StatusBadRequest {
+		t.Fatalf("file key collision %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.adminAPIKey() != liveKey {
+		t.Fatal("rejected PUT mutated live key")
+	}
+
+	if unpack.fileConfig.Webserver.APIKeys[0].Key != fileKey {
+		t.Fatalf("rejected PUT mutated file key %q", unpack.fileConfig.Webserver.APIKeys[0].Key)
 	}
 }
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -1,12 +1,20 @@
 package unpackerr
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"golift.io/starr/sonarr"
 )
 
 func TestConfigPutGeneralRoundTrip(t *testing.T) {
@@ -174,4 +182,343 @@ func TestConfigPutWebserverFilepathPassword(t *testing.T) {
 	if !strings.Contains(string(written), `filepath:`) {
 		t.Fatalf("config write dropped filepath:\n%s", written)
 	}
+}
+
+func putKey(unpack *Unpackerr) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+}
+
+func TestConfigPutRejectsUnknownAndEmptyJSON(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 200
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", `{}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.KeepHistory != 200 {
+		t.Fatalf("empty put applied keep_history %d", unpack.KeepHistory)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general",
+		`{"debug":true,"notAField":1}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown field %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general",
+		`{"debug":true}{"debug":false}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("extra json %d %s", rec.Code, rec.Body.String())
+	}
+
+	admin := unpack.Webserver.adminAPIKey()
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		`{"error":"forbidden"}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("error object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.Webserver.adminAPIKey() != admin {
+		t.Fatal("forbidden payload wiped live admin key")
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", `[null]`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("nil sonarr %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestConfigPutFoldersValidationDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	body := `{"interval":"1s","buffer":1000,"folder":[{"path":"/rejected/path","maxBytes":"bogus"}]}`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/folders", body, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bogus folder %d %s", rec.Code, rec.Body.String())
+	}
+
+	if len(unpack.Folders) != 0 {
+		t.Fatalf("rejected folder went live: %+v", unpack.Folders)
+	}
+
+	if len(unpack.fileConfig.Folders) != 0 {
+		t.Fatalf("rejected folder staged: %+v", unpack.fileConfig.Folders)
+	}
+}
+
+func TestConfigPutWebhooksValidationDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	body := `[{"name":"broken"},{"name":"ok","url":"http://127.0.0.1:1/hook"}]`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/webhooks", body, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("broken webhook %d %s", rec.Code, rec.Body.String())
+	}
+
+	if len(unpack.Webhook) != 0 {
+		t.Fatalf("rejected webhooks went live: %+v", unpack.Webhook)
+	}
+}
+
+func TestConfigPutSonarrPreservesQueueAndPath(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	queued := &sonarr.Queue{}
+	app := &SonarrConfig{Queue: queued}
+	app.URL = "http://127.0.0.1:8989"
+	app.APIKey = strings.Repeat("k", apiKeyMinLength)
+	unpack.Sonarr = []*SonarrConfig{app}
+
+	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `","path":"/dl"}]`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", body, key); rec.Code != http.StatusOK {
+		t.Fatalf("first put %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.Sonarr[0].Queue != queued {
+		t.Fatal("PUT dropped last-known Starr queue")
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", body, key); rec.Code != http.StatusOK {
+		t.Fatalf("second put %d %s", rec.Code, rec.Body.String())
+	}
+
+	var hits int
+
+	for _, path := range unpack.Sonarr[0].Paths {
+		if path == "/dl" {
+			hits++
+		}
+	}
+
+	if hits != 1 {
+		t.Fatalf("path merged %d times: %+v", hits, unpack.Sonarr[0].Paths)
+	}
+}
+
+func TestConfigPutWebserverKeepsListenAndEmptyKeys(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+	admin := unpack.Webserver.adminAPIKey()
+	listen := unpack.Webserver.ListenAddr
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	web.ListenAddr = "127.0.0.1:9999"
+	if len(web.APIKeys) == 0 {
+		t.Fatal("expected admin key on GET")
+	}
+
+	web.APIKeys[0].Key = ""
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if unpack.Webserver.ListenAddr != listen {
+		t.Fatalf("live listen changed to %s", unpack.Webserver.ListenAddr)
+	}
+
+	if unpack.fileConfig.Webserver.ListenAddr != "127.0.0.1:9999" {
+		t.Fatalf("file listen %s", unpack.fileConfig.Webserver.ListenAddr)
+	}
+
+	if !reply.RestartRequired {
+		t.Fatal("listen change must require restart")
+	}
+
+	if unpack.Webserver.adminAPIKey() != admin {
+		t.Fatal("empty api key did not keep existing key by name")
+	}
+}
+
+func TestConfigPutURLBaseRoundTripNeedsNoRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.Webserver.URLBase = "/unpackerr/"
+	unpack.snapshotFileConfig()
+	unpack.fileConfig.Webserver.URLBase = "unpackerr"
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", got.Body.String(), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if reply.RestartRequired {
+		t.Fatal("normalized urlbase round trip must not require restart")
+	}
+}
+
+func TestConfigPutWriteFailureLeavesLiveUnchanged(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windows || os.Geteuid() == 0 {
+		t.Skip("cannot chmod a directory unwritable")
+	}
+
+	dir := t.TempDir()
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
+	unpack.KeepHistory = 200
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", got.Body.String(), key); rec.Code != http.StatusOK {
+		t.Fatalf("seed put %d %s", rec.Code, rec.Body.String())
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil { //nolint:gosec // need a read-only dir
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) //nolint:gosec // restore after the read-only test
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 12
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fail := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), key)
+	if fail.Code != http.StatusInternalServerError {
+		t.Fatalf("write fail %d %s", fail.Code, fail.Body.String())
+	}
+
+	if unpack.KeepHistory != 200 {
+		t.Fatalf("live keep_history after write fail: %d", unpack.KeepHistory)
+	}
+}
+
+func TestWatchWorkThreadStartsWithoutApps(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.watchWorkThread()
+
+	done := make(chan struct{})
+
+	go func() {
+		unpack.workChan <- []func(){func() { close(done) }}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retrieveAppQueues would hang: no workChan consumer")
+	}
+}
+
+func TestConfigPutWebserverDoesNotRaceAuth(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	body := got.Body.String()
+	admin := unpack.Webserver.adminAPIKey()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	hit := func(method, target, payload string) {
+		var reader io.Reader
+		if payload != "" {
+			reader = strings.NewReader(payload)
+		}
+
+		req := httptest.NewRequestWithContext(ctx, method, target, reader)
+		req.Header.Set(headerAPIKey, admin)
+		unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			hit(http.MethodGet, "/api/auth/me", "")
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			hit(http.MethodPut, "/api/config/webserver", body)
+		}
+	}()
+
+	wait.Wait()
 }

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -93,18 +93,26 @@ type eventData struct {
 }
 
 func (u *Unpackerr) validateFolders() error {
-	for idx := range u.Folders {
-		if u.Folders[idx].DeleteAfter == nil {
+	return validateFolderList(u.Folders)
+}
+
+func validateFolderList(folders []*FolderConfig) error {
+	for idx := range folders {
+		if folders[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		if folders[idx].DeleteAfter == nil {
 			// If delete after wasn't set, then set it to 10 minutes.
-			u.Folders[idx].DeleteAfter = &cnfg.Duration{Duration: defaultFolderDelete}
+			folders[idx].DeleteAfter = &cnfg.Duration{Duration: defaultFolderDelete}
 		}
 
-		n, _, err := parseOptionalMaxBytes(u.Folders[idx].MaxBytes)
+		n, _, err := parseOptionalMaxBytes(folders[idx].MaxBytes)
 		if err != nil {
-			return fmt.Errorf("folder %s: %w", u.Folders[idx].Path, err)
+			return fmt.Errorf("folder %s: %w", folders[idx].Path, err)
 		}
 
-		u.Folders[idx].maxBytes = n
+		folders[idx].maxBytes = n
 	}
 
 	return nil

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -376,7 +376,7 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	// extract it.
 	queueSize, err := u.Extract(&xtractr.Xtract{
 		Password:         u.getPasswordFromPath(name),
-		Passwords:        u.Passwords,
+		Passwords:        u.applied().Passwords,
 		Name:             name,
 		Path:             name,
 		ExcludeSuffix:    exclude,
@@ -573,7 +573,7 @@ func (u *Unpackerr) finishFolderRemnants(folder *Folder, resp *xtractr.Response,
 		return
 	}
 
-	if remnantAction(u.RemnantAction) == "off" {
+	if remnantAction(u.applied().RemnantAction) == "off" {
 		folder.noRetry = true
 	}
 
@@ -716,12 +716,12 @@ func (f *Folders) saveEvent(event *eventData, dirPath string, now time.Time) {
 func (u *Unpackerr) checkFolderStats(now time.Time) {
 	for name, folder := range u.folders.Folders {
 		switch elapsed := now.Sub(folder.updated); {
-		case WAITING == folder.status && elapsed >= u.StartDelay.Duration:
+		case WAITING == folder.status && elapsed >= u.applied().StartDelay:
 			// The folder hasn't been written to in a while, extract it.
 			u.extractTrackedItem(name, folder, now)
 		case EXTRACTEDNOTHING == folder.status:
 			// Wait until this item hasn't been touched for a while, so it doesn't re-queue.
-			if now.Sub(folder.updated) > u.StartDelay.Duration {
+			if now.Sub(folder.updated) > u.applied().StartDelay {
 				// Ignore "no compressed files" errors for folders.
 				u.lockHistory()
 				delete(u.Map, name)
@@ -734,7 +734,7 @@ func (u *Unpackerr) checkFolderStats(now time.Time) {
 			u.unlockHistory()
 			delete(u.folders.Folders, name)
 			u.Printf("[Folder] Remnant left in place (remnant_action=off), giving up: %s", name)
-		case EXTRACTFAILED == folder.status && elapsed >= u.RetryDelay.Duration &&
+		case EXTRACTFAILED == folder.status && elapsed >= u.applied().RetryDelay &&
 			folder.retries < u.maxRetries():
 			u.lockHistory()
 			u.Retries++

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -129,7 +129,7 @@ func (u *Unpackerr) extractCompletedDownloads(now time.Time) {
 // extractCompletedDownload checks if a completed starr download needs to be queued for extraction.
 // This is called by extractCompletedDownloads() via the main routine in start.go.
 func (u *Unpackerr) extractCompletedDownload(name string, now time.Time, item *Extract) {
-	if d := u.StartDelay.Duration - now.Sub(item.Updated); d > time.Second { // wiggle room.
+	if d := u.applied().StartDelay - now.Sub(item.Updated); d > time.Second { // wiggle room.
 		u.Printf("[%s] Waiting for Start Delay: %v (%v remains)", item.App, name, d.Round(time.Second))
 		return
 	}
@@ -167,7 +167,7 @@ func (u *Unpackerr) extractCompletedDownload(name string, now time.Time, item *E
 
 	queueSize, _ := u.Extract(&xtractr.Xtract{
 		Password:       u.getPasswordFromPath(item.Path),
-		Passwords:      u.Passwords,
+		Passwords:      u.applied().Passwords,
 		Name:           name,
 		Path:           item.Path,
 		ExcludeSuffix:  xtractr.AllExcept(archiveTypes...),
@@ -243,7 +243,7 @@ func (u *Unpackerr) checkExtractDone(now time.Time) {
 		case item.Status == EXTRACTFAILED && item.NoRetry:
 			// Stay EXTRACTFAILED. DELETED is > IMPORTED, so checkQueueChanges
 			// would bounce a still-completed Starr item back to WAITING.
-		case item.Status == EXTRACTFAILED && elapsed >= u.RetryDelay.Duration &&
+		case item.Status == EXTRACTFAILED && elapsed >= u.applied().RetryDelay &&
 			item.Retries < u.maxRetries():
 			u.Retries++
 			item.Retries++
@@ -350,7 +350,7 @@ func (u *Unpackerr) handleXtractrCallback(resp *xtractr.Response) { //nolint:fun
 		item.Resp = resp
 		u.Printf("[%s] Cleared interrupted-extraction remnant(s), restarting extraction: %s", item.App, resp.X.Name)
 	case remnants:
-		if remnantAction(u.RemnantAction) == "off" {
+		if remnantAction(u.applied().RemnantAction) == "off" {
 			item.NoRetry = true
 		}
 

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -44,7 +44,7 @@ func (h *History) rUnlockHistory() {
 
 // This is called every time an item is queued.
 func (u *Unpackerr) updateHistory(item string) {
-	if u.KeepHistory == 0 {
+	if u.applied().KeepHistory == 0 {
 		return
 	}
 

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -49,22 +49,26 @@ func (u *Unpackerr) updateHistory(item string) {
 	}
 
 	if ui.HasGUI() && item != "" {
-		u.menu[histNone].Hide()
+		if none := u.menu[histNone]; none != nil {
+			none.Hide()
+		}
 	}
 
 	u.Items[0] = item
 
 	// Do not process 0; this isn't an `intrange`.
 	for idx := len(u.Items) - 1; idx > 0; idx-- {
-		// u.History.Items is a slice with a set (identical) length and capacity.
-		switch u.Items[idx] = u.Items[idx-1]; {
-		case !ui.HasGUI():
+		u.Items[idx] = u.Items[idx-1]
+		menu := u.menu[hist+strconv.Itoa(idx)]
+
+		switch {
+		case !ui.HasGUI() || menu == nil:
 			continue
 		case u.Items[idx] != "":
-			u.menu[hist+strconv.Itoa(idx)].SetTitle(u.Items[idx])
-			u.menu[hist+strconv.Itoa(idx)].Show()
+			menu.SetTitle(u.Items[idx])
+			menu.Show()
 		default:
-			u.menu[hist+strconv.Itoa(idx)].Hide()
+			menu.Hide()
 		}
 	}
 }

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -44,7 +44,7 @@ func (h *History) rUnlockHistory() {
 
 // This is called every time an item is queued.
 func (u *Unpackerr) updateHistory(item string) {
-	if u.applied().KeepHistory == 0 {
+	if u.applied().KeepHistory == 0 || len(u.Items) == 0 {
 		return
 	}
 

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -82,7 +82,7 @@ func (u *Unpackerr) historyFilePath() string {
 }
 
 func (u *Unpackerr) loadHistory() {
-	if u.KeepHistory == 0 {
+	if u.applied().KeepHistory == 0 {
 		return
 	}
 
@@ -91,7 +91,8 @@ func (u *Unpackerr) loadHistory() {
 	}
 
 	if u.histPath == "" {
-		u.Printf("[Unpackerr] History file disabled; keep_history=%d but no log, config, or home path", u.KeepHistory)
+		u.Printf("[Unpackerr] History file disabled; keep_history=%d but no log, config, or home path",
+			u.applied().KeepHistory)
 
 		return
 	}
@@ -99,7 +100,7 @@ func (u *Unpackerr) loadHistory() {
 	records := u.readHistoryRecords()
 	trimmed := false
 
-	if limit := int(u.KeepHistory); limit > 0 && len(records) > limit {
+	if limit := int(u.applied().KeepHistory); limit > 0 && len(records) > limit {
 		records = records[len(records)-limit:]
 		trimmed = true
 	}
@@ -198,7 +199,7 @@ func readBoundedLine(reader *bufio.Reader, maxLen int) ([]byte, error) {
 }
 
 func (u *Unpackerr) maybeRecordHistory(itemID string, item *Extract) {
-	if item == nil || u.KeepHistory == 0 || !item.Status.isDurableHistory() {
+	if item == nil || u.applied().KeepHistory == 0 || !item.Status.isDurableHistory() {
 		return
 	}
 
@@ -282,7 +283,7 @@ func (u *Unpackerr) upsertHistory(rec HistoryRecord) {
 
 	u.records = append(u.records, rec)
 
-	if limit := int(u.KeepHistory); limit > 0 && len(u.records) > limit {
+	if limit := int(u.applied().KeepHistory); limit > 0 && len(u.records) > limit {
 		u.records = u.records[len(u.records)-limit:]
 	}
 

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -76,8 +76,10 @@ func (u *Unpackerr) getLidarrQueue(server *LidarrConfig, start time.Time) {
 	}
 
 	// Only update if there was not an error fetching.
+	u.configMu.Lock()
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Lidarr, server.URL, nil)
+	u.configMu.Unlock()
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Lidarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Lidarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -81,7 +81,7 @@ func (u *Unpackerr) getLidarrQueue(server *LidarrConfig, start time.Time) {
 	u.configMu.Unlock()
 	u.saveQueueMetrics(queue.TotalRecords, start, starr.Lidarr, server.URL, nil)
 
-	if !u.Activity || queue.TotalRecords > 0 {
+	if !u.applied().Activity || queue.TotalRecords > 0 {
 		u.Printf("[Lidarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))
 	}
 }

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -152,8 +152,11 @@ func (u *Unpackerr) haveLidarrQitem(name string) bool {
 
 // lidarrServerByURL returns the Lidarr server config that matches the given URL, or nil.
 func (u *Unpackerr) lidarrServerByURL(url string) *LidarrConfig {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
 	for _, server := range u.Lidarr {
-		if server.URL == url {
+		if server != nil && server.URL == url {
 			return server
 		}
 	}

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -475,6 +475,10 @@ func (u *Unpackerr) cloneStoredFileWebserver() *WebServer {
 	u.configMu.RLock()
 	defer u.configMu.RUnlock()
 
+	return u.fileWebserverLocked()
+}
+
+func (u *Unpackerr) fileWebserverLocked() *WebServer {
 	if u.fileConfig == nil || u.fileConfig.Webserver == nil {
 		return nil
 	}

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -457,15 +457,27 @@ func (u *Unpackerr) cloneLiveWebserver() *WebServer {
 	return cloneWebserver(u.Webserver)
 }
 
-// cloneFileWebserver copies the on-disk webserver snapshot under the same mutex
-// that syncFileUIPassword uses, so GET /api/config/webserver cannot race the tray.
+// cloneFileWebserver copies the on-disk webserver snapshot under configMu so
+// GET /api/config/webserver cannot race a PUT or the tray persist path.
 func (u *Unpackerr) cloneFileWebserver() *WebServer {
-	if u == nil || u.fileConfig == nil || u.fileConfig.Webserver == nil {
-		return u.cloneLiveWebserver()
+	if cloned := u.cloneStoredFileWebserver(); cloned != nil {
+		return cloned
 	}
 
-	u.uiPassMu.RLock()
-	defer u.uiPassMu.RUnlock()
+	return u.cloneLiveWebserver()
+}
+
+func (u *Unpackerr) cloneStoredFileWebserver() *WebServer {
+	if u == nil {
+		return nil
+	}
+
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
+	if u.fileConfig == nil || u.fileConfig.Webserver == nil {
+		return nil
+	}
 
 	return cloneWebserver(u.fileConfig.Webserver)
 }

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -67,8 +67,10 @@ func (u *Unpackerr) getRadarrQueue(server *RadarrConfig, start time.Time) {
 	}
 
 	// Only update if there was not an error fetching.
+	u.configMu.Lock()
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Radarr, server.URL, nil)
+	u.configMu.Unlock()
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Radarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Radarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -72,7 +72,7 @@ func (u *Unpackerr) getRadarrQueue(server *RadarrConfig, start time.Time) {
 	u.configMu.Unlock()
 	u.saveQueueMetrics(queue.TotalRecords, start, starr.Radarr, server.URL, nil)
 
-	if !u.Activity || queue.TotalRecords > 0 {
+	if !u.applied().Activity || queue.TotalRecords > 0 {
 		u.Printf("[Radarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))
 	}
 }

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -67,8 +67,10 @@ func (u *Unpackerr) getReadarrQueue(server *ReadarrConfig, start time.Time) {
 	}
 
 	// Only update if there was not an error fetching.
+	u.configMu.Lock()
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Readarr, server.URL, nil)
+	u.configMu.Unlock()
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Readarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Readarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -72,7 +72,7 @@ func (u *Unpackerr) getReadarrQueue(server *ReadarrConfig, start time.Time) {
 	u.configMu.Unlock()
 	u.saveQueueMetrics(queue.TotalRecords, start, starr.Readarr, server.URL, nil)
 
-	if !u.Activity || queue.TotalRecords > 0 {
+	if !u.applied().Activity || queue.TotalRecords > 0 {
 		u.Printf("[Readarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))
 	}
 }

--- a/pkg/unpackerr/remnants.go
+++ b/pkg/unpackerr/remnants.go
@@ -243,7 +243,7 @@ func (u *Unpackerr) handleRemnants(
 		return 0, false
 	}
 
-	if remnantAction(u.RemnantAction) == "off" {
+	if remnantAction(u.applied().RemnantAction) == "off" {
 		for _, dest := range remnants {
 			u.Printf("Interrupted-extraction remnant left in place (remnant_action=off): %s", dest)
 		}
@@ -331,7 +331,7 @@ func (u *Unpackerr) clearRemnant(dest string) bool {
 		return false
 	}
 
-	if remnantAction(u.RemnantAction) == "delete" {
+	if remnantAction(u.applied().RemnantAction) == "delete" {
 		remove := os.Remove
 		if info.IsDir() {
 			remove = os.RemoveAll

--- a/pkg/unpackerr/remnants.go
+++ b/pkg/unpackerr/remnants.go
@@ -36,13 +36,21 @@ func remnantAction(s string) string {
 	}
 }
 
-func (u *Unpackerr) validateRemnantAction() error {
-	s := strings.TrimSpace(u.RemnantAction)
-	if s != "" && remnantAction(s) != strings.ToLower(s) {
-		return fmt.Errorf("%w: %q (want rename, delete, or off)", ErrInvalidRemnantAction, u.RemnantAction)
+func remnantActionError(s string) error {
+	trimmed := strings.TrimSpace(s)
+	if trimmed != "" && remnantAction(trimmed) != strings.ToLower(trimmed) {
+		return fmt.Errorf("%w: %q (want rename, delete, or off)", ErrInvalidRemnantAction, s)
 	}
 
-	u.RemnantAction = remnantAction(s)
+	return nil
+}
+
+func (u *Unpackerr) validateRemnantAction() error {
+	if err := remnantActionError(u.RemnantAction); err != nil {
+		return err
+	}
+
+	u.RemnantAction = remnantAction(u.RemnantAction)
 
 	return nil
 }

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -67,8 +67,10 @@ func (u *Unpackerr) getSonarrQueue(server *SonarrConfig, start time.Time) {
 	}
 
 	// Only update if there was not an error fetching.
+	u.configMu.Lock()
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Sonarr, server.URL, nil)
+	u.configMu.Unlock()
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Sonarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Sonarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -72,7 +72,7 @@ func (u *Unpackerr) getSonarrQueue(server *SonarrConfig, start time.Time) {
 	u.configMu.Unlock()
 	u.saveQueueMetrics(queue.TotalRecords, start, starr.Sonarr, server.URL, nil)
 
-	if !u.Activity || queue.TotalRecords > 0 {
+	if !u.applied().Activity || queue.TotalRecords > 0 {
 		u.Printf("[Sonarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))
 	}
 }

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -81,7 +81,9 @@ type Unpackerr struct {
 	menu             map[string]ui.MenuItem
 	fileConfig       *Config      // on-disk shape (filepath: values). Config is the live expanded copy.
 	livePasswords    StringSlice  // post-env, pre-expansion; GET /live uses this
-	configMu         sync.RWMutex // fileConfig and live Starr/folder/hook slices (PUT vs poller)
+	configMu         sync.RWMutex // fileConfig, live Starr/folder/hook slices, and Starr Queue pointers
+	workThreadMu     sync.Mutex
+	workThreads      int
 	hookOnce         sync.Once
 	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
 	uiPasswordNotice string

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
@@ -82,6 +83,7 @@ type Unpackerr struct {
 	fileConfig       *Config      // on-disk shape (filepath: values). Config is the live expanded copy.
 	livePasswords    StringSlice  // post-env, pre-expansion; GET /live uses this
 	configMu         sync.RWMutex // fileConfig, live Starr/folder/hook slices, and Starr Queue pointers
+	rtGeneral        atomic.Pointer[appliedGeneral]
 	workThreadMu     sync.Mutex
 	workThreads      int
 	hookOnce         sync.Once
@@ -451,11 +453,12 @@ func (u *Unpackerr) Run() {
 }
 
 func (u *Unpackerr) maxRetries() uint {
-	if u.MaxRetries == 0 {
+	n := u.applied().MaxRetries
+	if n == 0 {
 		return defaultMaxRetries
 	}
 
-	return u.MaxRetries
+	return n
 }
 
 var errInvalidMaxBytes = errors.New("invalid max_bytes")

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -81,7 +81,9 @@ type Unpackerr struct {
 	menu             map[string]ui.MenuItem
 	fileConfig       *Config      // on-disk shape (filepath: values). Config is the live expanded copy.
 	livePasswords    StringSlice  // post-env, pre-expansion; GET /live uses this
-	uiPassMu         sync.RWMutex // guards Webserver.UIPassword
+	configMu         sync.RWMutex // fileConfig and live Starr/folder/hook slices (PUT vs poller)
+	hookOnce         sync.Once
+	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
 	uiPasswordNotice string
 	uiPasswordGenErr error
 	configWriteErr   error
@@ -225,9 +227,7 @@ func Start() error {
 		DirMode:  os.FileMode(dirMode),
 	})
 
-	if len(unpackerr.Webhook) > 0 || len(unpackerr.Cmdhook) > 0 {
-		go unpackerr.watchCmdAndWebhooks()
-	}
+	unpackerr.ensureHookWorker()
 
 	go unpackerr.watchDeleteChannel()
 
@@ -350,6 +350,12 @@ func dirIsEmpty(path string) bool {
 	_, err = dir.Readdirnames(1)
 
 	return err == io.EOF //nolint:errorlint // this is still correct.
+}
+
+func (u *Unpackerr) ensureHookWorker() {
+	u.hookOnce.Do(func() {
+		go u.watchCmdAndWebhooks()
+	})
 }
 
 func (u *Unpackerr) watchCmdAndWebhooks() {

--- a/pkg/unpackerr/tray.go
+++ b/pkg/unpackerr/tray.go
@@ -152,7 +152,7 @@ func (u *Unpackerr) makeHistoryChannels() {
 	u.menu[histNone] = ui.WrapMenu(history.AddSubMenuItem("-- there is no history --", "nothing has been queued yet"))
 	u.menu[histNone].Disable()
 
-	if u.KeepHistory == 0 {
+	if u.applied().KeepHistory == 0 {
 		u.menu[histNone].SetTitle("-- history disabled --")
 		u.menu[histNone].SetTooltip("history is disabled in the config")
 	}

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -137,13 +137,13 @@ func (u *Unpackerr) runAllHooks(item *Extract) {
 		}
 	}
 
-	for _, hook := range u.Webhook {
+	for _, hook := range u.hookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
 			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
 		}
 	}
 
-	for _, hook := range u.Cmdhook {
+	for _, hook := range u.cmdhookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
 			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
 		}
@@ -220,43 +220,65 @@ func (w *WebhookConfig) send(ctx context.Context, body io.Reader) ([]byte, error
 	return reply, nil
 }
 
-func (u *Unpackerr) validateWebhook() error { //nolint:cyclop
-	for idx := range u.Webhook {
-		u.Webhook[idx].Command = ""
+func (u *Unpackerr) hookList() []*WebhookConfig {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
 
-		if u.Webhook[idx].URL == "" {
+	return u.Webhook
+}
+
+func (u *Unpackerr) cmdhookList() []*WebhookConfig {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
+	return u.Cmdhook
+}
+
+func (u *Unpackerr) validateWebhook() error {
+	return u.validateWebhookList(u.Webhook)
+}
+
+func (u *Unpackerr) validateWebhookList(list []*WebhookConfig) error { //nolint:cyclop
+	for idx := range list {
+		if list[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		list[idx].Command = ""
+
+		if list[idx].URL == "" {
 			return ErrWebhookNoURL
 		}
 
-		if u.Webhook[idx].Name == "" {
-			u.Webhook[idx].Name = u.Webhook[idx].URL
+		if list[idx].Name == "" {
+			list[idx].Name = list[idx].URL
 		}
 
-		if u.Webhook[idx].Nickname == "" && u.Webhook[idx].TmplPath == "" &&
-			!strings.Contains(u.Webhook[idx].URL, "pushover.net") {
-			u.Webhook[idx].Nickname = "Unpackerr"
+		if list[idx].Nickname == "" && list[idx].TmplPath == "" &&
+			!strings.Contains(list[idx].URL, "pushover.net") {
+			list[idx].Nickname = "Unpackerr"
 		}
 
-		if u.Webhook[idx].CType == "" {
-			u.Webhook[idx].CType = "application/json"
-			if strings.Contains(u.Webhook[idx].URL, "pushover.net") {
-				u.Webhook[idx].CType = "application/x-www-form-urlencoded"
+		if list[idx].CType == "" {
+			list[idx].CType = "application/json"
+			if strings.Contains(list[idx].URL, "pushover.net") {
+				list[idx].CType = "application/x-www-form-urlencoded"
 			}
 		}
 
-		if u.Webhook[idx].Timeout.Duration == 0 {
-			u.Webhook[idx].Timeout.Duration = u.Timeout.Duration
+		if list[idx].Timeout.Duration == 0 {
+			list[idx].Timeout.Duration = u.Timeout.Duration
 		}
 
-		if len(u.Webhook[idx].Events) == 0 {
-			u.Webhook[idx].Events = []ExtractStatus{WAITING}
+		if len(list[idx].Events) == 0 {
+			list[idx].Events = []ExtractStatus{WAITING}
 		}
 
-		if u.Webhook[idx].client == nil {
-			u.Webhook[idx].client = &http.Client{
-				Timeout: u.Webhook[idx].Timeout.Duration,
+		if list[idx].client == nil {
+			list[idx].client = &http.Client{
+				Timeout: list[idx].Timeout.Duration,
 				Transport: &http.Transport{TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: u.Webhook[idx].IgnoreSSL, //nolint:gosec
+					InsecureSkipVerify: list[idx].IgnoreSSL, //nolint:gosec
 				}},
 			}
 		}
@@ -343,7 +365,11 @@ func (w *WebhookConfig) HasEvent(e ExtractStatus) bool {
 func (u *Unpackerr) WebhookCounts() (uint, uint) {
 	var total, fails uint
 
-	for _, hook := range u.Webhook {
+	for _, hook := range u.hookList() {
+		if hook == nil {
+			continue
+		}
+
 		posts, failures := hook.Counts()
 		total += posts
 		fails += failures

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -267,7 +267,7 @@ func (u *Unpackerr) validateWebhookList(list []*WebhookConfig) error { //nolint:
 		}
 
 		if list[idx].Timeout.Duration == 0 {
-			list[idx].Timeout.Duration = u.Timeout.Duration
+			list[idx].Timeout.Duration = u.applied().Timeout
 		}
 
 		if len(list[idx].Events) == 0 {

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -194,7 +194,7 @@ func Index(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 // under specific circumstances.
 func (u *Unpackerr) fixForwardedFor(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:varnamelen
-		if x := r.Header.Get("X-Forwarded-For"); x == "" || !u.Webserver.allow.Contains(r.RemoteAddr) {
+		if x := r.Header.Get("X-Forwarded-For"); x == "" || !u.webAllowContains(r.RemoteAddr) {
 			r.Header.Set("X-Forwarded-For",
 				strings.Trim(r.RemoteAddr[:strings.LastIndex(r.RemoteAddr, ":")], "[]"))
 		} else if l := strings.LastIndexAny(x, ", "); l != -1 {

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -80,7 +80,7 @@ func (u *Unpackerr) getWhisparrQueue(server *RadarrConfig, start time.Time) {
 	u.configMu.Unlock()
 	u.saveQueueMetrics(queue.TotalRecords, start, starr.Whisparr, server.URL, nil)
 
-	if !u.Activity || queue.TotalRecords > 0 {
+	if !u.applied().Activity || queue.TotalRecords > 0 {
 		u.Printf("[Whisparr] Updated (%s): %d Items Queued, %d Retrieved",
 			server.URL, queue.TotalRecords, len(queue.Records))
 	}

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -75,8 +75,10 @@ func (u *Unpackerr) getWhisparrQueue(server *RadarrConfig, start time.Time) {
 	}
 
 	// Only update if there was not an error fetching.
+	u.configMu.Lock()
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Whisparr, server.URL, nil)
+	u.configMu.Unlock()
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Whisparr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Whisparr] Updated (%s): %d Items Queued, %d Retrieved",


### PR DESCRIPTION
## Why

Settings pages need to save one section, persist the whole TOML, and reload only that subsystem so in-flight extracts are not cancelled.

## What

- `PUT /api/config/{section}` with `write:config:{section}`. Body replaces the section (file GET then PUT).
- Decode uses `DisallowUnknownFields`, a 1 MiB cap, and a trailing-JSON check. Empty objects (`{}`, `{ }`, `{\n}`) and `null` return 400. Arrays may be `[]` (clear); `[null]` is 400.
- Validate a clone first. Atomic-write the staged file snapshot, then publish live. A write 500 leaves runtime unchanged. Env-only (no config path) still applies live. `writeConfigFile` holds exclusive `configMu` through render/write.
- Starr lists rebuild clients and leave `History.Map` alone. Invalid URLs/keys are rejected (unlike startup skip). Last-known `Queue` is carried by URL+API key under `configMu`; pollers publish `Queue` under the same lock. `path` is merged into `paths` without duplicates. The worker pool grows (never shrinks) when apps are added.
- Webhooks/cmdhooks validate (including HTTP clients) before publish. The hook worker starts with `sync.Once` so the first hook PUT is not a dead channel.
- Webserver keys, roles, password, and upstreams apply in place on the live object under `uiPassMu`, inside `commitConfig` so file and live stay ordered. `listen_addr` / `urlbase` / TLS / metrics / pprof / HTTP log settings stay on the running server and set `restartRequired`. Empty `apiKeys[].key` keeps the file snapshot secret for disk and the live secret for runtime, so env overlays are not written back.
- General applies immediately without resizing tray `History.Items`. Interval, start delay, progress, log_queues, parallel, logging (`debug`/`quiet`/files), and file/dir modes set `restartRequired`.
- Folders always set `restartRequired` (watcher restart would leak the old poller).
- Reply: `{"status":"ok","restartRequired":bool}`. Missing config file is not an error (env-only).

Made with [Cursor](https://cursor.com)