### PR TITLE
Add per-section PUT /api/config/{section} with main-loop apply and idle restart

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,13 @@ in mind; the items below have been raised and rejected before.
 - `filepath:` values are kept as written in `fileConfig` and expanded on the live
   copy only (`expandFilepaths`). That is intentional for every section.
 
+## Tests
+
+- Do not force a write failure with a read-only directory. The container image
+  runs as root, which ignores the permission bits, and Windows ignores them
+  outright. Use `blockedPath`, which puts the target under a regular file so
+  the write fails with ENOTDIR for every user and platform.
+
 ## Config PUT
 
 - Sections that the loop cannot re-apply in place return `restartRequired: true`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,42 @@
+# Review guidance for Unpackerr
+
+Unpackerr is a single-process daemon. One goroutine in `Run()` (`pkg/unpackerr/start.go`)
+owns the live `Config`, the queue map, and the folder tracker. HTTP handlers validate
+input and hand mutations to that goroutine through `onMainLoop`. Review with that model
+in mind; the items below have been raised and rejected before.
+
+## Concurrency
+
+- Live `Config` fields are read and written only on the main loop. Do not ask for a
+  mutex around `u.StartDelay`, `u.Passwords`, `u.Sonarr`, and similar. If a new reader
+  runs on another goroutine, route it through `onMainLoop` instead.
+- `retrieveAppQueues` does not need to snapshot the app lists. A config PUT applies on
+  the same goroutine, which is parked in `wait.Wait()` until every poll returns.
+- `syncFileUIPassword` is not a lock-order inversion. `uiPassword()` releases
+  `uiPassMu` before `configMu` is taken.
+- Two administrators saving config at the same instant is not a design target.
+  Do not propose snapshot-and-merge logic whose only purpose is concurrent PUTs.
+- `History.mu`, `histMu`, `configMu`, and `uiPassMu` each guard one thing for HTTP
+  readers. Do not suggest adding a fifth lock; suggest moving the work to the main loop.
+
+## Validation and input
+
+- Starr URLs are checked for an `http://` or `https://` prefix, matching startup.
+  Do not request `url.Parse` or a non-empty host.
+- The history JSONL is written by this process, capped at `keep_history`, and read
+  with `bufio.Reader.ReadBytes`. It is not untrusted input. Do not request line
+  caps, bounded readers, atomic rename, rollback copies, or `.bak` handling for it.
+- A local admin POST does not need context-cancellation checks between enqueue and
+  execution on the main loop.
+- `New()` allocates `Config`, `Webserver`, `History`, and `folders`. Nil checks on
+  those fields in HTTP handlers are dead code.
+- `filepath:` values are kept as written in `fileConfig` and expanded on the live
+  copy only (`expandFilepaths`). That is intentional for every section.
+
+## Config PUT
+
+- Sections that the loop cannot re-apply in place return `restartRequired: true`
+  and set `pendingRestart`; the loop re-execs itself once the queue is idle
+  (`maybeRestart`). Folders and listener/TLS/logger changes fall in this group.
+  Do not request an in-process watcher or listener rebuild.
+- General PUT resets the loop tickers directly; interval changes do not need a restart.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,11 @@ in mind; the items below have been raised and rejected before.
   execution on the main loop.
 - `New()` allocates `Config`, `Webserver`, `History`, and `folders`. Nil checks on
   those fields in HTTP handlers are dead code.
+- The tray builds its menus in `readyTray` before `go u.Run()`, and a config PUT
+  cannot apply until the loop drains `taskChan`, so those reads of live `Config`
+  are ordered before any possible write. They are not a race and do not need a
+  lock. When the web UI replaces the tray history menu it reads `/api/history`,
+  which is already guarded by `histMu`.
 - `filepath:` values are kept as written in `fileConfig` and expanded on the live
   copy only (`expandFilepaths`). That is intentional for every section.
 

--- a/pkg/configdef/live_test.go
+++ b/pkg/configdef/live_test.go
@@ -409,67 +409,6 @@ func TestAtomicWriteBackup(t *testing.T) {
 	}
 }
 
-func TestAtomicReplaceNoBackup(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "unpackerr.history.jsonl")
-
-	if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := AtomicReplace(path, []byte("new\n")); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(got) != "new\n" {
-		t.Fatalf("got %q", got)
-	}
-
-	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
-		t.Fatalf("backup should not exist: %v", err)
-	}
-}
-
-func TestAtomicReplaceRemovesStaleBackup(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "unpackerr.history.jsonl")
-	bak := path + ".bak"
-
-	if err := os.WriteFile(path, []byte("keep-me\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.WriteFile(bak, []byte("drop-me\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := AtomicReplace(path, []byte("new\n")); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(got) != "new\n" {
-		t.Fatalf("got %q", got)
-	}
-
-	if _, err := os.Stat(bak); !os.IsNotExist(err) {
-		t.Fatalf("stale backup should not exist: %v", err)
-	}
-}
-
 func MustLoad(t *testing.T) *Config {
 	t.Helper()
 

--- a/pkg/configdef/write.go
+++ b/pkg/configdef/write.go
@@ -17,15 +17,6 @@ const (
 
 // AtomicWrite writes data to path by temp file + rename, keeping path.bak.
 func AtomicWrite(path string, data []byte) error {
-	return atomicWrite(path, data, true)
-}
-
-// AtomicReplace writes data to path by temp file + rename without creating path.bak.
-func AtomicReplace(path string, data []byte) error {
-	return atomicWrite(path, data, false)
-}
-
-func atomicWrite(path string, data []byte, backup bool) error {
 	if path == "" {
 		return errEmptyConfigPath
 	}
@@ -66,84 +57,33 @@ func atomicWrite(path string, data []byte, backup bool) error {
 		return fmt.Errorf("closing temp config: %w", err)
 	}
 
-	if err := replaceFile(path, tmpName, mode, backup); err != nil {
-		return err
-	}
-
-	tmpName = "" // replaced; defer remove is a no-op
-
-	return nil
+	return replaceFile(path, tmpName, mode)
 }
 
-func replaceFile(path, tmpName string, mode os.FileMode, backup bool) error {
+// replaceFile keeps path.bak, then renames. Windows cannot rename over an open
+// or existing file, so it falls back to remove + rename and restores from .bak.
+func replaceFile(path, tmpName string, mode os.FileMode) error {
 	bak := path + backupSuffix
 
-	if backup {
-		if _, err := os.Stat(path); err == nil {
-			if err := copyFile(path, bak, mode); err != nil {
-				return fmt.Errorf("backing up config: %w", err)
-			}
+	if _, err := os.Stat(path); err == nil {
+		if err := copyFile(path, bak, mode); err != nil {
+			return fmt.Errorf("backing up config: %w", err)
 		}
 	}
 
 	if err := os.Rename(tmpName, path); err == nil {
-		if !backup {
-			_ = os.Remove(bak)
-		}
-
 		return nil
-	}
-
-	rollback, err := stashExisting(path, tmpName, mode, backup)
-	if err != nil {
-		return err
 	}
 
 	_ = os.Remove(path)
 
 	if err := os.Rename(tmpName, path); err != nil {
-		if backup {
-			_ = copyFile(bak, path, mode)
-		} else if rollback != "" {
-			_ = copyFile(rollback, path, mode)
-			_ = os.Remove(rollback)
-		}
+		_ = copyFile(bak, path, mode)
 
 		return fmt.Errorf("replacing config: %w", err)
 	}
 
-	if rollback != "" {
-		_ = os.Remove(rollback)
-	}
-
-	if !backup {
-		_ = os.Remove(bak)
-	}
-
 	return nil
-}
-
-// stashExisting copies dest aside before the Windows-style remove+rename fallback
-// so AtomicReplace can restore it if the second rename fails. The copy is not path.bak.
-func stashExisting(path, tmpName string, mode os.FileMode, backup bool) (string, error) {
-	if backup {
-		return "", nil
-	}
-
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-
-		return "", fmt.Errorf("stat config: %w", err)
-	}
-
-	rollback := tmpName + ".prev"
-	if err := copyFile(path, rollback, mode); err != nil {
-		return "", fmt.Errorf("stashing config: %w", err)
-	}
-
-	return rollback, nil
 }
 
 func copyFile(srcPath, dstPath string, mode os.FileMode) error {

--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -44,6 +44,10 @@ func (u *Unpackerr) registerAPIRoutes() {
 		path.Join(base, "config", ":section"),
 		u.requireConfigPerm(false, u.configGetHandler),
 	)
+	u.Webserver.router.PUT(
+		path.Join(base, "config", ":section"),
+		u.requireConfigPerm(true, u.configPutHandler),
+	)
 }
 
 func (u *Unpackerr) statsHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -86,8 +86,23 @@ type FoldersConfig struct {
 }
 
 func (u *Unpackerr) watchWorkThread() {
-	// 1 worker for each app, so they poll quickly.
-	for range len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr) {
+	u.ensureWorkThreads(u.starrAppCount())
+}
+
+func (u *Unpackerr) starrAppCount() int {
+	return len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr)
+}
+
+// ensureWorkThreads grows the poll worker pool to one per Starr app so a PUT
+// that adds apps keeps polling them concurrently. Main loop only.
+func (u *Unpackerr) ensureWorkThreads(count int) {
+	if count < 1 {
+		count = 1
+	}
+
+	for u.workThreads < count {
+		u.workThreads++
+
 		go func() {
 			for funcs := range u.workChan {
 				for _, fn := range funcs {
@@ -100,6 +115,8 @@ func (u *Unpackerr) watchWorkThread() {
 
 // retrieveAppQueues polls all the starr app queues. At the same time.
 // Then calls the check methods to scan their queue contents for changes.
+// The app lists cannot change underneath this: a config PUT applies on this
+// same goroutine, and it is parked in wait.Wait() until every poll returns.
 func (u *Unpackerr) retrieveAppQueues(now time.Time) {
 	wait := sync.WaitGroup{}
 	wait.Add(len(u.Lidarr) + len(u.Radarr) + len(u.Readarr) + len(u.Sonarr) + len(u.Whisparr))

--- a/pkg/unpackerr/auth.go
+++ b/pkg/unpackerr/auth.go
@@ -145,7 +145,7 @@ func (u *Unpackerr) requirePermHTTP(perm string, next http.Handler) http.Handler
 			return
 		}
 
-		perms := u.Webserver.PermissionsForKey(key)
+		perms := u.webPermissionsForKey(key)
 		if perms == nil {
 			writeJSON(response, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 
@@ -168,18 +168,37 @@ func (u *Unpackerr) authAPIKey(key string) (authInfo, bool) {
 		return authInfo{}, false
 	}
 
+	u.uiPassMu.RLock()
 	perms := u.Webserver.PermissionsForKey(key)
+	name := u.Webserver.keyName(key)
+	pass := u.Webserver.UIPassword
+	u.uiPassMu.RUnlock()
+
 	if perms == nil {
 		return authInfo{}, false
 	}
 
 	return authInfo{
-		Username:    u.Webserver.keyName(key),
+		Username:    name,
 		APIKey:      key,
-		Auth:        u.uiPassword().Type().String(),
+		Auth:        pass.Type().String(),
 		Via:         "key",
 		Permissions: perms,
 	}, true
+}
+
+func (u *Unpackerr) webPermissionsForKey(key string) []string {
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return u.Webserver.PermissionsForKey(key)
+}
+
+func (u *Unpackerr) webAllowContains(addr string) bool {
+	u.uiPassMu.RLock()
+	defer u.uiPassMu.RUnlock()
+
+	return u.Webserver.allow.Contains(addr)
 }
 
 func (u *Unpackerr) authenticate(request *http.Request) (authInfo, bool) {
@@ -222,8 +241,12 @@ func requestBearer(request *http.Request) string {
 }
 
 func (u *Unpackerr) proxyAuth(request *http.Request) (authInfo, bool) {
-	pass := u.uiPassword()
-	if !pass.Webauth() || !u.Webserver.allow.Contains(request.RemoteAddr) {
+	u.uiPassMu.RLock()
+	pass := u.Webserver.UIPassword
+	allowed := u.Webserver.allow.Contains(request.RemoteAddr)
+	u.uiPassMu.RUnlock()
+
+	if !pass.Webauth() || !allowed {
 		return authInfo{}, false
 	}
 
@@ -241,11 +264,14 @@ func (u *Unpackerr) proxyAuth(request *http.Request) (authInfo, bool) {
 }
 
 func (u *Unpackerr) sessionAuth(user string) authInfo {
-	pass := u.uiPassword()
+	u.uiPassMu.RLock()
+	pass := u.Webserver.UIPassword
+	admin := u.Webserver.adminAPIKey()
+	u.uiPassMu.RUnlock()
 
 	info := authInfo{
 		Username:    user,
-		APIKey:      u.Webserver.adminAPIKey(),
+		APIKey:      admin,
 		Auth:        pass.Type().String(),
 		Via:         "session",
 		Permissions: AllPermissions(),
@@ -338,7 +364,7 @@ func (u *Unpackerr) trustedForwardedHTTPS(request *http.Request) bool {
 		return false
 	}
 
-	if !u.Webserver.allow.Contains(request.RemoteAddr) {
+	if !u.webAllowContains(request.RemoteAddr) {
 		return false
 	}
 

--- a/pkg/unpackerr/auth_test.go
+++ b/pkg/unpackerr/auth_test.go
@@ -41,7 +41,9 @@ func testAuthUnpackerr(t *testing.T) *Unpackerr {
 	}
 
 	unpack.webRoutes()
+	// Mirror unmarshalConfig: snapshot the file shape, then clamp live.
 	unpack.snapshotFileConfig()
+	clampConfig(unpack.Config)
 
 	go unpack.runMainTasks(t.Context())
 

--- a/pkg/unpackerr/auth_test.go
+++ b/pkg/unpackerr/auth_test.go
@@ -41,7 +41,9 @@ func testAuthUnpackerr(t *testing.T) *Unpackerr {
 	}
 
 	unpack.webRoutes()
-	go unpack.runQueueActions(t.Context())
+	unpack.snapshotFileConfig()
+
+	go unpack.runMainTasks(t.Context())
 
 	return unpack
 }

--- a/pkg/unpackerr/cmdhook.go
+++ b/pkg/unpackerr/cmdhook.go
@@ -20,24 +20,32 @@ var (
 )
 
 func (u *Unpackerr) validateCmdhook() error {
-	for idx := range u.Cmdhook {
-		u.Cmdhook[idx].URL = ""
+	return u.validateCmdhookList(u.Cmdhook)
+}
 
-		u.Cmdhook[idx].Command = expandHomedir(u.Cmdhook[idx].Command)
-		if u.Cmdhook[idx].Command == "" {
+func (u *Unpackerr) validateCmdhookList(list []*WebhookConfig) error {
+	for idx := range list {
+		if list[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		list[idx].URL = ""
+
+		list[idx].Command = strings.TrimSpace(expandHomedir(list[idx].Command))
+		if list[idx].Command == "" {
 			return ErrCmdhookNoCmd
 		}
 
-		if u.Cmdhook[idx].Name == "" {
-			u.Cmdhook[idx].Name = strings.Fields(u.Cmdhook[idx].Command)[0]
+		if list[idx].Name == "" {
+			list[idx].Name = strings.Fields(list[idx].Command)[0]
 		}
 
-		if u.Cmdhook[idx].Timeout.Duration == 0 {
-			u.Cmdhook[idx].Timeout.Duration = u.Timeout.Duration
+		if list[idx].Timeout.Duration == 0 {
+			list[idx].Timeout.Duration = u.Timeout.Duration
 		}
 
-		if len(u.Cmdhook[idx].Events) == 0 {
-			u.Cmdhook[idx].Events = []ExtractStatus{WAITING}
+		if len(list[idx].Events) == 0 {
+			list[idx].Events = []ExtractStatus{WAITING}
 		}
 	}
 
@@ -140,7 +148,11 @@ func (u *Unpackerr) logCmdhook() {
 func (u *Unpackerr) CmdhookCounts() (uint, uint) {
 	var total, fails uint
 
-	for _, hook := range u.Cmdhook {
+	for _, hook := range u.cmdhookList() {
+		if hook == nil {
+			continue
+		}
+
 		posts, failures := hook.Counts()
 		total += posts
 		fails += failures

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -139,7 +140,15 @@ func configFileLocactions() (string, []string) {
 }
 
 // validateConfig makes sure config file values are ok. Returns file and dir modes.
-func (u *Unpackerr) validateConfig() (uint64, uint64) { //nolint:cyclop
+func (u *Unpackerr) validateConfig() (uint64, uint64) {
+	return u.clampConfig()
+}
+
+func (u *Unpackerr) clampConfig() (uint64, uint64) { //nolint:cyclop
+	if u.KeepHistory != 0 && len(u.Items) == 0 {
+		u.Items = make([]string, min(u.KeepHistory, trayHistory))
+	}
+
 	if u.DeleteDelay.Duration > 0 && u.DeleteDelay.Duration < minimumDeleteDelay {
 		u.DeleteDelay.Duration = minimumDeleteDelay
 	}
@@ -196,10 +205,6 @@ func (u *Unpackerr) validateConfig() (uint64, uint64) { //nolint:cyclop
 		u.LogFile = filepath.Join("~", ".unpackerr", "unpackerr.log")
 	}
 
-	if u.KeepHistory != 0 {
-		u.Items = make([]string, min(u.KeepHistory, trayHistory))
-	}
-
 	return fileMode, dirMode
 }
 
@@ -244,23 +249,30 @@ func (u *Unpackerr) createConfigFile(file string) (string, error) {
 
 // writeConfigFile atomically rewrites the active config file from the on-disk snapshot.
 func (u *Unpackerr) writeConfigFile() error {
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
+	return u.writeConfigFrom(u.fileConfig)
+}
+
+func (u *Unpackerr) writeConfigFrom(cfg *Config) error {
 	if strings.TrimSpace(u.ConfigFile) == "" {
 		return errNoConfigFile
 	}
 
 	schema, err := configdef.Load()
 	if err != nil {
-		return fmt.Errorf("definitions: %w", err)
+		return fmt.Errorf("%w: %w", errPersistConfig, err)
 	}
 
-	if u.fileConfig == nil {
+	if cfg == nil {
 		return errNoFileSnapshot
 	}
 
-	body := schema.RenderTOML(u.fileConfig, configdef.RenderOpts{Mode: configdef.RenderLive})
+	body := schema.RenderTOML(cfg, configdef.RenderOpts{Mode: configdef.RenderLive})
 
 	if err := configdef.AtomicWrite(u.ConfigFile, []byte(body)); err != nil {
-		return fmt.Errorf("writing config file: %w", err)
+		return fmt.Errorf("%w: %w", errPersistConfig, err)
 	}
 
 	return nil
@@ -285,7 +297,12 @@ func (u *Unpackerr) snapshotFileConfig() {
 }
 
 func (u *Unpackerr) syncFileUIPassword() {
-	if u.fileConfig == nil || u.Webserver == nil {
+	pass := u.uiPassword()
+
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
+	if u.fileConfig == nil {
 		return
 	}
 
@@ -293,12 +310,13 @@ func (u *Unpackerr) syncFileUIPassword() {
 		u.fileConfig.Webserver = &WebServer{}
 	}
 
-	u.uiPassMu.Lock()
-	u.fileConfig.Webserver.UIPassword = u.Webserver.UIPassword
-	u.uiPassMu.Unlock()
+	u.fileConfig.Webserver.UIPassword = pass
 }
 
 func (u *Unpackerr) appendFileAPIKey(key APIKey) {
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
 	if u.fileConfig == nil {
 		return
 	}
@@ -316,14 +334,10 @@ func (u *Unpackerr) snapshotLivePasswords() {
 	copy(u.livePasswords, u.Passwords)
 }
 
-// This function checks if rar passwords need to be read from a file path.
-// Only runs once at startup to load passwords into memory.
-func (u *Unpackerr) setPasswords() error {
-	u.snapshotLivePasswords()
-
+func expandPasswords(passwords StringSlice) (StringSlice, error) {
 	newPasswords := []string{}
 
-	for _, pass := range u.Passwords {
+	for _, pass := range passwords {
 		if !strings.HasPrefix(pass, filePrefix) {
 			newPasswords = append(newPasswords, pass)
 			continue
@@ -331,7 +345,7 @@ func (u *Unpackerr) setPasswords() error {
 
 		fileContent, err := os.ReadFile(strings.TrimPrefix(pass, filePrefix))
 		if err != nil {
-			return fmt.Errorf("reading password file: %w", err)
+			return nil, fmt.Errorf("reading password file: %w", err)
 		}
 
 		filePasswords := strings.Split(string(fileContent), "\n")
@@ -343,7 +357,20 @@ func (u *Unpackerr) setPasswords() error {
 		newPasswords = append(newPasswords, filePasswords...)
 	}
 
-	u.Passwords = newPasswords
+	return newPasswords, nil
+}
+
+// This function checks if rar passwords need to be read from a file path.
+// Only runs once at startup to load passwords into memory.
+func (u *Unpackerr) setPasswords() error {
+	u.snapshotLivePasswords()
+
+	expanded, err := expandPasswords(u.Passwords)
+	if err != nil {
+		return err
+	}
+
+	u.Passwords = expanded
 
 	return nil
 }
@@ -393,7 +420,7 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 		conf.DeleteDelay.Duration = u.DeleteDelay.Duration
 	}
 
-	if conf.Path != "" {
+	if conf.Path != "" && !slices.Contains(conf.Paths, conf.Path) {
 		conf.Paths = append(conf.Paths, conf.Path)
 	}
 

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -141,68 +141,77 @@ func configFileLocactions() (string, []string) {
 
 // validateConfig makes sure config file values are ok. Returns file and dir modes.
 func (u *Unpackerr) validateConfig() (uint64, uint64) {
-	return u.clampConfig()
+	u.ensureTrayRing()
+
+	return clampConfig(u.Config)
 }
 
-func (u *Unpackerr) clampConfig() (uint64, uint64) { //nolint:cyclop
+// ensureTrayRing sizes the GUI history ring. This is tray-only; the API and web
+// UI read /api/history instead, so it goes away with the tray history menu.
+func (u *Unpackerr) ensureTrayRing() {
 	if u.KeepHistory != 0 && len(u.Items) == 0 {
 		u.Items = make([]string, min(u.KeepHistory, trayHistory))
 	}
+}
 
-	if u.DeleteDelay.Duration > 0 && u.DeleteDelay.Duration < minimumDeleteDelay {
-		u.DeleteDelay.Duration = minimumDeleteDelay
+// clampConfig applies minimums and fills defaults for omitted values. It takes a
+// *Config so a config PUT can clamp a staged copy and compare that against live,
+// instead of comparing raw input against already-clamped values.
+func clampConfig(cfg *Config) (uint64, uint64) { //nolint:cyclop
+	if cfg.DeleteDelay.Duration > 0 && cfg.DeleteDelay.Duration < minimumDeleteDelay {
+		cfg.DeleteDelay.Duration = minimumDeleteDelay
 	}
 
-	if _, err := strconv.ParseUint(u.LogFileMode, bits8, base32); err != nil || u.LogFileMode == "" {
-		u.LogFileMode = strconv.FormatUint(defaultLogFileMode, bits8)
+	if _, err := strconv.ParseUint(cfg.LogFileMode, bits8, base32); err != nil || cfg.LogFileMode == "" {
+		cfg.LogFileMode = strconv.FormatUint(defaultLogFileMode, bits8)
 	}
 
-	fileMode, err := strconv.ParseUint(u.FileMode, bits8, base32)
-	if err != nil || u.FileMode == "" {
+	fileMode, err := strconv.ParseUint(cfg.FileMode, bits8, base32)
+	if err != nil || cfg.FileMode == "" {
 		fileMode = defaultFileMode
-		u.FileMode = strconv.FormatUint(fileMode, bits8)
+		cfg.FileMode = strconv.FormatUint(fileMode, bits8)
 	}
 
-	dirMode, err := strconv.ParseUint(u.DirMode, bits8, base32)
-	if err != nil || u.DirMode == "" {
+	dirMode, err := strconv.ParseUint(cfg.DirMode, bits8, base32)
+	if err != nil || cfg.DirMode == "" {
 		dirMode = defaultDirMode
-		u.DirMode = strconv.FormatUint(dirMode, bits8)
+		cfg.DirMode = strconv.FormatUint(dirMode, bits8)
 	}
 
-	if u.Parallel == 0 {
-		u.Parallel++
+	if cfg.Parallel == 0 {
+		cfg.Parallel++
 	}
 
-	if u.Progress.Duration == 0 {
-		u.Progress.Duration = defaultProgressInterval
-	} else if u.Progress.Duration < minimumProgressInterval {
-		u.Progress.Duration = minimumProgressInterval
+	if cfg.Progress.Duration == 0 {
+		cfg.Progress.Duration = defaultProgressInterval
+	} else if cfg.Progress.Duration < minimumProgressInterval {
+		cfg.Progress.Duration = minimumProgressInterval
 	}
 
-	if u.Folder.Buffer == 0 {
-		u.Folder.Buffer = defaultFolderBuf
-	} else if u.Folder.Buffer < minimumFolderBuf {
-		u.Folder.Buffer = minimumFolderBuf
+	if cfg.Folder.Buffer == 0 {
+		cfg.Folder.Buffer = defaultFolderBuf
+	} else if cfg.Folder.Buffer < minimumFolderBuf {
+		cfg.Folder.Buffer = minimumFolderBuf
 	}
 
-	if u.Interval.Duration < minimumInterval {
-		u.Interval.Duration = minimumInterval
+	if cfg.Interval.Duration < minimumInterval {
+		cfg.Interval.Duration = minimumInterval
 	}
 
-	if u.StartDelay.Duration < minimumInterval {
-		u.StartDelay.Duration = minimumInterval
+	if cfg.StartDelay.Duration < minimumInterval {
+		cfg.StartDelay.Duration = minimumInterval
 	}
 
-	if u.LogQueues.Duration < minimumInterval {
-		u.LogQueues.Duration = minimumInterval
+	if cfg.LogQueues.Duration < minimumInterval {
+		cfg.LogQueues.Duration = minimumInterval
 	}
 
-	if u.ErrorStdErr && runtime.GOOS == windows {
-		u.ErrorStdErr = false // no stderr on windows
+	if cfg.ErrorStdErr && runtime.GOOS == windows {
+		cfg.ErrorStdErr = false // no stderr on windows
 	}
 
-	if ui.HasGUI() && u.LogFile == "" {
-		u.LogFile = filepath.Join("~", ".unpackerr", "unpackerr.log")
+	if ui.HasGUI() && cfg.LogFile == "" {
+		cfg.LogFile = filepath.Join("~", ".unpackerr", "unpackerr.log")
 	}
 
 	return fileMode, dirMode

--- a/pkg/unpackerr/cnfgfile_test.go
+++ b/pkg/unpackerr/cnfgfile_test.go
@@ -1,14 +1,18 @@
 package unpackerr
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Unpackerr/unpackerr/pkg/configdef"
+	"golift.io/cnfg"
 	"golift.io/cnfgfile"
+	"golift.io/starr"
 )
 
 func TestWriteConfigFileRoundTrip(t *testing.T) {
@@ -476,5 +480,119 @@ func collectTOMLTags(typ reflect.Type, known, skip, found map[string]struct{}, s
 		}
 
 		collectTOMLTags(field.Type, known, skip, found, seen)
+	}
+}
+
+// TestWriteConfigFileFullRoundTrip proves a UI save cannot brick a config: every
+// section is populated, rendered to TOML, loaded back through the real loader,
+// and compared field for field. Values equal to a definitions.yml default are
+// written commented-out and re-filled at startup, so every value here is
+// non-default. filepath: values must survive as written.
+func TestWriteConfigFileFullRoundTrip(t *testing.T) { //nolint:funlen // one field per line is the point.
+	t.Parallel()
+
+	key := strings.Repeat("k", apiKeyMinLen)
+	starrKey := strings.Repeat("s", apiKeyMinLength)
+	unpack := New()
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.Config.Debug = true
+	unpack.Quiet = true
+	unpack.Activity = true
+	unpack.Parallel = 3
+	unpack.MaxRetries = 7
+	unpack.RemnantAction = "delete"
+	unpack.LogFile = "/var/log/unpackerr.log"
+	unpack.LogFiles = 4
+	unpack.LogFileMb = 12
+	unpack.FileMode = "0640"
+	unpack.DirMode = "0750"
+	unpack.KeepHistory = 50
+	unpack.Interval = cnfg.Duration{Duration: 3 * time.Minute}
+	unpack.StartDelay = cnfg.Duration{Duration: 2 * time.Minute}
+	unpack.Passwords = StringSlice{"plain-pass", "filepath:/run/secrets/rarpass"}
+	unpack.Webserver.ListenAddr = "127.0.0.1:5656"
+	unpack.Webserver.URLBase = "/unpackerr/"
+	unpack.Webserver.Metrics = true
+	unpack.Webserver.SSLCrtFile = "/etc/ssl/unpackerr.crt"
+	unpack.Webserver.SSLKeyFile = "/etc/ssl/unpackerr.key"
+	unpack.Webserver.Upstreams = StringSlice{"10.0.0.0/8"}
+	unpack.Webserver.UIPassword = "filepath:/run/secrets/ui"
+	unpack.Webserver.APIKeys = []APIKey{
+		{Name: "admin", Key: key, Roles: []string{RoleAdmin}},
+		{Name: "home", Key: strings.Repeat("h", apiKeyMinLen), Roles: []string{"stats"}},
+	}
+	unpack.Webserver.Roles = map[string]Role{"stats": {Permissions: []string{PermReadSystemStats}}}
+
+	starrConf := func(url string) StarrConfig {
+		secret := "filepath:/run/secrets/" + strings.TrimPrefix(url, "http://")
+
+		return StarrConfig{ //nolint:modernize // URL and APIKey are promoted; keeping Config explicit reads better.
+			Config: starr.Config{URL: url, APIKey: secret},
+			Paths:  StringSlice{"/downloads", "/mnt/dl"}, Protocols: "torrent",
+			DeleteOrig: true, Syncthing: true, ValidSSL: true, MaxBytes: "10GB",
+			DeleteDelay: cnfg.Duration{Duration: 7 * time.Minute}, Timeout: cnfg.Duration{Duration: 42 * time.Second},
+		}
+	}
+
+	unpack.Sonarr = []*SonarrConfig{{StarrConfig: starrConf("http://sonarr:8989")}}
+	unpack.Radarr = []*RadarrConfig{{StarrConfig: starrConf("http://radarr:7878")}}
+	unpack.Whisparr = []*RadarrConfig{{StarrConfig: starrConf("http://whisparr:6969")}}
+	unpack.Lidarr = []*LidarrConfig{{StarrConfig: starrConf("http://lidarr:8686"), SplitFlac: true}}
+	unpack.Readarr = []*ReadarrConfig{{StarrConfig: starrConf("http://readarr:8787")}}
+	unpack.Readarr[0].APIKey = starrKey
+	unpack.Folder.Interval = cnfg.Duration{Duration: 4 * time.Second}
+	unpack.Folder.Buffer = 5000
+	unpack.Folders = []*FolderConfig{{
+		Path: "/watch", ExtractPath: "/extracted", DeleteOrig: true, MoveBack: true, ExtractISOs: true,
+		DeleteAfter: &cnfg.Duration{Duration: 11 * time.Minute}, MaxNested: 2, MaxFiles: 99, MaxRatio: 3.5,
+		ExcludePaths: []string{"/watch/skip"},
+	}}
+	unpack.Webhook = []*WebhookConfig{{ //nolint:gosec // filepath: reference, not a credential.
+		Name: "discord", URL: "https://discord.example/hook", CType: "text/plain",
+		Timeout: cnfg.Duration{Duration: 9 * time.Second}, IgnoreSSL: true, Silent: true,
+		Events: ExtractStatuses{EXTRACTED, EXTRACTFAILED}, Exclude: StringSlice{"lidarr"},
+		Nickname: "Bot", Token: "filepath:/run/secrets/hook", Channel: "general",
+	}}
+	unpack.Cmdhook = []*WebhookConfig{{
+		Name: "notify", Command: "/usr/local/bin/notify.sh --flag", Shell: true,
+		Timeout: cnfg.Duration{Duration: 5 * time.Second}, Events: ExtractStatuses{IMPORTED},
+	}}
+	unpack.snapshotFileConfig()
+
+	if err := unpack.writeConfigFile(); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := New()
+	if err := cnfgfile.Unmarshal(loaded.Config, unpack.ConfigFile); err != nil {
+		t.Fatalf("decode: %v\n%s", err, body)
+	}
+
+	want, err := json.MarshalIndent(unpack.fileConfig, "", " ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := json.MarshalIndent(cloneConfig(loaded.Config), "", " ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(want) != string(got) {
+		t.Fatalf("round trip changed the config.\nwant:\n%s\ngot:\n%s\ntoml:\n%s", want, got, body)
+	}
+
+	for _, secret := range []string{
+		"filepath:/run/secrets/rarpass", "filepath:/run/secrets/ui",
+		"filepath:/run/secrets/sonarr:8989", "filepath:/run/secrets/hook",
+	} {
+		if !strings.Contains(string(body), secret) {
+			t.Fatalf("filepath: value %q was not written as-is:\n%s", secret, body)
+		}
 	}
 }

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -72,7 +72,13 @@ func (u *Unpackerr) configGetHandler(response http.ResponseWriter, request *http
 		return
 	}
 
-	writeConfigSection(response, u.fileConfigOrLive(), section)
+	// fileConfig is snapshotted in unmarshalConfig whether or not a file was found.
+	u.configMu.RLock()
+	cfg := cloneConfig(u.fileConfig)
+	u.configMu.RUnlock()
+
+	payload := configSectionFrom(cfg, section)
+	writeJSON(response, http.StatusOK, payload)
 }
 
 func (u *Unpackerr) configGetLiveHandler(
@@ -86,64 +92,56 @@ func (u *Unpackerr) configGetLiveHandler(
 		return
 	}
 
-	if section == SectionGeneral {
-		writeJSON(response, http.StatusOK, u.liveGeneralConfig())
-		return
-	}
+	// Live Config belongs to the main loop; snapshot it there.
+	var payload any
 
-	writeConfigSection(response, u.Config, section)
-}
+	err := u.onMainLoop(request.Context(), func() error {
+		if section == SectionGeneral {
+			payload = u.liveGeneralConfig()
+			return nil
+		}
 
-func (u *Unpackerr) fileConfigOrLive() *Config {
-	if u.fileConfig != nil {
-		return u.fileConfig
-	}
+		payload = configSectionFrom(cloneConfig(u.Config), section)
 
-	return u.Config
-}
-
-func writeConfigSection(response http.ResponseWriter, cfg *Config, section ConfigSection) {
-	payload, ok := configSectionFrom(cfg, section)
-	if !ok {
-		writeJSON(response, http.StatusNotFound, map[string]string{"error": "unknown section"})
+		return nil
+	})
+	if err != nil {
+		writeJSON(response, http.StatusGatewayTimeout, map[string]string{"error": err.Error()})
 		return
 	}
 
 	writeJSON(response, http.StatusOK, payload)
 }
 
-func configSectionFrom(cfg *Config, section ConfigSection) (any, bool) {
-	if cfg == nil {
-		return nil, false
-	}
-
+// configSectionFrom picks one section. requireConfigPerm already 404s unknown names.
+func configSectionFrom(cfg *Config, section ConfigSection) any {
 	switch section {
 	case SectionGeneral:
-		return generalConfigFrom(cfg), true
+		return generalConfigFrom(cfg)
 	case SectionWebserver:
 		if cfg.Webserver == nil {
-			return &WebServer{}, true
+			return &WebServer{}
 		}
 
-		return cfg.Webserver, true
+		return cfg.Webserver
 	case SectionSonarr:
-		return emptyIfNil(cfg.Sonarr), true
+		return emptyIfNil(cfg.Sonarr)
 	case SectionRadarr:
-		return emptyIfNil(cfg.Radarr), true
+		return emptyIfNil(cfg.Radarr)
 	case SectionLidarr:
-		return emptyIfNil(cfg.Lidarr), true
+		return emptyIfNil(cfg.Lidarr)
 	case SectionReadarr:
-		return emptyIfNil(cfg.Readarr), true
+		return emptyIfNil(cfg.Readarr)
 	case SectionWhisparr:
-		return emptyIfNil(cfg.Whisparr), true
+		return emptyIfNil(cfg.Whisparr)
 	case SectionFolders:
-		return foldersConfigFrom(cfg), true
+		return foldersConfigFrom(cfg)
 	case SectionWebhooks:
-		return emptyIfNil(cfg.Webhook), true
+		return emptyIfNil(cfg.Webhook)
 	case SectionCmdhooks:
-		return emptyIfNil(cfg.Cmdhook), true
+		return emptyIfNil(cfg.Cmdhook)
 	default:
-		return nil, false
+		return nil
 	}
 }
 

--- a/pkg/unpackerr/configapi_test.go
+++ b/pkg/unpackerr/configapi_test.go
@@ -18,6 +18,7 @@ func TestConfigGetSection(t *testing.T) {
 	unpack.Sonarr[0].Path = "/downloads"
 	unpack.Sonarr[0].URL = "http://127.0.0.1:8989"
 	unpack.Sonarr[0].APIKey = strings.Repeat("k", apiKeyMinLength)
+	unpack.snapshotFileConfig()
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -1,18 +1,59 @@
 package unpackerr
 
-func cloneConfig(src *Config) *Config {
-	if src == nil {
-		return nil
-	}
+import (
+	"golift.io/starr/lidarr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/readarr"
+	"golift.io/starr/sonarr"
+)
 
+// starrApp is what putStarrList and the clone/carry helpers need from each
+// Starr config type. P is the pointer type (*SonarrConfig), T the struct.
+type starrApp[T any] interface {
+	*T
+	conf() *StarrConfig
+	connect()         // build the API client from conf.
+	takeQueue(old *T) // keep the last polled queue from a matching old entry.
+	stripRuntime()    // nil the queue and client on a file-shaped clone.
+}
+
+func (s *SonarrConfig) conf() *StarrConfig { return &s.StarrConfig }
+func (s *SonarrConfig) connect()           { s.Sonarr = sonarr.New(&s.Config) }
+func (s *SonarrConfig) takeQueue(o *SonarrConfig) {
+	s.Queue = o.Queue
+}
+func (s *SonarrConfig) stripRuntime() { s.Queue, s.Sonarr = nil, nil }
+
+func (r *RadarrConfig) conf() *StarrConfig { return &r.StarrConfig }
+func (r *RadarrConfig) connect()           { r.Radarr = radarr.New(&r.Config) }
+func (r *RadarrConfig) takeQueue(o *RadarrConfig) {
+	r.Queue = o.Queue
+}
+func (r *RadarrConfig) stripRuntime() { r.Queue, r.Radarr = nil, nil }
+
+func (l *LidarrConfig) conf() *StarrConfig { return &l.StarrConfig }
+func (l *LidarrConfig) connect()           { l.Lidarr = lidarr.New(&l.Config) }
+func (l *LidarrConfig) takeQueue(o *LidarrConfig) {
+	l.Queue = o.Queue
+}
+func (l *LidarrConfig) stripRuntime() { l.Queue, l.Lidarr = nil, nil }
+
+func (r *ReadarrConfig) conf() *StarrConfig { return &r.StarrConfig }
+func (r *ReadarrConfig) connect()           { r.Readarr = readarr.New(&r.Config) }
+func (r *ReadarrConfig) takeQueue(o *ReadarrConfig) {
+	r.Queue = o.Queue
+}
+func (r *ReadarrConfig) stripRuntime() { r.Queue, r.Readarr = nil, nil }
+
+func cloneConfig(src *Config) *Config {
 	dst := *src
 	dst.Passwords = append(StringSlice(nil), src.Passwords...)
 	dst.Webserver = cloneWebserver(src.Webserver)
-	dst.Lidarr = cloneLidarrList(src.Lidarr)
-	dst.Radarr = cloneRadarrList(src.Radarr)
-	dst.Whisparr = cloneRadarrList(src.Whisparr)
-	dst.Readarr = cloneReadarrList(src.Readarr)
-	dst.Sonarr = cloneSonarrList(src.Sonarr)
+	dst.Lidarr = cloneStarrList(src.Lidarr)
+	dst.Radarr = cloneStarrList(src.Radarr)
+	dst.Whisparr = cloneStarrList(src.Whisparr)
+	dst.Readarr = cloneStarrList(src.Readarr)
+	dst.Sonarr = cloneStarrList(src.Sonarr)
 	dst.Folders = cloneFolderList(src.Folders)
 	dst.Webhook = cloneHookList(src.Webhook)
 	dst.Cmdhook = cloneHookList(src.Cmdhook)
@@ -67,92 +108,21 @@ func cloneRoles(src map[string]Role) map[string]Role {
 	return out
 }
 
-func cloneStarrConfig(src StarrConfig) StarrConfig {
-	dst := src
-	dst.Paths = append(StringSlice(nil), src.Paths...)
-
-	return dst
-}
-
-func cloneLidarrList(src []*LidarrConfig) []*LidarrConfig {
+// cloneStarrList copies a Starr list into its file shape: config only,
+// no queue, no client. Nil in, nil out so the TOML writer omits the table.
+func cloneStarrList[T any, P starrApp[T]](src []P) []P {
 	if src == nil {
 		return nil
 	}
 
-	out := make([]*LidarrConfig, len(src))
+	out := make([]P, len(src))
+
 	for idx, app := range src {
-		if app == nil {
-			continue
-		}
-
 		cloned := *app
-		cloned.StarrConfig = cloneStarrConfig(app.StarrConfig)
-		cloned.Queue = nil
-		cloned.Lidarr = nil
 		out[idx] = &cloned
-	}
 
-	return out
-}
-
-func cloneRadarrList(src []*RadarrConfig) []*RadarrConfig {
-	if src == nil {
-		return nil
-	}
-
-	out := make([]*RadarrConfig, len(src))
-	for idx, app := range src {
-		if app == nil {
-			continue
-		}
-
-		cloned := *app
-		cloned.StarrConfig = cloneStarrConfig(app.StarrConfig)
-		cloned.Queue = nil
-		cloned.Radarr = nil
-		out[idx] = &cloned
-	}
-
-	return out
-}
-
-func cloneReadarrList(src []*ReadarrConfig) []*ReadarrConfig {
-	if src == nil {
-		return nil
-	}
-
-	out := make([]*ReadarrConfig, len(src))
-	for idx, app := range src {
-		if app == nil {
-			continue
-		}
-
-		cloned := *app
-		cloned.StarrConfig = cloneStarrConfig(app.StarrConfig)
-		cloned.Queue = nil
-		cloned.Readarr = nil
-		out[idx] = &cloned
-	}
-
-	return out
-}
-
-func cloneSonarrList(src []*SonarrConfig) []*SonarrConfig {
-	if src == nil {
-		return nil
-	}
-
-	out := make([]*SonarrConfig, len(src))
-	for idx, app := range src {
-		if app == nil {
-			continue
-		}
-
-		cloned := *app
-		cloned.StarrConfig = cloneStarrConfig(app.StarrConfig)
-		cloned.Queue = nil
-		cloned.Sonarr = nil
-		out[idx] = &cloned
+		out[idx].conf().Paths = append(StringSlice(nil), app.conf().Paths...)
+		out[idx].stripRuntime()
 	}
 
 	return out
@@ -165,10 +135,6 @@ func cloneFolderList(src []*FolderConfig) []*FolderConfig {
 
 	out := make([]*FolderConfig, len(src))
 	for idx, folder := range src {
-		if folder == nil {
-			continue
-		}
-
 		cloned := *folder
 		if folder.DeleteAfter != nil {
 			dur := *folder.DeleteAfter
@@ -182,6 +148,7 @@ func cloneFolderList(src []*FolderConfig) []*FolderConfig {
 	return out
 }
 
+// cloneHookList copies hooks without the mutex, counters, client, or template.
 func cloneHookList(src []*WebhookConfig) []*WebhookConfig {
 	if src == nil {
 		return nil
@@ -189,11 +156,7 @@ func cloneHookList(src []*WebhookConfig) []*WebhookConfig {
 
 	out := make([]*WebhookConfig, len(src))
 	for idx, hook := range src {
-		if hook == nil {
-			continue
-		}
-
-		cloned := &WebhookConfig{
+		out[idx] = &WebhookConfig{
 			Name:      hook.Name,
 			URL:       hook.URL,
 			Command:   hook.Command,
@@ -210,7 +173,6 @@ func cloneHookList(src []*WebhookConfig) []*WebhookConfig {
 			Token:     hook.Token,
 			Channel:   hook.Channel,
 		}
-		out[idx] = cloned
 	}
 
 	return out

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -1,0 +1,537 @@
+package unpackerr
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"golift.io/cnfgfile"
+	"golift.io/starr"
+)
+
+const maxConfigBody = 1 << 20
+
+var (
+	errInvalidJSON        = errors.New("invalid json")
+	errEmptyConfigSection = errors.New("empty config section")
+	errNilConfigEntry     = errors.New("nil config entry")
+	errPersistConfig      = errors.New("persisting config file")
+)
+
+type configWriteReply struct {
+	Status          string `json:"status"`
+	RestartRequired bool   `json:"restartRequired"`
+}
+
+// configPutHandler reads the body on the HTTP goroutine, then decodes,
+// validates, writes the file, and applies live on the main loop.
+func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	section := ConfigSection(params.ByName("section"))
+
+	raw, err := decodeJSONBody(response, request)
+	if err != nil {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var restart bool
+
+	err = u.onMainLoop(request.Context(), func() error { //nolint:contextcheck // hook worker outlives the request.
+		var err error
+
+		restart, err = u.replaceConfigSection(section, raw)
+
+		return err
+	})
+	if err != nil {
+		writeJSON(response, statusForConfigPut(err), map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, configWriteReply{Status: "ok", RestartRequired: restart})
+}
+
+func statusForConfigPut(err error) int {
+	if errors.Is(err, errPersistConfig) {
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusBadRequest
+}
+
+// replaceConfigSection runs on the main loop. Sections that need a process
+// restart to fully apply return true; the caller sets pendingRestart.
+func (u *Unpackerr) replaceConfigSection(section ConfigSection, raw json.RawMessage) (bool, error) {
+	switch section {
+	case SectionGeneral:
+		return u.putGeneral(raw)
+	case SectionWebserver:
+		return u.putWebserver(raw)
+	case SectionSonarr:
+		return false, putStarrList(u, raw, starr.Sonarr, func(c *Config) *[]*SonarrConfig { return &c.Sonarr })
+	case SectionRadarr:
+		return false, putStarrList(u, raw, starr.Radarr, func(c *Config) *[]*RadarrConfig { return &c.Radarr })
+	case SectionLidarr:
+		return false, putStarrList(u, raw, starr.Lidarr, func(c *Config) *[]*LidarrConfig { return &c.Lidarr })
+	case SectionReadarr:
+		return false, putStarrList(u, raw, starr.Readarr, func(c *Config) *[]*ReadarrConfig { return &c.Readarr })
+	case SectionWhisparr:
+		return false, putStarrList(u, raw, starr.Whisparr, func(c *Config) *[]*RadarrConfig { return &c.Whisparr })
+	case SectionFolders:
+		return u.putFolders(raw)
+	case SectionWebhooks:
+		return false, u.putHooks(raw, u.validateWebhookList, func(c *Config) *[]*WebhookConfig { return &c.Webhook })
+	case SectionCmdhooks:
+		return false, u.putHooks(raw, u.validateCmdhookList, func(c *Config) *[]*WebhookConfig { return &c.Cmdhook })
+	default:
+		return false, fmt.Errorf("%w: %s", errUnknownSection, section)
+	}
+}
+
+var errUnknownSection = errors.New("unknown section")
+
+// decodeJSONBody reads one JSON value and rejects empty, null, or trailing data.
+func decodeJSONBody(response http.ResponseWriter, request *http.Request) (json.RawMessage, error) {
+	decoder := json.NewDecoder(http.MaxBytesReader(response, request.Body, maxConfigBody))
+
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, wrapJSONErr(err)
+	}
+
+	switch err := decoder.Decode(&struct{}{}); {
+	case errors.Is(err, io.EOF):
+	case err != nil:
+		return nil, wrapJSONErr(err)
+	default:
+		return nil, errExtraJSON
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, errEmptyConfigSection
+	}
+
+	return raw, nil
+}
+
+func wrapJSONErr(err error) error {
+	return fmt.Errorf("%w: %w", errInvalidJSON, err)
+}
+
+// unmarshalStrict decodes with unknown fields rejected.
+func unmarshalStrict(raw json.RawMessage, dest any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dest); err != nil {
+		return wrapJSONErr(err)
+	}
+
+	return nil
+}
+
+// unmarshalObject is unmarshalStrict plus a guard against a bare {}, which
+// would otherwise zero every field in an object section.
+func unmarshalObject(raw json.RawMessage, dest any) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return wrapJSONErr(err)
+	}
+
+	if len(probe) == 0 {
+		return errEmptyConfigSection
+	}
+
+	return unmarshalStrict(raw, dest)
+}
+
+// unmarshalList is unmarshalStrict plus a guard against [null] entries.
+func unmarshalList[T any, P interface{ *T }](raw json.RawMessage, dest *[]P) error {
+	if err := unmarshalStrict(raw, dest); err != nil {
+		return err
+	}
+
+	for _, item := range *dest {
+		if item == nil {
+			return errNilConfigEntry
+		}
+	}
+
+	return nil
+}
+
+// expandFilepaths replaces filepath: values on a live copy, the same way
+// startup does for the whole Config. The file-shaped copy keeps the prefix.
+func expandFilepaths(ptr any) error {
+	_, err := cnfgfile.Parse(ptr, &cnfgfile.Opts{
+		Name:          "Unpackerr",
+		TransformPath: expandHomedir,
+		Prefix:        filePrefix,
+	})
+	if err != nil {
+		return fmt.Errorf("parsing filepaths: %w", err)
+	}
+
+	return nil
+}
+
+// commitConfig stages the change onto a clone of fileConfig, writes the TOML,
+// then publishes live. A failed write changes nothing. Runs on the main loop;
+// configMu covers fileConfig and the hook slices that /api/stats reads.
+func (u *Unpackerr) commitConfig(mutateFile func(*Config), applyLive func()) error {
+	u.configMu.Lock()
+	defer u.configMu.Unlock()
+
+	if u.fileConfig != nil {
+		staged := cloneConfig(u.fileConfig)
+		mutateFile(staged)
+
+		if err := u.writeConfigFrom(staged); err != nil && !errors.Is(err, errNoConfigFile) {
+			return err
+		}
+
+		u.fileConfig = staged
+	}
+
+	applyLive()
+
+	return nil
+}
+
+func (u *Unpackerr) putGeneral(raw json.RawMessage) (bool, error) {
+	var next generalConfig
+	if err := unmarshalObject(raw, &next); err != nil {
+		return false, err
+	}
+
+	if err := remnantActionError(next.RemnantAction); err != nil {
+		return false, err
+	}
+
+	expanded, err := expandPasswords(next.Passwords)
+	if err != nil {
+		return false, err
+	}
+
+	restart := generalRestartRequired(u.Config, next)
+
+	return restart, u.commitConfig(func(cfg *Config) {
+		applyGeneral(cfg, next)
+	}, func() {
+		applyGeneral(u.Config, next)
+		u.livePasswords = append(StringSlice(nil), next.Passwords...)
+		u.Passwords = expanded
+		u.RemnantAction = remnantAction(next.RemnantAction)
+		u.clampConfig()
+		u.resetTickers()
+	})
+}
+
+// generalRestartRequired lists the general fields the main loop cannot
+// re-apply in place: logger construction and the xtractr instance.
+func generalRestartRequired(cur *Config, next generalConfig) bool {
+	return next.Debug != cur.Debug ||
+		next.Quiet != cur.Quiet ||
+		next.Parallel != cur.Parallel ||
+		next.LogFile != cur.LogFile ||
+		next.LogFiles != cur.LogFiles ||
+		next.LogFileMb != cur.LogFileMb ||
+		next.LogFileMode != cur.LogFileMode ||
+		next.ErrorStdErr != cur.ErrorStdErr ||
+		next.FileMode != cur.FileMode ||
+		next.DirMode != cur.DirMode
+}
+
+func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
+	var next WebServer
+	if err := unmarshalObject(raw, &next); err != nil {
+		return false, err
+	}
+
+	next.normalizeURLBase()
+
+	submitted := next.UIPassword
+	omitted := submitted.Val() == ""
+	fromFile := strings.HasPrefix(submitted.Val(), filePrefix)
+
+	if !omitted {
+		if err := expandCryptPassFile(&next.UIPassword); err != nil {
+			return false, err
+		}
+
+		if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser()); err != nil {
+			return false, err
+		}
+	}
+
+	liveSnap := u.cloneLiveWebserver()
+	fileSnap := u.cloneFileWebserver()
+
+	// Blank keys round-trip from a redacted GET. File keys fill from the file
+	// only so an env-overlay key never lands on disk; live fills from live then file.
+	fileOnly := &WebServer{APIKeys: cloneAPIKeys(next.APIKeys)}
+	keepNamedAPIKeys(fileOnly, fileSnap)
+	dropEmptyAPIKeys(fileOnly)
+	keepNamedAPIKeys(&next, liveSnap, fileSnap)
+
+	if omitted {
+		next.UIPassword = liveSnap.UIPassword
+	}
+
+	if err := next.validateAuth(); err != nil {
+		return false, err
+	}
+
+	next.allow = MakeIPs(next.Upstreams)
+
+	fileWeb := cloneWebserver(&next)
+	fileWeb.APIKeys = fileOnly.APIKeys
+
+	switch {
+	case omitted:
+		fileWeb.UIPassword = fileSnap.UIPassword
+	case fromFile:
+		fileWeb.UIPassword = submitted
+	}
+
+	if err := fileWeb.validateAuth(); err != nil {
+		return false, err
+	}
+
+	restart := webserverRestartRequired(liveSnap, &next)
+
+	return restart, u.commitConfig(func(cfg *Config) {
+		cfg.Webserver = fileWeb
+	}, func() {
+		u.applyLiveWebserverAuth(&next)
+	})
+}
+
+func webserverRestartRequired(cur, next *WebServer) bool {
+	return cur.ListenAddr != next.ListenAddr ||
+		cur.URLBase != next.URLBase ||
+		cur.SSLCrtFile != next.SSLCrtFile ||
+		cur.SSLKeyFile != next.SSLKeyFile ||
+		cur.Metrics != next.Metrics ||
+		cur.Pprof != next.Pprof ||
+		cur.LogFile != next.LogFile ||
+		cur.LogFiles != next.LogFiles ||
+		cur.LogFileMb != next.LogFileMb
+}
+
+func dropEmptyAPIKeys(web *WebServer) {
+	out := make([]APIKey, 0, len(web.APIKeys))
+
+	for _, key := range web.APIKeys {
+		if strings.TrimSpace(key.Key) != "" {
+			out = append(out, key)
+		}
+	}
+
+	web.APIKeys = out
+}
+
+// keepNamedAPIKeys fills a blank apiKeys[].key from an existing key of the
+// same name so a redacted GET can round-trip without requiring PermAll.
+func keepNamedAPIKeys(next *WebServer, sources ...*WebServer) {
+	byName := make(map[string]string)
+
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+
+		for idx := range src.APIKeys {
+			name := src.APIKeys[idx].Name
+			if name == "" || src.APIKeys[idx].Key == "" {
+				continue
+			}
+
+			if _, exists := byName[name]; !exists {
+				byName[name] = src.APIKeys[idx].Key
+			}
+		}
+	}
+
+	for idx := range next.APIKeys {
+		if strings.TrimSpace(next.APIKeys[idx].Key) == "" {
+			next.APIKeys[idx].Key = byName[next.APIKeys[idx].Name]
+		}
+	}
+}
+
+// applyLiveWebserverAuth swaps the auth fields HTTP goroutines read.
+// The listener itself is not touched; listen/TLS/urlbase need a restart.
+func (u *Unpackerr) applyLiveWebserverAuth(next *WebServer) {
+	u.uiPassMu.Lock()
+	defer u.uiPassMu.Unlock()
+
+	u.Webserver.APIKeys = cloneAPIKeys(next.APIKeys)
+	u.Webserver.Roles = cloneRoles(next.Roles)
+	u.Webserver.UIPassword = next.UIPassword
+	u.Webserver.Upstreams = append(StringSlice(nil), next.Upstreams...)
+	u.Webserver.allow = next.allow
+	u.Webserver.keyPerms = next.keyPerms
+}
+
+func applyGeneral(dst *Config, next generalConfig) {
+	dst.Debug = next.Debug
+	dst.Quiet = next.Quiet
+	dst.Activity = next.Activity
+	dst.Parallel = next.Parallel
+	dst.ErrorStdErr = next.ErrorStdErr
+	dst.LogFile = next.LogFile
+	dst.LogFiles = next.LogFiles
+	dst.LogFileMb = next.LogFileMb
+	dst.LogFileMode = next.LogFileMode
+	dst.MaxRetries = next.MaxRetries
+	dst.RemnantAction = next.RemnantAction
+	dst.FileMode = next.FileMode
+	dst.DirMode = next.DirMode
+	dst.LogQueues = next.LogQueues
+	dst.Interval = next.Interval
+	dst.Timeout = next.Timeout
+	dst.DeleteDelay = next.DeleteDelay
+	dst.StartDelay = next.StartDelay
+	dst.RetryDelay = next.RetryDelay
+	dst.Progress = next.Progress
+	dst.KeepHistory = next.KeepHistory
+	dst.Passwords = append(StringSlice(nil), next.Passwords...)
+}
+
+func (u *Unpackerr) uiPasswordUser() string {
+	if name := u.uiPassword().Username(); name != "" {
+		return name
+	}
+
+	return defaultUIUser
+}
+
+func normalizeStoredPassword(pass *CryptPass, fallback string) error {
+	if pass.Val() == "" || pass.IsCrypted() || pass.Webauth() {
+		return nil
+	}
+
+	user, plain := splitUserPass(pass.Val(), fallback)
+
+	return pass.SetPlain(user, plain)
+}
+
+// putStarrList replaces one Starr app list. The file copy keeps filepath:
+// values; the live copy is expanded, validated, and given clients. Queues
+// carry over by url+apikey so an unchanged app keeps polling state.
+func putStarrList[T any, P starrApp[T]](
+	unpackerr *Unpackerr, raw json.RawMessage, app starr.App, field func(*Config) *[]P,
+) error {
+	var list []P
+	if err := unmarshalList(raw, &list); err != nil {
+		return err
+	}
+
+	fileList := cloneStarrList(list)
+
+	if err := expandFilepaths(&list); err != nil {
+		return err
+	}
+
+	for _, item := range list {
+		if err := unpackerr.validateApp(item.conf(), app); err != nil {
+			return err
+		}
+
+		item.connect()
+	}
+
+	return unpackerr.commitConfig(func(cfg *Config) {
+		*field(cfg) = fileList
+	}, func() {
+		live := field(unpackerr.Config)
+		carryQueues(*live, list)
+		*live = list
+
+		unpackerr.ensureWorkThreads(unpackerr.starrAppCount())
+	})
+}
+
+func starrIdentity(conf *StarrConfig) string {
+	return conf.URL + "\x00" + conf.APIKey
+}
+
+func carryQueues[T any, P starrApp[T]](prev, next []P) {
+	seen := make(map[string]P, len(prev))
+	for _, app := range prev {
+		seen[starrIdentity(app.conf())] = app
+	}
+
+	for _, app := range next {
+		if old, ok := seen[starrIdentity(app.conf())]; ok {
+			app.takeQueue(old)
+		}
+	}
+}
+
+func (u *Unpackerr) putFolders(raw json.RawMessage) (bool, error) {
+	var next foldersConfigAPI
+	if err := unmarshalObject(raw, &next); err != nil {
+		return false, err
+	}
+
+	for _, folder := range next.Folder {
+		if folder == nil {
+			return false, errNilConfigEntry
+		}
+	}
+
+	fileList := cloneFolderList(next.Folder)
+
+	if err := expandFilepaths(&next.Folder); err != nil {
+		return false, err
+	}
+
+	if err := validateFolderList(next.Folder); err != nil {
+		return false, err
+	}
+
+	// The fsnotify watcher is built once at startup; the new list needs a restart.
+	return true, u.commitConfig(func(cfg *Config) {
+		cfg.Folder.Interval = next.Interval
+		cfg.Folder.Buffer = next.Buffer
+		cfg.Folders = fileList
+	}, func() {
+		u.Folder.Interval = next.Interval
+		u.Folder.Buffer = next.Buffer
+		u.Folders = next.Folder
+	})
+}
+
+func (u *Unpackerr) putHooks(
+	raw json.RawMessage, validate func([]*WebhookConfig) error, field func(*Config) *[]*WebhookConfig,
+) error {
+	var list []*WebhookConfig
+	if err := unmarshalList(raw, &list); err != nil {
+		return err
+	}
+
+	fileList := cloneHookList(list)
+
+	if err := expandFilepaths(&list); err != nil {
+		return err
+	}
+
+	if err := validate(list); err != nil {
+		return err
+	}
+
+	return u.commitConfig(func(cfg *Config) {
+		*field(cfg) = fileList
+	}, func() {
+		*field(u.Config) = list
+		u.ensureHookWorker()
+	})
+}

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -2,6 +2,7 @@ package unpackerr
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,11 +63,14 @@ func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http
 }
 
 func statusForConfigPut(err error) int {
-	if errors.Is(err, errPersistConfig) {
+	switch {
+	case errors.Is(err, errPersistConfig):
 		return http.StatusInternalServerError
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout
+	default:
+		return http.StatusBadRequest
 	}
-
-	return http.StatusBadRequest
 }
 
 // replaceConfigSection runs on the main loop. Sections that need a process

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -45,6 +45,9 @@ func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http
 		var err error
 
 		restart, err = u.replaceConfigSection(section, raw)
+		if restart {
+			u.pendingRestart = true
+		}
 
 		return err
 	})

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -45,11 +45,13 @@ func (u *Unpackerr) configPutHandler(response http.ResponseWriter, request *http
 		var err error
 
 		restart, err = u.replaceConfigSection(section, raw)
-		if restart {
-			u.pendingRestart = true
+		if err != nil {
+			return err // nothing changed, so nothing needs a restart.
 		}
 
-		return err
+		u.pendingRestart = u.pendingRestart || restart
+
+		return nil
 	})
 	if err != nil {
 		writeJSON(response, statusForConfigPut(err), map[string]string{"error": err.Error()})
@@ -222,7 +224,15 @@ func (u *Unpackerr) putGeneral(raw json.RawMessage) (bool, error) {
 		return false, err
 	}
 
-	restart := generalRestartRequired(u.Config, next)
+	// Decide the restart from a clamped copy. Comparing raw input against the
+	// live config would ask for a restart whenever a value was omitted, since
+	// clampConfig is about to fill it with the same default.
+	staged := *u.Config
+	applyGeneral(&staged, next)
+	clampConfig(&staged)
+
+	restart := generalRestartRequired(u.Config, &staged)
+	historyWasOff := u.KeepHistory == 0
 
 	return restart, u.commitConfig(func(cfg *Config) {
 		applyGeneral(cfg, next)
@@ -231,14 +241,20 @@ func (u *Unpackerr) putGeneral(raw json.RawMessage) (bool, error) {
 		u.livePasswords = append(StringSlice(nil), next.Passwords...)
 		u.Passwords = expanded
 		u.RemnantAction = remnantAction(next.RemnantAction)
-		u.clampConfig()
+		clampConfig(u.Config)
+		u.ensureTrayRing()
 		u.resetTickers()
+
+		if historyWasOff && u.KeepHistory > 0 {
+			u.loadHistory() // histPath is only resolved while history is enabled.
+		}
 	})
 }
 
-// generalRestartRequired lists the general fields the main loop cannot
-// re-apply in place: logger construction and the xtractr instance.
-func generalRestartRequired(cur *Config, next generalConfig) bool {
+// generalRestartRequired lists the general fields the main loop cannot re-apply
+// in place: logger construction, the xtractr instance, and the defaults that
+// validation already copied into each Starr app and hook.
+func generalRestartRequired(cur, next *Config) bool {
 	return next.Debug != cur.Debug ||
 		next.Quiet != cur.Quiet ||
 		next.Parallel != cur.Parallel ||
@@ -248,7 +264,11 @@ func generalRestartRequired(cur *Config, next generalConfig) bool {
 		next.LogFileMode != cur.LogFileMode ||
 		next.ErrorStdErr != cur.ErrorStdErr ||
 		next.FileMode != cur.FileMode ||
-		next.DirMode != cur.DirMode
+		next.DirMode != cur.DirMode ||
+		// Both only seed per-app values in validateApp and validate*HookList,
+		// so running clients keep the old value until they are rebuilt.
+		next.Timeout != cur.Timeout ||
+		next.DeleteDelay != cur.DeleteDelay
 }
 
 func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -1,0 +1,953 @@
+package unpackerr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golift.io/starr/sonarr"
+)
+
+func TestConfigPutGeneralRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 200
+	unpack.Items = make([]string, trayHistory)
+	unpack.Items[0] = "queued"
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 50
+	general.Debug = true
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.KeepHistory != 50 || !unpack.Config.Debug {
+		t.Fatalf("applied %+v debug %v", unpack.KeepHistory, unpack.Config.Debug)
+	}
+
+	if len(unpack.Items) != trayHistory || unpack.Items[0] != "queued" {
+		t.Fatalf("PUT resized history items: %+v", unpack.Items)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(written)
+	if !strings.Contains(text, "keep_history = 50") || !strings.Contains(text, "debug = true") {
+		t.Fatalf("fileConfig write missed PUT:\n%s", text)
+	}
+}
+
+func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 0
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 50
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.KeepHistory != 50 {
+		t.Fatalf("applied keep_history %d", unpack.KeepHistory)
+	}
+
+	if len(unpack.Items) != trayHistory {
+		t.Fatalf("tray items after enabling history: %d", len(unpack.Items))
+	}
+
+	unpack.updateHistory("queued")
+
+	if unpack.Items[0] != "queued" {
+		t.Fatalf("updateHistory after enable: %+v", unpack.Items)
+	}
+}
+
+func TestConfigPutCmdhookRejectsWhitespaceCommand(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodPut, "/api/config/cmdhooks", `[{"command":"   "}]`, withKey)
+	if got.Code != http.StatusBadRequest {
+		t.Fatalf("whitespace cmdhook %d %s", got.Code, got.Body.String())
+	}
+}
+
+func TestConfigPutWebserverRejectsFileKeyCollision(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	fileKey, liveKey := splitFileAndLiveAdminKeys(t, unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	for idx := range web.APIKeys {
+		web.APIKeys[idx].Key = ""
+	}
+
+	web.APIKeys = append(web.APIKeys, APIKey{
+		Name:  "extra",
+		Key:   fileKey,
+		Roles: []string{RoleAdmin},
+	})
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if put.Code != http.StatusBadRequest {
+		t.Fatalf("file key collision %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.adminAPIKey() != liveKey {
+		t.Fatal("rejected PUT mutated live key")
+	}
+
+	if unpack.fileConfig.Webserver.APIKeys[0].Key != fileKey {
+		t.Fatalf("rejected PUT mutated file key %q", unpack.fileConfig.Webserver.APIKeys[0].Key)
+	}
+}
+
+func TestConfigPutSonarrValidates(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	bad := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr",
+		`[{"url":"not-a-url","apiKey":"`+strings.Repeat("k", apiKeyMinLength)+`"}]`, withKey)
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("bad url %d %s", bad.Code, bad.Body.String())
+	}
+
+	good := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr",
+		`[{"url":"http://127.0.0.1:8989","apiKey":"`+strings.Repeat("k", apiKeyMinLength)+`","path":"/dl"}]`, withKey)
+	if good.Code != http.StatusOK {
+		t.Fatalf("good %d %s", good.Code, good.Body.String())
+	}
+
+	if len(unpack.Sonarr) != 1 || unpack.Sonarr[0].URL != "http://127.0.0.1:8989" {
+		t.Fatalf("sonarr %+v", unpack.Sonarr)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(written), "http://127.0.0.1:8989") {
+		t.Fatalf("sonarr PUT missed fileConfig:\n%s", written)
+	}
+}
+
+func TestConfigPutNeedsWritePerm(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	readKey := strings.Repeat("P", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"general": {Permissions: []string{PermReadConfig(SectionGeneral)}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "ro",
+		Key:   readKey,
+		Roles: []string{"general"},
+	})
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", `{}`, func(req *http.Request) {
+		req.Header.Set(headerAPIKey, readKey)
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("readonly put %d", rec.Code)
+	}
+}
+
+func TestConfigPutWebserverFilepathPassword(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	passFile := filepath.Join(dir, "ui.pass")
+
+	if err := os.WriteFile(passFile, []byte("correct-horse\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	web.UIPassword = CryptPass(filePrefix + passFile)
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain(defaultUIUser, "correct-horse") {
+		t.Fatal("live password must expand filepath:")
+	}
+
+	stored := unpack.fileConfig.Webserver.UIPassword.Val()
+	if stored != filePrefix+passFile {
+		t.Fatalf("file snapshot must keep filepath:, got %q", stored)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(written), `filepath:`) {
+		t.Fatalf("config write dropped filepath:\n%s", written)
+	}
+}
+
+func putKey(unpack *Unpackerr) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+}
+
+func TestConfigPutRejectsUnknownAndEmptyJSON(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 200
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", `{}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", "{ }", key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("whitespace empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", "{\n}", key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("newline empty object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.KeepHistory != 200 {
+		t.Fatalf("empty put applied keep_history %d", unpack.KeepHistory)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general",
+		`{"debug":true,"notAField":1}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown field %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general",
+		`{"debug":true}{"debug":false}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("extra json %d %s", rec.Code, rec.Body.String())
+	}
+
+	admin := unpack.Webserver.adminAPIKey()
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		`{"error":"forbidden"}`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("error object %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.Webserver.adminAPIKey() != admin {
+		t.Fatal("forbidden payload wiped live admin key")
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", `[null]`, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("nil sonarr %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestConfigPutFoldersValidationDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	body := `{"interval":"1s","buffer":1000,"folder":[{"path":"/rejected/path","maxBytes":"bogus"}]}`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/folders", body, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bogus folder %d %s", rec.Code, rec.Body.String())
+	}
+
+	if len(unpack.Folders) != 0 {
+		t.Fatalf("rejected folder went live: %+v", unpack.Folders)
+	}
+
+	if len(unpack.fileConfig.Folders) != 0 {
+		t.Fatalf("rejected folder staged: %+v", unpack.fileConfig.Folders)
+	}
+}
+
+func TestConfigPutWebhooksValidationDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	body := `[{"name":"broken"},{"name":"ok","url":"http://127.0.0.1:1/hook"}]`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/webhooks", body, key); rec.Code != http.StatusBadRequest {
+		t.Fatalf("broken webhook %d %s", rec.Code, rec.Body.String())
+	}
+
+	if len(unpack.Webhook) != 0 {
+		t.Fatalf("rejected webhooks went live: %+v", unpack.Webhook)
+	}
+}
+
+func TestConfigPutSonarrPreservesQueueAndPath(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	queued := &sonarr.Queue{}
+	app := &SonarrConfig{Queue: queued}
+	app.URL = "http://127.0.0.1:8989"
+	app.APIKey = strings.Repeat("k", apiKeyMinLength)
+	unpack.Sonarr = []*SonarrConfig{app}
+
+	body := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `","path":"/dl"}]`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", body, key); rec.Code != http.StatusOK {
+		t.Fatalf("first put %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.Sonarr[0].Queue != queued {
+		t.Fatal("PUT dropped last-known Starr queue")
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", body, key); rec.Code != http.StatusOK {
+		t.Fatalf("second put %d %s", rec.Code, rec.Body.String())
+	}
+
+	var hits int
+
+	for _, path := range unpack.Sonarr[0].Paths {
+		if path == "/dl" {
+			hits++
+		}
+	}
+
+	if hits != 1 {
+		t.Fatalf("path merged %d times: %+v", hits, unpack.Sonarr[0].Paths)
+	}
+}
+
+func TestConfigPutWebserverKeepsListenAndEmptyKeys(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+	admin := unpack.Webserver.adminAPIKey()
+	listen := unpack.Webserver.ListenAddr
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	web.ListenAddr = "127.0.0.1:9999"
+	if len(web.APIKeys) == 0 {
+		t.Fatal("expected admin key on GET")
+	}
+
+	web.APIKeys[0].Key = ""
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if unpack.Webserver.ListenAddr != listen {
+		t.Fatalf("live listen changed to %s", unpack.Webserver.ListenAddr)
+	}
+
+	if unpack.fileConfig.Webserver.ListenAddr != "127.0.0.1:9999" {
+		t.Fatalf("file listen %s", unpack.fileConfig.Webserver.ListenAddr)
+	}
+
+	if !reply.RestartRequired {
+		t.Fatal("listen change must require restart")
+	}
+
+	if unpack.Webserver.adminAPIKey() != admin {
+		t.Fatal("empty api key did not keep existing key by name")
+	}
+}
+
+func TestConfigPutURLBaseRoundTripNeedsNoRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.Webserver.URLBase = "/unpackerr/"
+	unpack.snapshotFileConfig()
+	unpack.fileConfig.Webserver.URLBase = "unpackerr"
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", got.Body.String(), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if reply.RestartRequired {
+		t.Fatal("normalized urlbase round trip must not require restart")
+	}
+}
+
+func TestConfigPutWriteFailureLeavesLiveUnchanged(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windows || os.Geteuid() == 0 {
+		t.Skip("cannot chmod a directory unwritable")
+	}
+
+	dir := t.TempDir()
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
+	unpack.KeepHistory = 200
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/general", got.Body.String(), key); rec.Code != http.StatusOK {
+		t.Fatalf("seed put %d %s", rec.Code, rec.Body.String())
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil { //nolint:gosec // need a read-only dir
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) //nolint:gosec // restore after the read-only test
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.KeepHistory = 12
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fail := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), key)
+	if fail.Code != http.StatusInternalServerError {
+		t.Fatalf("write fail %d %s", fail.Code, fail.Body.String())
+	}
+
+	if unpack.KeepHistory != 200 {
+		t.Fatalf("live keep_history after write fail: %d", unpack.KeepHistory)
+	}
+}
+
+func TestWatchWorkThreadStartsWithoutApps(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.watchWorkThread()
+
+	done := make(chan struct{})
+
+	go func() {
+		unpack.workChan <- []func(){func() { close(done) }}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retrieveAppQueues would hang: no workChan consumer")
+	}
+}
+
+func TestConfigPutWebserverDoesNotRaceAuth(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	body := got.Body.String()
+	admin := unpack.Webserver.adminAPIKey()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	hit := func(method, target, payload string) {
+		var reader io.Reader
+		if payload != "" {
+			reader = strings.NewReader(payload)
+		}
+
+		req := httptest.NewRequestWithContext(ctx, method, target, reader)
+		req.Header.Set(headerAPIKey, admin)
+		unpack.Webserver.router.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			hit(http.MethodGet, "/api/auth/me", "")
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		for ctx.Err() == nil {
+			hit(http.MethodPut, "/api/config/webserver", body)
+		}
+	}()
+
+	wait.Wait()
+	// A PUT whose request context expired may still be applying on the loop; drain before TempDir cleanup.
+	_ = unpack.onMainLoop(t.Context(), func() error { return nil })
+}
+
+func TestConfigPutDebugQuietRequiresRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.Config.Debug = false
+	unpack.Quiet = false
+	unpack.snapshotFileConfig()
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var general generalConfig
+	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
+		t.Fatal(err)
+	}
+
+	general.Debug = true
+	general.Quiet = true
+
+	body, err := json.Marshal(general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(body), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reply.RestartRequired {
+		t.Fatal("debug/quiet must require restart")
+	}
+
+	if !unpack.Config.Debug || !unpack.Quiet {
+		t.Fatal("debug/quiet must still apply live")
+	}
+}
+
+func TestConfigPutWebserverKeepsFileKeysOffLiveOverlay(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	fileKey, liveKey := splitFileAndLiveAdminKeys(t, unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	for idx := range web.APIKeys {
+		web.APIKeys[idx].Key = ""
+	}
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, liveKey)
+	})
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	assertFileAndLiveAdminKeys(t, unpack, fileKey, liveKey)
+}
+
+func splitFileAndLiveAdminKeys(t *testing.T, unpack *Unpackerr) (string, string) {
+	t.Helper()
+
+	fileKey := strings.Repeat("F", apiKeyMinLen)
+	liveKey := strings.Repeat("L", apiKeyMinLen)
+	unpack.Webserver.APIKeys = []APIKey{{
+		Name:  defaultAdminKeyName,
+		Key:   liveKey,
+		Roles: []string{RoleAdmin},
+	}}
+
+	if err := unpack.Webserver.validateAuth(); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.snapshotFileConfig()
+	unpack.fileConfig.Webserver.APIKeys = []APIKey{{
+		Name:  defaultAdminKeyName,
+		Key:   fileKey,
+		Roles: []string{RoleAdmin},
+	}}
+
+	return fileKey, liveKey
+}
+
+func assertFileAndLiveAdminKeys(t *testing.T, unpack *Unpackerr, fileKey, liveKey string) {
+	t.Helper()
+
+	if unpack.Webserver.adminAPIKey() != liveKey {
+		t.Fatal("live overlay key must remain the runtime secret")
+	}
+
+	if unpack.fileConfig.Webserver.APIKeys[0].Key != fileKey {
+		t.Fatalf("file key %q", unpack.fileConfig.Webserver.APIKeys[0].Key)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(written)
+	if strings.Contains(text, liveKey) {
+		t.Fatalf("live overlay leaked into the config file:\n%s", text)
+	}
+
+	if !strings.Contains(text, fileKey) {
+		t.Fatalf("file key missing from config file:\n%s", text)
+	}
+}
+
+func TestEnsureWorkThreadsGrowsWithApps(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.watchWorkThread()
+
+	if unpack.workThreads != 1 {
+		t.Fatalf("floor workers %d", unpack.workThreads)
+	}
+
+	unpack.Sonarr = []*SonarrConfig{{}, {}, {}}
+	unpack.ensureWorkThreads(unpack.starrAppCount())
+
+	if unpack.workThreads != 3 {
+		t.Fatalf("grown workers %d", unpack.workThreads)
+	}
+
+	unpack.ensureWorkThreads(1)
+
+	if unpack.workThreads != 3 {
+		t.Fatalf("pool shrank to %d", unpack.workThreads)
+	}
+}
+
+type holdResponseWriter struct {
+	http.ResponseWriter
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *holdResponseWriter) hold() {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+}
+
+func (w *holdResponseWriter) WriteHeader(code int) {
+	w.hold()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *holdResponseWriter) Write(p []byte) (int, error) {
+	w.hold()
+
+	wrote, err := w.ResponseWriter.Write(p)
+	if err != nil {
+		return wrote, fmt.Errorf("write response: %w", err)
+	}
+
+	return wrote, nil
+}
+
+func TestConfigGetReleasesLockBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	admin := unpack.Webserver.adminAPIKey()
+	hold := &holdResponseWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		started:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+
+	var finished sync.WaitGroup
+
+	finished.Go(func() {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/config/sonarr", nil)
+		req.Header.Set(headerAPIKey, admin)
+		unpack.Webserver.router.ServeHTTP(hold, req)
+	})
+
+	select {
+	case <-hold.started:
+	case <-time.After(2 * time.Second):
+		close(hold.release)
+		finished.Wait()
+		t.Fatal("GET never reached response write")
+	}
+
+	putBody := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+	putDone := make(chan int, 1)
+
+	go func() {
+		body := strings.NewReader(putBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/config/sonarr", body)
+		req.Header.Set(headerAPIKey, admin)
+
+		rec := httptest.NewRecorder()
+		unpack.Webserver.router.ServeHTTP(rec, req)
+
+		putDone <- rec.Code
+	}()
+
+	select {
+	case code := <-putDone:
+		if code != http.StatusOK {
+			close(hold.release)
+			finished.Wait()
+			t.Fatalf("PUT during GET write: %d", code)
+		}
+	case <-time.After(2 * time.Second):
+		close(hold.release)
+		finished.Wait()
+		t.Fatal("PUT blocked while GET held the response writer; configMu is still held across encode")
+	}
+
+	close(hold.release)
+	finished.Wait()
+}
+
+// A filepath: Starr key must expand for the live client and stay filepath: on disk.
+func TestConfigPutStarrFilepathKeyExpandsLiveOnly(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	secret := strings.Repeat("s", apiKeyMinLength)
+	keyFile := filepath.Join(t.TempDir(), "sonarr.key")
+
+	if err := os.WriteFile(keyFile, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := json.Marshal([]map[string]string{{"url": "http://127.0.0.1:8989", "apiKey": "filepath:" + keyFile}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", string(body), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	})
+
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	if got := unpack.Sonarr[0].APIKey; got != secret {
+		t.Fatalf("live api key %q, want the file contents", got)
+	}
+
+	if got := unpack.fileConfig.Sonarr[0].APIKey; got != "filepath:"+keyFile {
+		t.Fatalf("file api key %q, want filepath: kept", got)
+	}
+
+	written, err := os.ReadFile(unpack.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The TOML writer escapes path separators, so match the prefix, not the full path.
+	if !strings.Contains(string(written), `api_key = "filepath:`) || strings.Contains(string(written), secret) {
+		t.Fatalf("config on disk must keep filepath: and never the secret:\n%s", written)
+	}
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -74,13 +74,10 @@ func TestConfigPutGeneralRoundTrip(t *testing.T) {
 	}
 }
 
-func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
-	t.Parallel()
-
-	unpack := testAuthUnpackerr(t)
-	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
-	unpack.KeepHistory = 0
-	unpack.snapshotFileConfig()
+// enableHistoryPUT turns keep_history on through the API, the way the settings
+// UI will, on an instance that started with it disabled.
+func enableHistoryPUT(t *testing.T, unpack *Unpackerr, keep uint) {
+	t.Helper()
 
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
@@ -96,7 +93,7 @@ func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	general.KeepHistory = 50
+	general.KeepHistory = keep
 
 	body, err := json.Marshal(general)
 	if err != nil {
@@ -108,9 +105,20 @@ func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
 		t.Fatalf("put %d %s", put.Code, put.Body.String())
 	}
 
-	if unpack.KeepHistory != 50 {
+	if unpack.KeepHistory != keep {
 		t.Fatalf("applied keep_history %d", unpack.KeepHistory)
 	}
+}
+
+func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 0
+	unpack.snapshotFileConfig()
+
+	enableHistoryPUT(t, unpack, 50)
 
 	if len(unpack.Items) != trayHistory {
 		t.Fatalf("tray items after enabling history: %d", len(unpack.Items))
@@ -120,6 +128,38 @@ func TestConfigPutGeneralEnablesTrayHistory(t *testing.T) {
 
 	if unpack.Items[0] != "queued" {
 		t.Fatalf("updateHistory after enable: %+v", unpack.Items)
+	}
+}
+
+// Enabling history at runtime also has to resolve the JSONL path, or rows would
+// stay in memory and vanish on the next restart.
+func TestConfigPutGeneralEnablesHistoryFile(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.KeepHistory = 0
+	unpack.snapshotFileConfig()
+
+	if unpack.histPath != "" {
+		t.Fatal("history path should be unset while keep_history is 0")
+	}
+
+	enableHistoryPUT(t, unpack, 50)
+
+	if unpack.histPath == "" {
+		t.Fatal("enabling keep_history did not resolve the history file path")
+	}
+
+	unpack.maybeRecordHistory("/dl/done", &Extract{Path: "/dl/done", Status: IMPORTED, Updated: time.Now()})
+
+	written, err := os.ReadFile(unpack.histPath)
+	if err != nil {
+		t.Fatalf("history file after enable: %v", err)
+	}
+
+	if !strings.Contains(string(written), `"id":"/dl/done"`) {
+		t.Fatalf("record was not persisted:\n%s", written)
 	}
 }
 
@@ -987,5 +1027,114 @@ func TestConfigPutSetsPendingRestart(t *testing.T) {
 
 	if !unpack.pendingRestart {
 		t.Fatal("a folder list change needs the watcher rebuilt, so it must request a restart")
+	}
+}
+
+// A general PUT that changes nothing must not schedule a re-exec, including on
+// the second pass, when clampConfig has already filled the omitted defaults.
+func TestConfigPutGeneralNoChangeNeedsNoRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/general", "", withKey)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	body := got.Body.String()
+
+	for pass := 1; pass <= 2; pass++ {
+		put := doAuth(t, unpack, http.MethodPut, "/api/config/general", body, withKey)
+		if put.Code != http.StatusOK {
+			t.Fatalf("pass %d put %d %s", pass, put.Code, put.Body.String())
+		}
+
+		var reply configWriteReply
+		if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+			t.Fatal(err)
+		}
+
+		if reply.RestartRequired || unpack.pendingRestart {
+			t.Fatalf("pass %d: unchanged general PUT scheduled a restart", pass)
+		}
+	}
+
+	// Dropping only the clamped mode fields must not restart either: the clamp
+	// refills them with the values live already has.
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(body), &fields); err != nil {
+		t.Fatal(err)
+	}
+
+	delete(fields, "fileMode")
+	delete(fields, "dirMode")
+	delete(fields, "logFileMode")
+
+	trimmed, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/general", string(trimmed), withKey)
+	if put.Code != http.StatusOK {
+		t.Fatalf("omitted modes %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.pendingRestart {
+		t.Fatal("omitting the clamped mode fields must not schedule a restart")
+	}
+
+	if unpack.FileMode == "" || unpack.DirMode == "" || unpack.LogFileMode == "" {
+		t.Fatalf("clamp did not refill modes: %q %q %q", unpack.FileMode, unpack.DirMode, unpack.LogFileMode)
+	}
+}
+
+// A PUT that cannot persist must not leave a restart armed.
+func TestConfigPutWriteFailureDoesNotArmRestart(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod read-only dirs do not block writes on windows")
+	}
+
+	unpack := testAuthUnpackerr(t)
+	dir := filepath.Join(t.TempDir(), "ro")
+
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+
+	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	if err := os.Chmod(dir, 0o555); err != nil { //nolint:gosec // need a read-only dir
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) //nolint:gosec // restore for cleanup
+
+	folders, err := json.Marshal(map[string]any{
+		"interval": "1s", "buffer": 1000, "folder": []map[string]string{{"path": t.TempDir()}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := doAuth(t, unpack, http.MethodPut, "/api/config/folders", string(folders), func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("read-only config should 500: %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.pendingRestart {
+		t.Fatal("a failed PUT changed nothing, so it must not schedule a restart")
 	}
 }

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -575,10 +574,6 @@ func TestConfigPutURLBaseRoundTripNeedsNoRestart(t *testing.T) {
 func TestConfigPutWriteFailureLeavesLiveUnchanged(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == windows || os.Geteuid() == 0 {
-		t.Skip("cannot chmod a directory unwritable")
-	}
-
 	dir := t.TempDir()
 	unpack := testAuthUnpackerr(t)
 	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
@@ -595,11 +590,7 @@ func TestConfigPutWriteFailureLeavesLiveUnchanged(t *testing.T) {
 		t.Fatalf("seed put %d %s", rec.Code, rec.Body.String())
 	}
 
-	if err := os.Chmod(dir, 0o555); err != nil { //nolint:gosec // need a read-only dir
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) //nolint:gosec // restore after the read-only test
+	unpack.ConfigFile = blockedPath(t, "unpackerr.conf")
 
 	var general generalConfig
 	if err := json.Unmarshal(got.Body.Bytes(), &general); err != nil {
@@ -1096,29 +1087,27 @@ func TestConfigPutGeneralNoChangeNeedsNoRestart(t *testing.T) {
 	}
 }
 
+// blockedPath returns a path whose parent is a regular file, so creating it
+// fails with ENOTDIR for any user. Read-only directories do not work here:
+// root ignores the permission bits, and Windows ignores them entirely.
+func blockedPath(t *testing.T, name string) string {
+	t.Helper()
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return filepath.Join(blocker, name)
+}
+
 // A PUT that cannot persist must not leave a restart armed.
 func TestConfigPutWriteFailureDoesNotArmRestart(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
-		t.Skip("chmod read-only dirs do not block writes on windows")
-	}
-
 	unpack := testAuthUnpackerr(t)
-	dir := filepath.Join(t.TempDir(), "ro")
-
-	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatal(err)
-	}
-
-	unpack.ConfigFile = filepath.Join(dir, "unpackerr.conf")
 	unpack.snapshotFileConfig()
-
-	if err := os.Chmod(dir, 0o555); err != nil { //nolint:gosec // need a read-only dir
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) //nolint:gosec // restore for cleanup
+	unpack.ConfigFile = blockedPath(t, "unpackerr.conf")
 
 	folders, err := json.Marshal(map[string]any{
 		"interval": "1s", "buffer": 1000, "folder": []map[string]string{{"path": t.TempDir()}},
@@ -1131,10 +1120,36 @@ func TestConfigPutWriteFailureDoesNotArmRestart(t *testing.T) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
 	})
 	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("read-only config should 500: %d %s", rec.Code, rec.Body.String())
+		t.Fatalf("unwritable config should 500: %d %s", rec.Code, rec.Body.String())
 	}
 
 	if unpack.pendingRestart {
 		t.Fatal("a failed PUT changed nothing, so it must not schedule a restart")
+	}
+}
+
+// History delete and clear must report a failed rewrite instead of a false 200:
+// the rows come back on the next start.
+func TestHistoryWriteFailureReportsError(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.KeepHistory = 10
+	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
+	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
+	unpack.histPath = blockedPath(t, historyFileName)
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	del := doAuth(t, unpack, http.MethodPost, "/api/history/delete", `{"id":"a"}`, withKey)
+	if del.Code != http.StatusInternalServerError {
+		t.Fatalf("delete with an unwritable history file: %d %s", del.Code, del.Body.String())
+	}
+
+	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
+	if cleared.Code != http.StatusInternalServerError {
+		t.Fatalf("clear with an unwritable history file: %d %s", cleared.Code, cleared.Body.String())
 	}
 }

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -951,3 +951,41 @@ func TestConfigPutStarrFilepathKeyExpandsLiveOnly(t *testing.T) {
 		t.Fatalf("config on disk must keep filepath: and never the secret:\n%s", written)
 	}
 }
+
+// Restart-required sections flag the loop; live-only sections do not.
+func TestConfigPutSetsPendingRestart(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	sonarr := `[{"url":"http://127.0.0.1:8989","apiKey":"` + strings.Repeat("k", apiKeyMinLength) + `"}]`
+	if rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr", sonarr, withKey); rec.Code != http.StatusOK {
+		t.Fatalf("sonarr %d %s", rec.Code, rec.Body.String())
+	}
+
+	if unpack.pendingRestart {
+		t.Fatal("a Starr list applies live and must not request a restart")
+	}
+
+	folders, err := json.Marshal(map[string]any{
+		"interval": "1s", "buffer": 1000, "folder": []map[string]string{{"path": t.TempDir()}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := doAuth(t, unpack, http.MethodPut, "/api/config/folders", string(folders), withKey)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("folders %d %s", rec.Code, rec.Body.String())
+	}
+
+	if !unpack.pendingRestart {
+		t.Fatal("a folder list change needs the watcher rebuilt, so it must request a restart")
+	}
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -1153,3 +1153,27 @@ func TestHistoryWriteFailureReportsError(t *testing.T) {
 		t.Fatalf("clear with an unwritable history file: %d %s", cleared.Code, cleared.Body.String())
 	}
 }
+
+// A PUT whose caller went away reports the main-loop timeout the way the queue
+// and live-config handlers do, instead of blaming the payload with a 400.
+func TestConfigPutCanceledRequestIsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/config/general", strings.NewReader(`{"interval":"2m"}`))
+	req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+
+	rec := httptest.NewRecorder()
+	unpack.Webserver.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("canceled PUT should be 504: %d %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -93,18 +93,26 @@ type eventData struct {
 }
 
 func (u *Unpackerr) validateFolders() error {
-	for idx := range u.Folders {
-		if u.Folders[idx].DeleteAfter == nil {
+	return validateFolderList(u.Folders)
+}
+
+func validateFolderList(folders []*FolderConfig) error {
+	for idx := range folders {
+		if folders[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		if folders[idx].DeleteAfter == nil {
 			// If delete after wasn't set, then set it to 10 minutes.
-			u.Folders[idx].DeleteAfter = &cnfg.Duration{Duration: defaultFolderDelete}
+			folders[idx].DeleteAfter = &cnfg.Duration{Duration: defaultFolderDelete}
 		}
 
-		n, _, err := parseOptionalMaxBytes(u.Folders[idx].MaxBytes)
+		n, _, err := parseOptionalMaxBytes(folders[idx].MaxBytes)
 		if err != nil {
-			return fmt.Errorf("folder %s: %w", u.Folders[idx].Path, err)
+			return fmt.Errorf("folder %s: %w", folders[idx].Path, err)
 		}
 
-		u.Folders[idx].maxBytes = n
+		folders[idx].maxBytes = n
 	}
 
 	return nil
@@ -154,11 +162,13 @@ func (u *Unpackerr) PollFolders() {
 
 	u.Folders, flist = checkFolders(u.Folders, u.Logger)
 
-	u.folders, err = u.Folder.newWatcher(u.Folders, u.Logger)
+	folders, err := u.Folder.newWatcher(u.Folders, u.Logger)
 	if err != nil {
 		u.Errorf("Watching Folders: %s", err)
 		return
 	}
+
+	u.folders = folders
 	// do not close either watcher.
 
 	if len(u.Folders) == 0 {
@@ -338,7 +348,12 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	u.folders.Folders[name].updated = now
 	u.folders.Folders[name].status = QUEUED
 
-	if u.skipR00WhenRarExists(name, now) {
+	// Do not extract r00 file if rar file with same name exists.
+	if strings.HasSuffix(strings.ToLower(name), ".r00") &&
+		xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
+		u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
+		u.folders.Folders[name].status = EXTRACTEDNOTHING
+
 		return
 	}
 
@@ -393,24 +408,6 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	}
 
 	u.Printf("[Folder] Queued: %s, queue size: %d", name, queueSize)
-}
-
-// skipR00WhenRarExists records a completed no-op when a .r00 companion is skipped
-// because the matching .rar is already present.
-func (u *Unpackerr) skipR00WhenRarExists(name string, now time.Time) bool {
-	if !strings.HasSuffix(strings.ToLower(name), ".r00") ||
-		!xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
-		return false
-	}
-
-	u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
-	u.folders.Folders[name].status = EXTRACTEDNOTHING
-	u.lockHistory()
-	_ = u.updateQueueStatus(&newStatus{Name: name, Status: QUEUED}, now, false)
-	u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTEDNOTHING}, now, true)
-	u.unlockHistory()
-
-	return true
 }
 
 // folderExcludeSuffixes returns archive suffixes to ignore when scanning for items to extract.

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -760,18 +760,18 @@ func (u *Unpackerr) deleteAfterReached(name string, now time.Time, folder *Folde
 	var webhook bool
 	// Folder reached delete delay (after extraction), nuke it.
 	if folder.config.DeleteFiles && !folder.config.MoveBack {
-		u.delChan <- &fileDeleteReq{Paths: []string{strings.TrimRight(name, `/\`) + suffix}}
+		u.queueDelete(&fileDeleteReq{Paths: []string{strings.TrimRight(name, `/\`) + suffix}})
 		webhook = true
 	} else if folder.config.DeleteFiles && len(folder.files) > 0 {
-		u.delChan <- &fileDeleteReq{Paths: folder.files}
+		u.queueDelete(&fileDeleteReq{Paths: folder.files})
 		webhook = true
 	}
 
 	if folder.config.DeleteOrig && !folder.config.MoveBack {
-		u.delChan <- &fileDeleteReq{Paths: []string{name}}
+		u.queueDelete(&fileDeleteReq{Paths: []string{name}})
 		webhook = true
 	} else if folder.config.DeleteOrig && len(folder.archives) > 0 {
-		u.delChan <- &fileDeleteReq{Paths: folder.archives.List()}
+		u.queueDelete(&fileDeleteReq{Paths: folder.archives.List()})
 		webhook = true
 	}
 

--- a/pkg/unpackerr/folder_test.go
+++ b/pkg/unpackerr/folder_test.go
@@ -200,36 +200,3 @@ func newTestFolders(t *testing.T, cfg *FolderConfig) *Folders {
 
 	return folders
 }
-
-func TestExtractTrackedItemR00WithRarRecordsHistory(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	r00 := filepath.Join(dir, "show.r00")
-	rar := filepath.Join(dir, "show.rar")
-
-	if err := os.WriteFile(r00, []byte("x"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.WriteFile(rar, []byte("x"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	unpack := New()
-	unpack.KeepHistory = 10
-	unpack.histPath = filepath.Join(t.TempDir(), historyFileName)
-	unpack.folders = &Folders{
-		Logs: noopLogger{},
-		Folders: map[string]*Folder{
-			r00: {config: &FolderConfig{}, status: WAITING},
-		},
-	}
-
-	unpack.extractTrackedItem(r00, unpack.folders.Folders[r00], time.Now())
-
-	got := unpack.historySnapshot()
-	if len(got) != 1 || got[0].Status != EXTRACTEDNOTHING || got[0].ID != r00 {
-		t.Fatalf("%+v", got)
-	}
-}

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -269,15 +269,15 @@ func (u *Unpackerr) checkExtractDone(now time.Time) {
 			var webhook bool
 
 			if item.DeleteOrig {
-				u.delChan <- &fileDeleteReq{Paths: []string{item.Path}}
+				u.queueDelete(&fileDeleteReq{Paths: []string{item.Path}})
 				webhook = true //nolint:wsl_v5
 			} else if item.Resp != nil && len(item.Resp.NewFiles) > 0 && item.DeleteDelay >= 0 {
 				// Delete extracted files and purge empty parents up to and including the download path.
-				u.delChan <- &fileDeleteReq{
+				u.queueDelete(&fileDeleteReq{
 					Paths:            item.Resp.NewFiles,
 					PurgeEmptyParent: true,
 					PurgeEmptyRoot:   item.Path,
-				}
+				})
 				webhook = true //nolint:wsl_v5
 			}
 

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -44,27 +44,31 @@ func (h *History) rUnlockHistory() {
 
 // This is called every time an item is queued.
 func (u *Unpackerr) updateHistory(item string) {
-	if u.KeepHistory == 0 {
+	if u.KeepHistory == 0 || len(u.Items) == 0 {
 		return
 	}
 
 	if ui.HasGUI() && item != "" {
-		u.menu[histNone].Hide()
+		if none := u.menu[histNone]; none != nil {
+			none.Hide()
+		}
 	}
 
 	u.Items[0] = item
 
 	// Do not process 0; this isn't an `intrange`.
 	for idx := len(u.Items) - 1; idx > 0; idx-- {
-		// u.History.Items is a slice with a set (identical) length and capacity.
-		switch u.Items[idx] = u.Items[idx-1]; {
-		case !ui.HasGUI():
+		u.Items[idx] = u.Items[idx-1]
+		menu := u.menu[hist+strconv.Itoa(idx)]
+
+		switch {
+		case !ui.HasGUI() || menu == nil:
 			continue
 		case u.Items[idx] != "":
-			u.menu[hist+strconv.Itoa(idx)].SetTitle(u.Items[idx])
-			u.menu[hist+strconv.Itoa(idx)].Show()
+			menu.SetTitle(u.Items[idx])
+			menu.Show()
 		default:
-			u.menu[hist+strconv.Itoa(idx)].Hide()
+			menu.Hide()
 		}
 	}
 }

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -104,7 +105,9 @@ func (u *Unpackerr) loadHistory() {
 
 	// The file is append-only; fold duplicates and over-cap rows on startup.
 	if lines != len(u.records) {
-		u.compactHistoryLocked()
+		if err := u.compactHistoryLocked(); err != nil {
+			u.Errorf("Compacting history file: %v", err)
+		}
 	}
 }
 
@@ -249,7 +252,10 @@ func (u *Unpackerr) upsertHistory(rec HistoryRecord) {
 	}
 
 	if limit := int(u.KeepHistory); limit > 0 && u.histLines >= limit*historyCompactFactor {
-		u.compactHistoryLocked()
+		if err := u.compactHistoryLocked(); err != nil {
+			u.Errorf("Compacting history file: %v", err)
+		}
+
 		return
 	}
 
@@ -275,9 +281,9 @@ func (u *Unpackerr) upsertHistory(rec HistoryRecord) {
 }
 
 // compactHistoryLocked rewrites the file from memory: one line per record.
-func (u *Unpackerr) compactHistoryLocked() {
+func (u *Unpackerr) compactHistoryLocked() error {
 	if u.histPath == "" {
-		return
+		return nil
 	}
 
 	var buf bytes.Buffer
@@ -288,16 +294,16 @@ func (u *Unpackerr) compactHistoryLocked() {
 	}
 
 	if err := os.MkdirAll(filepath.Dir(u.histPath), logsDirMode); err != nil {
-		u.Errorf("Making history dir: %v", err)
-		return
+		return fmt.Errorf("making history dir: %w", err)
 	}
 
 	if err := os.WriteFile(u.histPath, buf.Bytes(), historyFileMode); err != nil {
-		u.Errorf("Writing history file: %v", err)
-		return
+		return fmt.Errorf("writing history file: %w", err)
 	}
 
 	u.histLines = len(u.records)
+
+	return nil
 }
 
 func (u *Unpackerr) historySnapshot() []HistoryRecord {
@@ -360,15 +366,15 @@ func (u *Unpackerr) deleteHistoryID(itemID string) error {
 	}
 
 	u.records = slices.Delete(u.records, idx, idx+1)
-	u.compactHistoryLocked()
 
-	return nil
+	return u.compactHistoryLocked()
 }
 
-func (u *Unpackerr) clearHistory() {
+func (u *Unpackerr) clearHistory() error {
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
 	u.records = nil
-	u.compactHistoryLocked()
+
+	return u.compactHistoryLocked()
 }

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -5,25 +5,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
 	"time"
-
-	"github.com/Unpackerr/unpackerr/pkg/configdef"
 )
 
 const (
 	historyFileName = "unpackerr.history.jsonl"
-	historyScanMax  = 1024 * 1024
+	historyFileMode = 0o600
+	// historyCompactFactor: rewrite the file once appended lines exceed this
+	// many times keep_history, so the on-disk log stays bounded.
+	historyCompactFactor = 2
 )
 
-var (
-	errHistoryLineTooLong = errors.New("history line exceeds maximum")
-	errHistoryNotFound    = errors.New("not found")
-)
+var errHistoryNotFound = errors.New("not found")
 
 // HistoryRecord is one completed or failed pipeline item (JSONL + API).
 type HistoryRecord struct {
@@ -91,114 +88,98 @@ func (u *Unpackerr) loadHistory() {
 	}
 
 	if u.histPath == "" {
-		u.Printf("[Unpackerr] History file disabled; keep_history=%d but no log, config, or home path", u.KeepHistory)
+		u.Printf("[Unpackerr] History file disabled; keep_history=%d but no log, config, or home path",
+			u.KeepHistory)
 
 		return
 	}
 
-	records := u.readHistoryRecords()
-	trimmed := false
-
-	if limit := int(u.KeepHistory); limit > 0 && len(records) > limit {
-		records = records[len(records)-limit:]
-		trimmed = true
-	}
+	lines, records := u.readHistoryRecords()
 
 	u.histMu.Lock()
-	u.records = records
+	defer u.histMu.Unlock()
 
-	if trimmed {
-		if err := u.writeHistoryLocked(); err != nil {
-			u.Errorf("Writing history file: %v", err)
-		}
+	u.records = u.capHistoryLocked(mergeHistory(nil, records...))
+	u.histLines = lines
+
+	// The file is append-only; fold duplicates and over-cap rows on startup.
+	if lines != len(u.records) {
+		u.compactHistoryLocked()
 	}
-
-	u.histMu.Unlock()
 }
 
-func (u *Unpackerr) readHistoryRecords() []HistoryRecord {
+// readHistoryRecords returns the line count and every parseable record, in file
+// order. This is a file we write ourselves; bad lines are skipped, not fatal.
+func (u *Unpackerr) readHistoryRecords() (int, []HistoryRecord) {
 	file, err := os.Open(u.histPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			u.Errorf("Opening history file: %v", err)
 		}
 
-		return nil
+		return 0, nil
 	}
-
 	defer file.Close()
 
-	reader := bufio.NewReader(file)
-
-	var records []HistoryRecord
+	var (
+		reader  = bufio.NewReader(file)
+		records []HistoryRecord
+		lines   int
+	)
 
 	for {
-		line, readErr := readBoundedLine(reader, historyScanMax)
-		switch {
-		case errors.Is(readErr, errHistoryLineTooLong):
-			u.Errorf("Skipping oversized history line")
-		case errors.Is(readErr, io.EOF):
-			return u.appendHistoryLine(records, line)
-		case readErr != nil:
-			u.Errorf("Reading history file: %v", readErr)
+		line, err := reader.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			lines++
 
-			return records
-		default:
-			records = u.appendHistoryLine(records, line)
+			var rec HistoryRecord
+			if jsonErr := json.Unmarshal(line, &rec); jsonErr != nil {
+				u.Errorf("Skipping bad history line: %v", jsonErr)
+			} else {
+				records = append(records, rec)
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			return lines, records
+		} else if err != nil {
+			u.Errorf("Reading history file: %v", err)
+			return lines, records
 		}
 	}
 }
 
-func (u *Unpackerr) appendHistoryLine(records []HistoryRecord, line []byte) []HistoryRecord {
-	line = bytes.TrimSpace(line)
-	if len(line) == 0 {
-		return records
+// mergeHistory upserts recs onto list by ID, keeping the earliest Started.
+func mergeHistory(list []HistoryRecord, recs ...HistoryRecord) []HistoryRecord {
+	for _, rec := range recs {
+		if rec.ID == "" {
+			rec.ID = rec.Path
+		}
+
+		if idx := slices.IndexFunc(list, func(r HistoryRecord) bool { return r.ID == rec.ID }); idx >= 0 {
+			if rec.Started.IsZero() {
+				rec.Started = list[idx].Started
+			}
+
+			list = slices.Delete(list, idx, idx+1)
+		}
+
+		list = append(list, rec)
 	}
 
-	var rec HistoryRecord
-	if err := json.Unmarshal(line, &rec); err != nil {
-		u.Errorf("Skipping bad history line: %v", err)
-
-		return records
-	}
-
-	return append(records, rec)
+	return list
 }
 
-func readBoundedLine(reader *bufio.Reader, maxLen int) ([]byte, error) {
-	var line []byte
-
-	for {
-		chunk, err := reader.ReadSlice('\n')
-		if len(line)+len(chunk) > maxLen {
-			for errors.Is(err, bufio.ErrBufferFull) {
-				_, err = reader.ReadSlice('\n')
-			}
-
-			if err == nil || errors.Is(err, io.EOF) {
-				return nil, errHistoryLineTooLong
-			}
-
-			return nil, fmt.Errorf("reading history line: %w", err)
-		}
-
-		line = append(line, chunk...)
-
-		switch {
-		case errors.Is(err, bufio.ErrBufferFull):
-			continue
-		case err == nil:
-			return bytes.TrimSpace(line), nil
-		case errors.Is(err, io.EOF):
-			return bytes.TrimSpace(line), io.EOF
-		default:
-			return nil, fmt.Errorf("reading history line: %w", err)
-		}
+func (u *Unpackerr) capHistoryLocked(list []HistoryRecord) []HistoryRecord {
+	if limit := int(u.KeepHistory); limit > 0 && len(list) > limit {
+		return list[len(list)-limit:]
 	}
+
+	return list
 }
 
 func (u *Unpackerr) maybeRecordHistory(itemID string, item *Extract) {
-	if item == nil || u.KeepHistory == 0 || !item.Status.isDurableHistory() {
+	if u.KeepHistory == 0 || !item.Status.isDurableHistory() {
 		return
 	}
 
@@ -255,62 +236,68 @@ func historyFromExtract(itemID string, item *Extract) HistoryRecord {
 	return rec
 }
 
+// upsertHistory records one durable transition: update memory, append one
+// line. The file is compacted only when appends outgrow the cap.
 func (u *Unpackerr) upsertHistory(rec HistoryRecord) {
-	if rec.ID == "" {
-		rec.ID = rec.Path
-	}
-
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
-	found := -1
+	u.records = u.capHistoryLocked(mergeHistory(u.records, rec))
 
-	for idx := range u.records {
-		if u.records[idx].ID == rec.ID {
-			found = idx
-			if rec.Started.IsZero() {
-				rec.Started = u.records[idx].Started
-			}
-
-			break
-		}
+	if u.histPath == "" {
+		return
 	}
 
-	if found >= 0 {
-		u.records = append(u.records[:found], u.records[found+1:]...)
+	if limit := int(u.KeepHistory); limit > 0 && u.histLines >= limit*historyCompactFactor {
+		u.compactHistoryLocked()
+		return
 	}
 
-	u.records = append(u.records, rec)
-
-	if limit := int(u.KeepHistory); limit > 0 && len(u.records) > limit {
-		u.records = u.records[len(u.records)-limit:]
+	line, err := json.Marshal(u.records[len(u.records)-1])
+	if err != nil {
+		u.Errorf("Encoding history: %v", err)
+		return
 	}
 
-	if err := u.writeHistoryLocked(); err != nil {
+	file, err := os.OpenFile(u.histPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, historyFileMode)
+	if err != nil {
+		u.Errorf("Opening history file: %v", err)
+		return
+	}
+	defer file.Close()
+
+	if _, err := file.Write(append(line, '\n')); err != nil {
 		u.Errorf("Writing history file: %v", err)
+		return
 	}
+
+	u.histLines++
 }
 
-func (u *Unpackerr) writeHistoryLocked() error {
+// compactHistoryLocked rewrites the file from memory: one line per record.
+func (u *Unpackerr) compactHistoryLocked() {
 	if u.histPath == "" {
-		return nil
+		return
 	}
 
 	var buf bytes.Buffer
 
 	enc := json.NewEncoder(&buf)
-
 	for idx := range u.records {
-		if err := enc.Encode(u.records[idx]); err != nil {
-			return fmt.Errorf("encoding history: %w", err)
-		}
+		_ = enc.Encode(u.records[idx]) //nolint:errchkjson // ExtractStatus has a MarshalText that cannot fail.
 	}
 
-	if err := configdef.AtomicReplace(u.histPath, buf.Bytes()); err != nil {
-		return fmt.Errorf("writing history file: %w", err)
+	if err := os.MkdirAll(filepath.Dir(u.histPath), logsDirMode); err != nil {
+		u.Errorf("Making history dir: %v", err)
+		return
 	}
 
-	return nil
+	if err := os.WriteFile(u.histPath, buf.Bytes(), historyFileMode); err != nil {
+		u.Errorf("Writing history file: %v", err)
+		return
+	}
+
+	u.histLines = len(u.records)
 }
 
 func (u *Unpackerr) historySnapshot() []HistoryRecord {
@@ -367,41 +354,21 @@ func (u *Unpackerr) deleteHistoryID(itemID string) error {
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
-	found := -1
-
-	for idx := range u.records {
-		if u.records[idx].ID == itemID {
-			found = idx
-			break
-		}
-	}
-
-	if found < 0 {
+	idx := slices.IndexFunc(u.records, func(r HistoryRecord) bool { return r.ID == itemID })
+	if idx < 0 {
 		return errHistoryNotFound
 	}
 
-	saved := u.records[found]
-	u.records = slices.Delete(u.records, found, found+1)
-
-	if err := u.writeHistoryLocked(); err != nil {
-		u.records = slices.Insert(u.records, found, saved)
-		return err
-	}
+	u.records = slices.Delete(u.records, idx, idx+1)
+	u.compactHistoryLocked()
 
 	return nil
 }
 
-func (u *Unpackerr) clearHistory() error {
+func (u *Unpackerr) clearHistory() {
 	u.histMu.Lock()
 	defer u.histMu.Unlock()
 
-	saved := u.records
 	u.records = nil
-
-	if err := u.writeHistoryLocked(); err != nil {
-		u.records = saved
-		return err
-	}
-
-	return nil
+	u.compactHistoryLocked()
 }

--- a/pkg/unpackerr/historyfile_test.go
+++ b/pkg/unpackerr/historyfile_test.go
@@ -34,8 +34,8 @@ func TestHistoryUpsertAndCap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	text := string(body)
-	if !strings.Contains(text, `"id":"c"`) || strings.Contains(text, `"id":"a"`) {
+	// Append-only: the file still holds the over-cap row until it is compacted.
+	if text := string(body); !strings.Contains(text, `"id":"c"`) || !strings.Contains(text, `"id":"a"`) {
 		t.Fatalf("file %s", text)
 	}
 
@@ -44,6 +44,15 @@ func TestHistoryUpsertAndCap(t *testing.T) {
 
 	if len(unpack.historySnapshot()) != 2 {
 		t.Fatal("reload")
+	}
+
+	// Load folds the file back to the cap.
+	if body, err = os.ReadFile(unpack.histPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if text := string(body); strings.Contains(text, `"id":"a"`) || strings.Count(text, "\n") != 2 {
+		t.Fatalf("compacted file %s", text)
 	}
 }
 
@@ -148,50 +157,5 @@ func TestLoadHistoryRewritesFileCap(t *testing.T) {
 
 	if strings.Count(string(body), `"id":`) != 1 || !strings.Contains(string(body), `"id":"c"`) {
 		t.Fatalf("file %s", body)
-	}
-}
-
-func TestLoadHistoryKeepsRecordsAfterBadLine(t *testing.T) {
-	t.Parallel()
-
-	path := filepath.Join(t.TempDir(), historyFileName)
-	line := func(id string) string {
-		return `{"id":"` + id + `","path":"` + id + `","status":"imported"}` + "\n"
-	}
-
-	body := line("a") + strings.Repeat("x", historyScanMax+16) + "\n" + line("c")
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	unpack := New()
-	unpack.KeepHistory = 10
-	unpack.histPath = path
-	unpack.loadHistory()
-
-	got := unpack.historySnapshot()
-	if len(got) != 2 || got[0].ID != "c" || got[1].ID != "a" {
-		t.Fatalf("%+v", got)
-	}
-}
-
-func TestLoadHistorySkipsOversizedLineWithoutNewline(t *testing.T) {
-	t.Parallel()
-
-	path := filepath.Join(t.TempDir(), historyFileName)
-	body := `{"id":"a","path":"a","status":"imported"}` + "\n" + strings.Repeat("x", historyScanMax+16)
-
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	unpack := New()
-	unpack.KeepHistory = 10
-	unpack.histPath = path
-	unpack.loadHistory()
-
-	got := unpack.historySnapshot()
-	if len(got) != 1 || got[0].ID != "a" {
-		t.Fatalf("%+v", got)
 	}
 }

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -77,7 +77,7 @@ func (u *Unpackerr) getLidarrQueue(server *LidarrConfig, start time.Time) {
 
 	// Only update if there was not an error fetching.
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Lidarr, server.URL, nil)
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Lidarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Lidarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/mainloop.go
+++ b/pkg/unpackerr/mainloop.go
@@ -1,0 +1,44 @@
+package unpackerr
+
+import (
+	"context"
+	"fmt"
+)
+
+// mainTask is work an HTTP handler hands to the main goroutine in Run().
+// Live config, the queue map, and the folder tracker are owned by that
+// goroutine; HTTP validates and then asks the loop to apply.
+type mainTask struct {
+	fn     func() error
+	result chan error
+}
+
+// onMainLoop runs fn on the main goroutine and waits for it.
+func (u *Unpackerr) onMainLoop(ctx context.Context, fn func() error) error {
+	task := &mainTask{fn: fn, result: make(chan error, 1)}
+
+	select {
+	case u.taskChan <- task:
+	case <-ctx.Done():
+		return fmt.Errorf("main loop: %w", ctx.Err())
+	}
+
+	select {
+	case err := <-task.result:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("main loop: %w", ctx.Err())
+	}
+}
+
+// runMainTasks stands in for Run() in tests that exercise HTTP handlers.
+func (u *Unpackerr) runMainTasks(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task := <-u.taskChan:
+			task.result <- task.fn()
+		}
+	}
+}

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -447,25 +447,17 @@ func (u *Unpackerr) mutateUIPassword(mutate func(*CryptPass) error) error {
 // cloneLiveWebserver copies the running webserver under the password mutex so
 // HTTP GETs cannot race tray updates of UIPassword.
 func (u *Unpackerr) cloneLiveWebserver() *WebServer {
-	if u == nil || u.Webserver == nil {
-		return &WebServer{}
-	}
-
 	u.uiPassMu.RLock()
 	defer u.uiPassMu.RUnlock()
 
 	return cloneWebserver(u.Webserver)
 }
 
-// cloneFileWebserver copies the on-disk webserver snapshot under the same mutex
-// that syncFileUIPassword uses, so GET /api/config/webserver cannot race the tray.
+// cloneFileWebserver copies the on-disk webserver section under configMu so
+// GET /api/config/webserver cannot race a PUT or the tray persist path.
 func (u *Unpackerr) cloneFileWebserver() *WebServer {
-	if u == nil || u.fileConfig == nil || u.fileConfig.Webserver == nil {
-		return u.cloneLiveWebserver()
-	}
-
-	u.uiPassMu.RLock()
-	defer u.uiPassMu.RUnlock()
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
 
 	return cloneWebserver(u.fileConfig.Webserver)
 }

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -82,7 +82,11 @@ func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *ht
 }
 
 func (u *Unpackerr) historyClearHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	u.clearHistory()
+	if err := u.clearHistory(); err != nil {
+		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
 	writeJSON(response, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -92,12 +96,14 @@ func (u *Unpackerr) historyDeleteHandler(response http.ResponseWriter, request *
 		return
 	}
 
-	if err := u.deleteHistoryID(itemID); err != nil {
+	switch err := u.deleteHistoryID(itemID); {
+	case errors.Is(err, errHistoryNotFound):
 		writeJSON(response, http.StatusNotFound, map[string]string{"error": err.Error()})
-		return
+	case err != nil:
+		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
 	}
-
-	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
 }
 
 func writeQueueActionError(response http.ResponseWriter, err error) {

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -15,25 +14,10 @@ import (
 
 const maxActionBody = 4096
 
-type queueActionKind byte
-
-const (
-	queueRetry queueActionKind = iota + 1
-	queueForget
-)
-
-type queueAction struct {
-	kind   queueActionKind
-	id     string
-	errFn  func() error
-	result chan error
-}
-
 var (
 	errQueueNotFound       = errors.New("queue item not found")
 	errQueueNotFailed      = errors.New("queue item is not extractfailed")
 	errQueueNotForgettable = errors.New("queue item is still in progress")
-	errUnknownQueueAction  = errors.New("unknown queue action")
 	errMissingID           = errors.New("id is required")
 )
 
@@ -75,7 +59,7 @@ func (u *Unpackerr) queueRetryHandler(response http.ResponseWriter, request *htt
 		return
 	}
 
-	if err := u.dispatchQueueAction(request.Context(), queueRetry, itemID); err != nil {
+	if err := u.onMainLoop(request.Context(), func() error { return u.retryQueueID(itemID) }); err != nil {
 		writeQueueActionError(response, err)
 		return
 	}
@@ -89,7 +73,7 @@ func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *ht
 		return
 	}
 
-	if err := u.dispatchQueueAction(request.Context(), queueForget, itemID); err != nil {
+	if err := u.onMainLoop(request.Context(), func() error { return u.forgetQueueID(itemID) }); err != nil {
 		writeQueueActionError(response, err)
 		return
 	}
@@ -98,11 +82,7 @@ func (u *Unpackerr) queueForgetHandler(response http.ResponseWriter, request *ht
 }
 
 func (u *Unpackerr) historyClearHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	if err := u.clearHistory(); err != nil {
-		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
+	u.clearHistory()
 	writeJSON(response, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -113,19 +93,11 @@ func (u *Unpackerr) historyDeleteHandler(response http.ResponseWriter, request *
 	}
 
 	if err := u.deleteHistoryID(itemID); err != nil {
-		writeJSON(response, historyDeleteCode(err), map[string]string{"error": err.Error()})
+		writeJSON(response, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
 	}
 
 	writeJSON(response, http.StatusOK, map[string]string{"status": "ok", "id": itemID})
-}
-
-func historyDeleteCode(err error) int {
-	if errors.Is(err, errHistoryNotFound) {
-		return http.StatusNotFound
-	}
-
-	return http.StatusInternalServerError
 }
 
 func writeQueueActionError(response http.ResponseWriter, err error) {
@@ -141,51 +113,7 @@ func writeQueueActionError(response http.ResponseWriter, err error) {
 	}
 }
 
-func (u *Unpackerr) dispatchQueueAction(ctx context.Context, kind queueActionKind, id string) error {
-	action := &queueAction{kind: kind, id: id, errFn: ctx.Err, result: make(chan error, 1)}
-
-	select {
-	case u.queueActChan <- action:
-	case <-ctx.Done():
-		return fmt.Errorf("queue action: %w", ctx.Err())
-	}
-
-	select {
-	case err := <-action.result:
-		return err
-	case <-ctx.Done():
-		return fmt.Errorf("queue action: %w", ctx.Err())
-	}
-}
-
-func (u *Unpackerr) runQueueActions(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case action := <-u.queueActChan:
-			action.result <- u.applyQueueAction(action)
-		}
-	}
-}
-
-func (u *Unpackerr) applyQueueAction(action *queueAction) error {
-	if action.errFn != nil {
-		if err := action.errFn(); err != nil {
-			return fmt.Errorf("queue action: %w", err)
-		}
-	}
-
-	switch action.kind {
-	case queueRetry:
-		return u.retryQueueID(action.id)
-	case queueForget:
-		return u.forgetQueueID(action.id)
-	default:
-		return errUnknownQueueAction
-	}
-}
-
+// retryQueueID runs on the main loop; History.mu covers the HTTP readers of Map.
 func (u *Unpackerr) retryQueueID(itemID string) error {
 	now := time.Now()
 
@@ -215,12 +143,8 @@ func (u *Unpackerr) retryQueueID(itemID string) error {
 }
 
 func (u *Unpackerr) retryFolderLocked(itemID string, item *Extract, now time.Time) error {
-	if u.folders == nil {
-		return errQueueNotFound
-	}
-
 	folder, ok := u.folders.Folders[itemID]
-	if !ok || folder == nil {
+	if !ok {
 		return errQueueNotFound
 	}
 
@@ -257,11 +181,9 @@ func (u *Unpackerr) forgetQueueID(itemID string) error {
 		u.forgotten[itemID] = struct{}{}
 	}
 
-	if u.folders != nil {
-		if _, exists := u.folders.Folders[itemID]; exists {
-			u.folders.Remove(itemID)
-			delete(u.folders.Folders, itemID)
-		}
+	if _, exists := u.folders.Folders[itemID]; exists {
+		u.folders.Remove(itemID)
+		delete(u.folders.Folders, itemID)
 	}
 
 	return nil

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -1,12 +1,8 @@
 package unpackerr
 
 import (
-	"context"
-	"errors"
 	"net/http"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -14,36 +10,6 @@ import (
 	"golift.io/starr"
 	"golift.io/starr/radarr"
 )
-
-func TestQueueActionSkipsCanceled(t *testing.T) {
-	t.Parallel()
-
-	unpack := New()
-	unpack.queueActChan = make(chan *queueAction)
-	unpack.Map["/dl/fail"] = &Extract{Path: "/dl/fail", Status: EXTRACTFAILED, NoRetry: true}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	errc := make(chan error, 1)
-
-	go func() {
-		errc <- unpack.dispatchQueueAction(ctx, queueRetry, "/dl/fail")
-	}()
-
-	action := <-unpack.queueActChan
-
-	cancel()
-
-	action.result <- unpack.applyQueueAction(action)
-
-	if err := <-errc; !errors.Is(err, context.Canceled) {
-		t.Fatalf("dispatch %v", err)
-	}
-
-	item := unpack.Map["/dl/fail"]
-	if item.Status != EXTRACTFAILED || item.Retries != 0 {
-		t.Fatalf("canceled retry applied %+v", item)
-	}
-}
 
 func TestQueueRetryAndForget(t *testing.T) {
 	t.Parallel()
@@ -263,10 +229,6 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
 	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: DELETED, Updated: time.Now()})
 
-	if err := os.WriteFile(unpack.histPath+".bak", []byte(`{"id":"stale"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
 	withKey := func(req *http.Request) {
 		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
 	}
@@ -281,10 +243,6 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 		t.Fatalf("after delete %+v", left)
 	}
 
-	if _, err := os.Stat(unpack.histPath + ".bak"); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("history bak: %v", err)
-	}
-
 	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
 	if cleared.Code != http.StatusOK {
 		t.Fatalf("clear %d", cleared.Code)
@@ -292,61 +250,6 @@ func TestHistoryDeleteAndClear(t *testing.T) {
 
 	if len(unpack.historySnapshot()) != 0 {
 		t.Fatal("history not cleared")
-	}
-}
-
-func TestHistoryWriteFailureRestores(t *testing.T) {
-	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("unix directory permissions")
-	}
-
-	if os.Geteuid() == 0 {
-		t.Skip("root ignores directory permissions")
-	}
-
-	unpack := testAuthUnpackerr(t)
-	unpack.KeepHistory = 10
-
-	dir := t.TempDir()
-
-	sub := filepath.Join(dir, "hist")
-	if err := os.Mkdir(sub, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	unpack.histPath = filepath.Join(sub, historyFileName)
-	unpack.upsertHistory(HistoryRecord{ID: "a", Path: "a", Status: IMPORTED, Updated: time.Now()})
-	unpack.upsertHistory(HistoryRecord{ID: "b", Path: "b", Status: DELETED, Updated: time.Now()})
-
-	if err := os.Chmod(sub, 0o555); err != nil { //nolint:gosec // need a read-only dir
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) }) //nolint:gosec // restore after the read-only test
-
-	withKey := func(req *http.Request) {
-		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
-	}
-
-	del := doAuth(t, unpack, http.MethodPost, "/api/history/delete", `{"id":"a"}`, withKey)
-	if del.Code != http.StatusInternalServerError {
-		t.Fatalf("delete fail %d %s", del.Code, del.Body.String())
-	}
-
-	left := unpack.historySnapshot()
-	if len(left) != 2 {
-		t.Fatalf("delete should restore %+v", left)
-	}
-
-	cleared := doAuth(t, unpack, http.MethodPost, "/api/history/clear", "", withKey)
-	if cleared.Code != http.StatusInternalServerError {
-		t.Fatalf("clear fail %d %s", cleared.Code, cleared.Body.String())
-	}
-
-	if len(unpack.historySnapshot()) != 2 {
-		t.Fatal("clear should restore")
 	}
 }
 

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -68,7 +68,7 @@ func (u *Unpackerr) getRadarrQueue(server *RadarrConfig, start time.Time) {
 
 	// Only update if there was not an error fetching.
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Radarr, server.URL, nil)
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Radarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Radarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -68,7 +68,7 @@ func (u *Unpackerr) getReadarrQueue(server *ReadarrConfig, start time.Time) {
 
 	// Only update if there was not an error fetching.
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Readarr, server.URL, nil)
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Readarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Readarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/remnants.go
+++ b/pkg/unpackerr/remnants.go
@@ -36,13 +36,21 @@ func remnantAction(s string) string {
 	}
 }
 
-func (u *Unpackerr) validateRemnantAction() error {
-	s := strings.TrimSpace(u.RemnantAction)
-	if s != "" && remnantAction(s) != strings.ToLower(s) {
-		return fmt.Errorf("%w: %q (want rename, delete, or off)", ErrInvalidRemnantAction, u.RemnantAction)
+func remnantActionError(s string) error {
+	trimmed := strings.TrimSpace(s)
+	if trimmed != "" && remnantAction(trimmed) != strings.ToLower(trimmed) {
+		return fmt.Errorf("%w: %q (want rename, delete, or off)", ErrInvalidRemnantAction, s)
 	}
 
-	u.RemnantAction = remnantAction(s)
+	return nil
+}
+
+func (u *Unpackerr) validateRemnantAction() error {
+	if err := remnantActionError(u.RemnantAction); err != nil {
+		return err
+	}
+
+	u.RemnantAction = remnantAction(u.RemnantAction)
 
 	return nil
 }

--- a/pkg/unpackerr/restart.go
+++ b/pkg/unpackerr/restart.go
@@ -48,13 +48,13 @@ func (u *Unpackerr) maybeRestart() {
 // pending delete. WAITING and EXTRACTFAILED items are rediscovered from the
 // next Starr poll, so they do not block.
 func (u *Unpackerr) idle() bool {
-	if len(u.updates)+len(u.folders.Updates)+len(u.folders.Events)+len(u.hookChan)+len(u.delChan) > 0 {
+	// inFlight covers deletes and hooks from the send until the worker is
+	// done, so their channel depth is already accounted for.
+	if u.inFlight.Load() > 0 {
 		return false
 	}
 
-	// Channel length misses an item a worker already received, so a delete or
-	// a hook that is running right now also has to hold the restart off.
-	if u.inFlight.Load() > 0 {
+	if len(u.updates)+len(u.folders.Updates)+len(u.folders.Events) > 0 {
 		return false
 	}
 

--- a/pkg/unpackerr/restart.go
+++ b/pkg/unpackerr/restart.go
@@ -1,0 +1,62 @@
+package unpackerr
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+const restartShutdownTimeout = 5 * time.Second
+
+// maybeRestart re-executes the process once a config PUT asked for a restart
+// and nothing is mid-flight. Main loop only, from the cleaner tick.
+func (u *Unpackerr) maybeRestart() {
+	if !u.pendingRestart || !u.idle() {
+		return
+	}
+
+	u.pendingRestart = false
+	u.Printf("[Unpackerr] Config change needs a restart and the queue is idle; restarting now.")
+
+	if u.Webserver != nil && u.Webserver.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), restartShutdownTimeout)
+		_ = u.Webserver.server.Shutdown(ctx)
+
+		cancel()
+	}
+
+	if err := restartProcess(); err != nil {
+		u.Errorf("Restart failed, restart Unpackerr by hand to apply the saved config: %v", err)
+		return
+	}
+
+	os.Exit(0) // Windows only: the replacement is already running. exec(2) never returns here.
+}
+
+// idle reports whether a restart would interrupt an extraction or lose a
+// pending delete. WAITING and EXTRACTFAILED items are rediscovered from the
+// next Starr poll, so they do not block.
+func (u *Unpackerr) idle() bool {
+	if len(u.updates)+len(u.folders.Updates)+len(u.folders.Events)+len(u.hookChan)+len(u.delChan) > 0 {
+		return false
+	}
+
+	for _, folder := range u.folders.Folders {
+		if folder.status == QUEUED || folder.status == EXTRACTING {
+			return false
+		}
+	}
+
+	u.rLockHistory()
+	defer u.rUnlockHistory()
+
+	for _, item := range u.Map {
+		switch item.Status {
+		case QUEUED, EXTRACTING, EXTRACTED, IMPORTED, DELETING:
+			return false
+		case WAITING, EXTRACTFAILED, DELETED, DELETEFAILED, EXTRACTEDNOTHING:
+		}
+	}
+
+	return true
+}

--- a/pkg/unpackerr/restart.go
+++ b/pkg/unpackerr/restart.go
@@ -16,6 +16,17 @@ func (u *Unpackerr) maybeRestart() {
 	}
 
 	u.pendingRestart = false
+
+	// Resolve the binary before anything is torn down. Past this point the
+	// listener is gone, so the only fallible step has to happen first.
+	exe, err := os.Executable()
+	if err != nil {
+		u.Errorf("Config saved, but the Unpackerr binary path is unknown, "+
+			"so it needs a manual restart to apply: %v", err)
+
+		return
+	}
+
 	u.Printf("[Unpackerr] Config change needs a restart and the queue is idle; restarting now.")
 
 	if u.Webserver != nil && u.Webserver.server != nil {
@@ -25,8 +36,8 @@ func (u *Unpackerr) maybeRestart() {
 		cancel()
 	}
 
-	if err := restartProcess(); err != nil {
-		u.Errorf("Restart failed, restart Unpackerr by hand to apply the saved config: %v", err)
+	if err := restartProcess(exe); err != nil {
+		u.Errorf("Restart failed; the saved config needs a manual restart to apply: %v", err)
 		return
 	}
 
@@ -38,6 +49,12 @@ func (u *Unpackerr) maybeRestart() {
 // next Starr poll, so they do not block.
 func (u *Unpackerr) idle() bool {
 	if len(u.updates)+len(u.folders.Updates)+len(u.folders.Events)+len(u.hookChan)+len(u.delChan) > 0 {
+		return false
+	}
+
+	// Channel length misses an item a worker already received, so a delete or
+	// a hook that is running right now also has to hold the restart off.
+	if u.inFlight.Load() > 0 {
 		return false
 	}
 

--- a/pkg/unpackerr/restart_test.go
+++ b/pkg/unpackerr/restart_test.go
@@ -33,7 +33,7 @@ func TestIdleBlocksOnInFlightWork(t *testing.T) {
 	}
 
 	unpack.folders.Folders["/watch/x"].status = WAITING
-	unpack.delChan <- &fileDeleteReq{}
+	unpack.queueDelete(&fileDeleteReq{})
 
 	if unpack.idle() {
 		t.Fatal("a pending delete must block a restart")

--- a/pkg/unpackerr/restart_test.go
+++ b/pkg/unpackerr/restart_test.go
@@ -1,0 +1,55 @@
+package unpackerr
+
+import "testing"
+
+func TestIdleBlocksOnInFlightWork(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	if !unpack.idle() {
+		t.Fatal("empty queue must be idle")
+	}
+
+	unpack.Map["/dl/waiting"] = &Extract{Path: "/dl/waiting", Status: WAITING}
+	unpack.Map["/dl/failed"] = &Extract{Path: "/dl/failed", Status: EXTRACTFAILED}
+
+	if !unpack.idle() {
+		t.Fatal("waiting and failed items are rediscovered after a restart; they must not block")
+	}
+
+	for _, status := range []ExtractStatus{QUEUED, EXTRACTING, EXTRACTED, IMPORTED, DELETING} {
+		unpack.Map["/dl/busy"] = &Extract{Path: "/dl/busy", Status: status}
+
+		if unpack.idle() {
+			t.Fatalf("%s must block a restart", status)
+		}
+	}
+
+	delete(unpack.Map, "/dl/busy")
+	unpack.folders.Folders["/watch/x"] = &Folder{status: EXTRACTING}
+
+	if unpack.idle() {
+		t.Fatal("an extracting folder must block a restart")
+	}
+
+	unpack.folders.Folders["/watch/x"].status = WAITING
+	unpack.delChan <- &fileDeleteReq{}
+
+	if unpack.idle() {
+		t.Fatal("a pending delete must block a restart")
+	}
+}
+
+func TestMaybeRestartWaitsForIdle(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.pendingRestart = true
+	unpack.Map["/dl/busy"] = &Extract{Path: "/dl/busy", Status: EXTRACTING}
+
+	unpack.maybeRestart()
+
+	if !unpack.pendingRestart {
+		t.Fatal("restart must stay pending while an extraction runs")
+	}
+}

--- a/pkg/unpackerr/restart_unix.go
+++ b/pkg/unpackerr/restart_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package unpackerr
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// restartProcess replaces this process image in place. The PID is kept, so a
+// Docker PID 1 or systemd unit sees a reload, not an exit.
+func restartProcess() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil { //nolint:gosec // re-exec of our own binary and args.
+		return fmt.Errorf("exec %s: %w", exe, err)
+	}
+
+	return nil
+}

--- a/pkg/unpackerr/restart_unix.go
+++ b/pkg/unpackerr/restart_unix.go
@@ -10,12 +10,7 @@ import (
 
 // restartProcess replaces this process image in place. The PID is kept, so a
 // Docker PID 1 or systemd unit sees a reload, not an exit.
-func restartProcess() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("finding executable: %w", err)
-	}
-
+func restartProcess(exe string) error {
 	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil { //nolint:gosec // re-exec of our own binary and args.
 		return fmt.Errorf("exec %s: %w", exe, err)
 	}

--- a/pkg/unpackerr/restart_windows.go
+++ b/pkg/unpackerr/restart_windows.go
@@ -7,12 +7,7 @@ import (
 )
 
 // restartProcess starts a fresh copy; the caller exits. Windows has no exec(2).
-func restartProcess() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("finding executable: %w", err)
-	}
-
+func restartProcess(exe string) error {
 	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec,noctx // relaunching ourselves.
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 

--- a/pkg/unpackerr/restart_windows.go
+++ b/pkg/unpackerr/restart_windows.go
@@ -1,0 +1,24 @@
+package unpackerr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// restartProcess starts a fresh copy; the caller exits. Windows has no exec(2).
+func restartProcess() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec,noctx // relaunching ourselves.
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting %s: %w", exe, err)
+	}
+
+	return nil
+}

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -68,7 +68,7 @@ func (u *Unpackerr) getSonarrQueue(server *SonarrConfig, start time.Time) {
 
 	// Only update if there was not an error fetching.
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Sonarr, server.URL, nil)
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Sonarr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Sonarr] Updated (%s): %d Items Queued, %d Retrieved", server.URL, queue.TotalRecords, len(queue.Records))

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -66,29 +66,37 @@ type Unpackerr struct {
 	*Config
 	*History
 	*xtractr.Xtractr
-	metrics      *metrics
-	folders      *Folders
-	sigChan      chan os.Signal
-	updates      chan *xtractr.Response
-	progChan     chan *ExtractProgress
-	hookChan     chan *hookQueueItem
-	delChan      chan *fileDeleteReq
-	queueActChan chan *queueAction
-	workChan     chan []func()
+	metrics  *metrics
+	folders  *Folders
+	sigChan  chan os.Signal
+	updates  chan *xtractr.Response
+	progChan chan *ExtractProgress
+	hookChan chan *hookQueueItem
+	delChan  chan *fileDeleteReq
+	taskChan chan *mainTask // HTTP hands config applies and queue actions to Run().
+	workChan chan []func()
 	*Logger
-	rotatorr         *rotatorr.Logger
-	httpLog          *rotatorr.Logger
-	menu             map[string]ui.MenuItem
-	fileConfig       *Config      // on-disk shape (filepath: values). Config is the live expanded copy.
-	livePasswords    StringSlice  // post-env, pre-expansion; GET /live uses this
-	uiPassMu         sync.RWMutex // guards Webserver.UIPassword
+	rotatorr *rotatorr.Logger
+	httpLog  *rotatorr.Logger
+	menu     map[string]ui.MenuItem
+	// Live Config is owned by the main goroutine in Run(). fileConfig is the
+	// on-disk shape (filepath: values kept) and is also written by the tray,
+	// so it and the hook slices that /api/stats counts sit under configMu.
+	fileConfig       *Config
+	livePasswords    StringSlice // post-env, pre-expansion; GET /live uses this
+	configMu         sync.RWMutex
+	tickers          *loopTickers
+	workThreads      int
+	hookOnce         sync.Once
+	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
 	uiPasswordNotice string
 	uiPasswordGenErr error
 	configWriteErr   error
 	adminKeyNotice   string
 	adminKeyErr      error
 	histPath         string
-	histMu           sync.Mutex
+	histMu           sync.Mutex // records and the JSONL file; HTTP reads, main loop appends.
+	histLines        int        // lines in the file since the last compaction.
 	records          []HistoryRecord
 }
 
@@ -121,16 +129,17 @@ type Flags struct {
 // An empty struct will surely cause you pain, so use this!
 func New() *Unpackerr {
 	return &Unpackerr{
-		Flags:        &Flags{EnvPrefix: "UN"},
-		hookChan:     make(chan *hookQueueItem, updateChanBuf),
-		delChan:      make(chan *fileDeleteReq, updateChanBuf),
-		queueActChan: make(chan *queueAction, updateChanBuf),
-		sigChan:      make(chan os.Signal, signalBuf),
-		workChan:     make(chan []func(), 1),
-		History:      &History{Map: make(map[string]*Extract), forgotten: make(map[string]struct{})},
-		updates:      make(chan *xtractr.Response, updateChanBuf),
-		progChan:     make(chan *ExtractProgress),
-		menu:         make(map[string]ui.MenuItem),
+		Flags:    &Flags{EnvPrefix: "UN"},
+		hookChan: make(chan *hookQueueItem, updateChanBuf),
+		delChan:  make(chan *fileDeleteReq, updateChanBuf),
+		taskChan: make(chan *mainTask, updateChanBuf),
+		sigChan:  make(chan os.Signal, signalBuf),
+		workChan: make(chan []func(), 1),
+		History:  &History{Map: make(map[string]*Extract), forgotten: make(map[string]struct{})},
+		folders:  &Folders{Folders: make(map[string]*Folder)}, // replaced by PollFolders when folders are configured.
+		updates:  make(chan *xtractr.Response, updateChanBuf),
+		progChan: make(chan *ExtractProgress),
+		menu:     make(map[string]ui.MenuItem),
 		Config: &Config{
 			KeepHistory:   defaultHistory,
 			LogQueues:     cnfg.Duration{Duration: time.Minute + time.Second},
@@ -225,9 +234,7 @@ func Start() error {
 		DirMode:  os.FileMode(dirMode),
 	})
 
-	if len(unpackerr.Webhook) > 0 || len(unpackerr.Cmdhook) > 0 {
-		go unpackerr.watchCmdAndWebhooks()
-	}
+	unpackerr.ensureHookWorker()
 
 	go unpackerr.watchDeleteChannel()
 
@@ -352,6 +359,12 @@ func dirIsEmpty(path string) bool {
 	return err == io.EOF //nolint:errorlint // this is still correct.
 }
 
+func (u *Unpackerr) ensureHookWorker() {
+	u.hookOnce.Do(func() {
+		go u.watchCmdAndWebhooks()
+	})
+}
+
 func (u *Unpackerr) watchCmdAndWebhooks() {
 	for hook := range u.hookChan {
 		if hook.URL != "" {
@@ -382,20 +395,37 @@ func (u *Unpackerr) ParseFlags() *Unpackerr {
 }
 
 // Run starts the loop that does the work.
-func (u *Unpackerr) Run() {
-	var (
-		poller   = time.NewTicker(u.Interval.Duration)   // poll apps at configured interval.
-		cleaner  = time.NewTicker(cleanerInterval)       // clean at a fast interval.
-		xtractr  = time.NewTicker(u.StartDelay.Duration) // Check if an extract needs to start.
-		progress = time.NewTicker(u.Progress.Duration)   // Progress update for extractions.
-		now      = version.Started                       // Used for file system event time stamps.
-	)
+// loopTickers are owned by Run(). A general config PUT resets them in place.
+type loopTickers struct {
+	poller   *time.Ticker // poll apps at configured interval.
+	xtractr  *time.Ticker // check if an extract needs to start.
+	progress *time.Ticker // progress update for extractions.
+	logger   *time.Ticker // log/print current queue counts.
+}
 
-	// Only start the queue/totals log timer when at least one app or folder is configured.
-	var logger <-chan time.Time
-	if len(u.Lidarr)+len(u.Radarr)+len(u.Readarr)+len(u.Sonarr)+len(u.Whisparr)+len(u.Folders) > 0 {
-		logger = time.NewTicker(u.Config.LogQueues.Duration).C
-	} else {
+func (u *Unpackerr) resetTickers() {
+	if u.tickers == nil {
+		return // PUT before Run(); tests do this.
+	}
+
+	u.tickers.poller.Reset(u.Interval.Duration)
+	u.tickers.xtractr.Reset(u.StartDelay.Duration)
+	u.tickers.progress.Reset(u.Progress.Duration)
+	u.tickers.logger.Reset(u.LogQueues.Duration)
+}
+
+func (u *Unpackerr) Run() {
+	u.tickers = &loopTickers{
+		poller:   time.NewTicker(u.Interval.Duration),
+		xtractr:  time.NewTicker(u.StartDelay.Duration),
+		progress: time.NewTicker(u.Progress.Duration),
+		logger:   time.NewTicker(u.LogQueues.Duration),
+	}
+
+	cleaner := time.NewTicker(cleanerInterval) // clean at a fast interval.
+	now := version.Started                     // Used for file system event time stamps.
+
+	if u.starrAppCount()+len(u.Folders) == 0 {
 		u.Printf("No Starr apps or folders configured. Shut down and add some apps or folders to your config file.")
 	}
 
@@ -405,12 +435,12 @@ func (u *Unpackerr) Run() {
 	// This is the "main go routine" in start.go.
 	for {
 		select {
-		case now = <-poller.C:
+		case now = <-u.tickers.poller.C:
 			// polling interval. pull queue data from all apps.
 			u.retrieveAppQueues(now)
 			// check for state changes in the qpp queues.
 			u.checkQueueChanges(now)
-		case now = <-xtractr.C:
+		case now = <-u.tickers.xtractr.C:
 			// Check if any completed items have elapsed their start delay.
 			u.extractCompletedDownloads(now)
 		case now = <-cleaner.C:
@@ -426,16 +456,18 @@ func (u *Unpackerr) Run() {
 		case event := <-u.folders.Events:
 			// file system event for watched folder.
 			u.processEvent(event, now)
-		case action := <-u.queueActChan:
-			// HTTP retry/forget must mutate Map and Folders on this goroutine.
-			action.result <- u.applyQueueAction(action)
-		case now := <-logger:
-			// Log/print current queue counts once in a while.
-			u.logCurrentQueue(now)
+		case task := <-u.taskChan:
+			// HTTP config PUT and queue retry/forget mutate live state on this goroutine.
+			task.result <- task.fn()
+		case now := <-u.tickers.logger.C:
+			// Log/print current queue counts once in a while, when something is configured.
+			if u.starrAppCount()+len(u.Folders) > 0 {
+				u.logCurrentQueue(now)
+			}
 		case prog := <-u.progChan:
 			// Update progress for in-process extractions.
 			u.handleProgress(prog)
-		case now = <-progress.C:
+		case now = <-u.tickers.progress.C:
 			// Print the collected progress info.
 			u.printProgress(now)
 		}

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -88,7 +88,7 @@ type Unpackerr struct {
 	configMu         sync.RWMutex
 	tickers          *loopTickers
 	pendingRestart   bool
-	inFlight         atomic.Int64 // delete and hook work a worker already received.
+	inFlight         atomic.Int64 // queued-or-running delete and hook work.
 	workThreads      int
 	hookOnce         sync.Once
 	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
@@ -263,21 +263,27 @@ func fileList(paths ...string) []string {
 	return files
 }
 
+// queueDelete publishes a delete request and counts it in flight. Counting at
+// the send keeps it atomic with respect to idle(): both run on the main loop,
+// so a restart can never observe the gap between a send and its receive.
+func (u *Unpackerr) queueDelete(req *fileDeleteReq) {
+	u.inFlight.Add(1)
+
+	u.delChan <- req
+}
+
 func (u *Unpackerr) watchDeleteChannel() {
 	for input := range u.delChan {
-		if len(input.Paths) == 0 {
-			continue
-		}
-
 		u.deleteRequest(input)
 	}
 }
 
-// deleteRequest counts itself in flight so an idle-gated restart cannot land
-// between the receive and the last file being removed.
 func (u *Unpackerr) deleteRequest(input *fileDeleteReq) {
-	u.inFlight.Add(1)
-	defer u.inFlight.Add(-1)
+	defer u.inFlight.Add(-1) // paired with queueDelete.
+
+	if len(input.Paths) == 0 {
+		return
+	}
 
 	u.Debugf("Deleting files: %s", strings.Join(fileList(input.Paths...), ", "))
 	u.DeleteFiles(input.Paths...)
@@ -377,17 +383,21 @@ func (u *Unpackerr) ensureHookWorker() {
 	})
 }
 
+// queueHook publishes a hook and counts it in flight. See queueDelete.
+func (u *Unpackerr) queueHook(item *hookQueueItem) {
+	u.inFlight.Add(1)
+
+	u.hookChan <- item
+}
+
 func (u *Unpackerr) watchCmdAndWebhooks() {
 	for hook := range u.hookChan {
 		u.runHook(hook)
 	}
 }
 
-// runHook counts itself in flight so an idle-gated restart cannot drop a
-// webhook or command that is already running.
 func (u *Unpackerr) runHook(hook *hookQueueItem) {
-	u.inFlight.Add(1)
-	defer u.inFlight.Add(-1)
+	defer u.inFlight.Add(-1) // paired with queueHook.
 
 	if hook.URL != "" {
 		u.sendWebhookWithLog(hook.WebhookConfig, hook.WebhookPayload)

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -86,6 +86,7 @@ type Unpackerr struct {
 	livePasswords    StringSlice // post-env, pre-expansion; GET /live uses this
 	configMu         sync.RWMutex
 	tickers          *loopTickers
+	pendingRestart   bool
 	workThreads      int
 	hookOnce         sync.Once
 	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
@@ -447,6 +448,7 @@ func (u *Unpackerr) Run() {
 			// Check for extraction state changes and act on them.
 			u.checkExtractDone(now)
 			u.checkFolderStats(now)
+			u.maybeRestart()
 		case resp := <-u.updates:
 			// xtractr callback for starr download extraction.
 			u.handleXtractrCallback(resp)

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
@@ -87,6 +88,7 @@ type Unpackerr struct {
 	configMu         sync.RWMutex
 	tickers          *loopTickers
 	pendingRestart   bool
+	inFlight         atomic.Int64 // delete and hook work a worker already received.
 	workThreads      int
 	hookOnce         sync.Once
 	uiPassMu         sync.RWMutex // live webserver auth: UIPassword, APIKeys, Roles, keyPerms, Upstreams, allow
@@ -267,24 +269,33 @@ func (u *Unpackerr) watchDeleteChannel() {
 			continue
 		}
 
-		u.Debugf("Deleting files: %s", strings.Join(fileList(input.Paths...), ", "))
-		u.DeleteFiles(input.Paths...)
+		u.deleteRequest(input)
+	}
+}
 
-		if !input.PurgeEmptyParent {
-			continue
-		}
+// deleteRequest counts itself in flight so an idle-gated restart cannot land
+// between the receive and the last file being removed.
+func (u *Unpackerr) deleteRequest(input *fileDeleteReq) {
+	u.inFlight.Add(1)
+	defer u.inFlight.Add(-1)
 
-		root := input.PurgeEmptyRoot
+	u.Debugf("Deleting files: %s", strings.Join(fileList(input.Paths...), ", "))
+	u.DeleteFiles(input.Paths...)
+
+	if !input.PurgeEmptyParent {
+		return
+	}
+
+	root := input.PurgeEmptyRoot
+	if root != "" {
+		root = filepath.Clean(root)
+	}
+
+	if purged := u.purgeEmptyFolders(input.Paths, root); purged > 0 {
 		if root != "" {
-			root = filepath.Clean(root)
-		}
-
-		if purged := u.purgeEmptyFolders(input.Paths, root); purged > 0 {
-			if root != "" {
-				u.Printf("Purged %d empty folder(s) up to %s", purged, root)
-			} else {
-				u.Printf("Purged %d empty folder(s)", purged)
-			}
+			u.Printf("Purged %d empty folder(s) up to %s", purged, root)
+		} else {
+			u.Printf("Purged %d empty folder(s)", purged)
 		}
 	}
 }
@@ -368,13 +379,22 @@ func (u *Unpackerr) ensureHookWorker() {
 
 func (u *Unpackerr) watchCmdAndWebhooks() {
 	for hook := range u.hookChan {
-		if hook.URL != "" {
-			u.sendWebhookWithLog(hook.WebhookConfig, hook.WebhookPayload)
-		}
+		u.runHook(hook)
+	}
+}
 
-		if hook.Command != "" {
-			u.runCmdhookWithLog(hook.WebhookConfig, hook.WebhookPayload)
-		}
+// runHook counts itself in flight so an idle-gated restart cannot drop a
+// webhook or command that is already running.
+func (u *Unpackerr) runHook(hook *hookQueueItem) {
+	u.inFlight.Add(1)
+	defer u.inFlight.Add(-1)
+
+	if hook.URL != "" {
+		u.sendWebhookWithLog(hook.WebhookConfig, hook.WebhookPayload)
+	}
+
+	if hook.Command != "" {
+		u.runCmdhookWithLog(hook.WebhookConfig, hook.WebhookPayload)
 	}
 }
 

--- a/pkg/unpackerr/tray.go
+++ b/pkg/unpackerr/tray.go
@@ -56,7 +56,10 @@ func (u *Unpackerr) readyTray() {
 	u.menu["info"].Disable()
 
 	go u.watchKillerChannels()
-	go u.watchDebugChannels()
+
+	if u.menu["debug"] != nil {
+		go u.watchDebugChannels()
+	}
 	go u.Run()
 
 	u.showGeneratedPassword()
@@ -99,10 +102,6 @@ func (u *Unpackerr) makeChannels() {
 }
 
 func (u *Unpackerr) watchDebugChannels() {
-	if !u.Config.Debug {
-		return
-	}
-
 	for {
 		select {
 		case <-u.menu["debug"].Clicked():

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -139,13 +139,13 @@ func (u *Unpackerr) runAllHooks(item *Extract) {
 
 	for _, hook := range u.hookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
-			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
+			u.queueHook(&hookQueueItem{WebhookConfig: hook, WebhookPayload: payload})
 		}
 	}
 
 	for _, hook := range u.cmdhookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
-			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
+			u.queueHook(&hookQueueItem{WebhookConfig: hook, WebhookPayload: payload})
 		}
 	}
 }

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -137,13 +137,13 @@ func (u *Unpackerr) runAllHooks(item *Extract) {
 		}
 	}
 
-	for _, hook := range u.Webhook {
+	for _, hook := range u.hookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
 			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
 		}
 	}
 
-	for _, hook := range u.Cmdhook {
+	for _, hook := range u.cmdhookList() {
 		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
 			u.hookChan <- &hookQueueItem{WebhookConfig: hook, WebhookPayload: payload}
 		}
@@ -220,43 +220,65 @@ func (w *WebhookConfig) send(ctx context.Context, body io.Reader) ([]byte, error
 	return reply, nil
 }
 
-func (u *Unpackerr) validateWebhook() error { //nolint:cyclop
-	for idx := range u.Webhook {
-		u.Webhook[idx].Command = ""
+func (u *Unpackerr) hookList() []*WebhookConfig {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
 
-		if u.Webhook[idx].URL == "" {
+	return u.Webhook
+}
+
+func (u *Unpackerr) cmdhookList() []*WebhookConfig {
+	u.configMu.RLock()
+	defer u.configMu.RUnlock()
+
+	return u.Cmdhook
+}
+
+func (u *Unpackerr) validateWebhook() error {
+	return u.validateWebhookList(u.Webhook)
+}
+
+func (u *Unpackerr) validateWebhookList(list []*WebhookConfig) error { //nolint:cyclop
+	for idx := range list {
+		if list[idx] == nil {
+			return errNilConfigEntry
+		}
+
+		list[idx].Command = ""
+
+		if list[idx].URL == "" {
 			return ErrWebhookNoURL
 		}
 
-		if u.Webhook[idx].Name == "" {
-			u.Webhook[idx].Name = u.Webhook[idx].URL
+		if list[idx].Name == "" {
+			list[idx].Name = list[idx].URL
 		}
 
-		if u.Webhook[idx].Nickname == "" && u.Webhook[idx].TmplPath == "" &&
-			!strings.Contains(u.Webhook[idx].URL, "pushover.net") {
-			u.Webhook[idx].Nickname = "Unpackerr"
+		if list[idx].Nickname == "" && list[idx].TmplPath == "" &&
+			!strings.Contains(list[idx].URL, "pushover.net") {
+			list[idx].Nickname = "Unpackerr"
 		}
 
-		if u.Webhook[idx].CType == "" {
-			u.Webhook[idx].CType = "application/json"
-			if strings.Contains(u.Webhook[idx].URL, "pushover.net") {
-				u.Webhook[idx].CType = "application/x-www-form-urlencoded"
+		if list[idx].CType == "" {
+			list[idx].CType = "application/json"
+			if strings.Contains(list[idx].URL, "pushover.net") {
+				list[idx].CType = "application/x-www-form-urlencoded"
 			}
 		}
 
-		if u.Webhook[idx].Timeout.Duration == 0 {
-			u.Webhook[idx].Timeout.Duration = u.Timeout.Duration
+		if list[idx].Timeout.Duration == 0 {
+			list[idx].Timeout.Duration = u.Timeout.Duration
 		}
 
-		if len(u.Webhook[idx].Events) == 0 {
-			u.Webhook[idx].Events = []ExtractStatus{WAITING}
+		if len(list[idx].Events) == 0 {
+			list[idx].Events = []ExtractStatus{WAITING}
 		}
 
-		if u.Webhook[idx].client == nil {
-			u.Webhook[idx].client = &http.Client{
-				Timeout: u.Webhook[idx].Timeout.Duration,
+		if list[idx].client == nil {
+			list[idx].client = &http.Client{
+				Timeout: list[idx].Timeout.Duration,
 				Transport: &http.Transport{TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: u.Webhook[idx].IgnoreSSL, //nolint:gosec
+					InsecureSkipVerify: list[idx].IgnoreSSL, //nolint:gosec
 				}},
 			}
 		}
@@ -343,7 +365,11 @@ func (w *WebhookConfig) HasEvent(e ExtractStatus) bool {
 func (u *Unpackerr) WebhookCounts() (uint, uint) {
 	var total, fails uint
 
-	for _, hook := range u.Webhook {
+	for _, hook := range u.hookList() {
+		if hook == nil {
+			continue
+		}
+
 		posts, failures := hook.Counts()
 		total += posts
 		fails += failures

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -194,7 +194,7 @@ func Index(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 // under specific circumstances.
 func (u *Unpackerr) fixForwardedFor(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:varnamelen
-		if x := r.Header.Get("X-Forwarded-For"); x == "" || !u.Webserver.allow.Contains(r.RemoteAddr) {
+		if x := r.Header.Get("X-Forwarded-For"); x == "" || !u.webAllowContains(r.RemoteAddr) {
 			r.Header.Set("X-Forwarded-For",
 				strings.Trim(r.RemoteAddr[:strings.LastIndex(r.RemoteAddr, ":")], "[]"))
 		} else if l := strings.LastIndexAny(x, ", "); l != -1 {

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -76,7 +76,7 @@ func (u *Unpackerr) getWhisparrQueue(server *RadarrConfig, start time.Time) {
 
 	// Only update if there was not an error fetching.
 	server.Queue = queue
-	u.saveQueueMetrics(server.Queue.TotalRecords, start, starr.Whisparr, server.URL, nil)
+	u.saveQueueMetrics(queue.TotalRecords, start, starr.Whisparr, server.URL, nil)
 
 	if !u.Activity || queue.TotalRecords > 0 {
 		u.Printf("[Whisparr] Updated (%s): %d Items Queued, %d Retrieved",


### PR DESCRIPTION
Replaces #688, which accumulated 26 review rounds of concurrency scaffolding built one comment at a time. Same feature, rebuilt on a single ownership rule.

## Model

The `Run()` goroutine owns live `Config`, the queue map, and the folder tracker. HTTP handlers read the body, then hand decode + validate + file write + live apply to that goroutine through `onMainLoop`. Queue retry/forget use the same handoff. `configMu` now covers only `fileConfig` (also written by the tray) and the hook slices `/api/stats` counts. No config lock is taken anywhere on the extraction path.

## Fixes over #688

- A `filepath:` Starr API key survived a GET/PUT round trip on disk but was published to the live client as the literal string, so that app 401'd until restart. The live list is now expanded the way startup does it.
- `retrieveAppQueues` swapped the live app lists for a snapshot and back; with PUT on the main loop the lists cannot change mid-poll, so that is gone.
- `u.Items` (the tray ring) was allocated from the HTTP goroutine by `clampConfig`; it is main-loop-only again.
- A skipped `.r00` companion entered the queue map and fired an `EXTRACTEDNOTHING` webhook purely to get a history row. Reverted to pre-stack behavior.

## Removed

`applied.go` and its atomic snapshot, the four `carry*Queues` / `clone*List` copies, five identical Starr PUT handlers, the bounded JSONL line reader, atomic-rename + rollback + `.bak` sweep on the history file, the context-cancel short-circuit on queue actions, and the nil guards on `New()`-allocated fields.

## Added

- General PUT resets the loop tickers in place, so interval changes no longer report `restartRequired`.
- Sections that cannot be re-applied in place (folders, listener/TLS/urlbase, logger, xtractr options) set `pendingRestart`; the cleaner tick re-execs the binary once nothing is queued, extracting, or waiting on a delete. `syscall.Exec` keeps the PID on unix; Windows starts a copy and exits. Tray re-init on macOS/Windows after re-exec needs a manual check.
- History is append-only: one line per durable transition, compacted on load and when appends reach 2× `keep_history`.
- `TestWriteConfigFileFullRoundTrip`: every section populated with non-default values, rendered, reloaded through `cnfgfile.Unmarshal`, compared field for field.
- `.github/copilot-instructions.md` with the review guidance this model assumes.

Net −555 lines against #688's head. `go test -race ./...` and `golangci-lint` clean; each commit builds on its own.
