### PR TITLE
Serve a committed OpenAPI 3 spec at /api/openapi.json

### DIFF
--- a/pkg/unpackerr/openapi.go
+++ b/pkg/unpackerr/openapi.go
@@ -1,0 +1,22 @@
+package unpackerr
+
+import (
+	_ "embed"
+	"net/http"
+	"path"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+//go:embed openapi.json
+var openapiJSON []byte
+
+func (u *Unpackerr) registerOpenAPIRoute() {
+	u.Webserver.router.GET(path.Join(u.Webserver.URLBase, "api", "openapi.json"), u.openapiHandler)
+}
+
+func (u *Unpackerr) openapiHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(http.StatusOK)
+	_, _ = response.Write(openapiJSON)
+}

--- a/pkg/unpackerr/openapi.go
+++ b/pkg/unpackerr/openapi.go
@@ -2,8 +2,10 @@ package unpackerr
 
 import (
 	_ "embed"
+	"encoding/json"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -11,12 +13,50 @@ import (
 //go:embed openapi.json
 var openapiJSON []byte
 
-func (u *Unpackerr) registerOpenAPIRoute() {
-	u.Webserver.router.GET(path.Join(u.Webserver.URLBase, "api", "openapi.json"), u.openapiHandler)
+func openAPIServerURL(urlbase string) string {
+	base := strings.TrimSuffix(urlbase, "/")
+	if base == "" {
+		return "/"
+	}
+
+	return base
 }
 
-func (u *Unpackerr) openapiHandler(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	response.Header().Set("Content-Type", "application/json")
-	response.WriteHeader(http.StatusOK)
-	_, _ = response.Write(openapiJSON)
+func openAPISpec(urlbase string) []byte {
+	var doc map[string]any
+	if err := json.Unmarshal(openapiJSON, &doc); err != nil {
+		return openapiJSON
+	}
+
+	servers, _ := doc["servers"].([]any)
+	if len(servers) == 0 {
+		return openapiJSON
+	}
+
+	server, ok := servers[0].(map[string]any)
+	if !ok {
+		return openapiJSON
+	}
+
+	server["url"] = openAPIServerURL(urlbase)
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return openapiJSON
+	}
+
+	return out
+}
+
+func (u *Unpackerr) registerOpenAPIRoute() {
+	spec := openAPISpec(u.Webserver.URLBase)
+	u.Webserver.router.GET(path.Join(u.Webserver.URLBase, "api", "openapi.json"), openapiHandler(spec))
+}
+
+func openapiHandler(spec []byte) httprouter.Handle {
+	return func(response http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+		response.Header().Set("Content-Type", "application/json")
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write(spec)
+	}
 }

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -1,0 +1,425 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Unpackerr API",
+    "version": "1.0.0",
+    "description": "HTTP API for Unpackerr. Login returns an admin API key and a session cookie. After that, send X-Api-Key (or Authorization: Bearer). This spec contains no secret values."
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This Unpackerr instance (respect urlbase)"
+    }
+  ],
+  "tags": [
+    {"name": "auth"},
+    {"name": "system"},
+    {"name": "queue"},
+    {"name": "history"},
+    {"name": "config"}
+  ],
+  "security": [
+    {"apiKey": []},
+    {"bearer": []},
+    {"session": []}
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
+      },
+      "bearer": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "session": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {"type": "string"}
+        }
+      },
+      "LoginRequest": {
+        "type": "object",
+        "required": ["name", "kdf"],
+        "properties": {
+          "name": {"type": "string", "description": "Username (default admin)"},
+          "kdf": {"type": "string", "description": "PBKDF2-HMAC-SHA-256 hex of the password; never send plaintext"}
+        }
+      },
+      "AuthInfo": {
+        "type": "object",
+        "properties": {
+          "username": {"type": "string"},
+          "apiKey": {"type": "string"},
+          "auth": {"type": "string"},
+          "via": {"type": "string"},
+          "permissions": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "Stats": {
+        "type": "object",
+        "properties": {
+          "waiting": {"type": "integer"},
+          "queued": {"type": "integer"},
+          "extracting": {"type": "integer"},
+          "failed": {"type": "integer"},
+          "extracted": {"type": "integer"},
+          "imported": {"type": "integer"},
+          "deleted": {"type": "integer"},
+          "hookOK": {"type": "integer"},
+          "hookFail": {"type": "integer"},
+          "cmdOK": {"type": "integer"},
+          "cmdFail": {"type": "integer"},
+          "retries": {"type": "integer"},
+          "finished": {"type": "integer"}
+        }
+      },
+      "SystemInfo": {
+        "type": "object",
+        "properties": {
+          "version": {"type": "string"},
+          "revision": {"type": "string"},
+          "started": {"type": "string", "format": "date-time"},
+          "uptime": {"type": "string"},
+          "listenAddr": {"type": "string"},
+          "urlbase": {"type": "string"},
+          "auth": {"type": "string"},
+          "metrics": {"type": "boolean"}
+        }
+      },
+      "QueueItem": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "app": {"type": "string"},
+          "url": {"type": "string"},
+          "path": {"type": "string"},
+          "outputPath": {"type": "string"},
+          "status": {"type": "string"},
+          "retries": {"type": "integer"},
+          "updated": {"type": "string", "format": "date-time"},
+          "progress": {"type": "string"},
+          "error": {"type": "string"}
+        }
+      },
+      "HistoryRecord": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "app": {"type": "string"},
+          "url": {"type": "string"},
+          "path": {"type": "string"},
+          "outputPath": {"type": "string"},
+          "status": {"type": "string"},
+          "retries": {"type": "integer"},
+          "started": {"type": "string", "format": "date-time"},
+          "updated": {"type": "string", "format": "date-time"},
+          "finished": {"type": "string", "format": "date-time"},
+          "archives": {"type": "integer"},
+          "files": {"type": "integer"},
+          "bytes": {"type": "integer"},
+          "ratio": {"type": "number"},
+          "elapsed": {"type": "string"},
+          "error": {"type": "string"},
+          "progress": {"type": "string"}
+        }
+      },
+      "IDRequest": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {"type": "string", "description": "Queue or history item id (usually a filesystem path)"}
+        }
+      },
+      "StatusReply": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string"},
+          "id": {"type": "string"}
+        }
+      },
+      "ConfigWriteReply": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string"},
+          "restartRequired": {"type": "boolean"}
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Missing or invalid credentials",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "Forbidden": {
+        "description": "Authenticated but missing permission",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      }
+    }
+  },
+  "paths": {
+    "/api/openapi.json": {
+      "get": {
+        "tags": ["system"],
+        "summary": "OpenAPI 3 document",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "OpenAPI document",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": ["auth"],
+        "summary": "Log in with PBKDF2 hex; sets session cookie and returns the admin API key",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/LoginRequest"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Logged in",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AuthInfo"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": ["auth"],
+        "summary": "Clear the session cookie",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Logged out",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
+          }
+        }
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "tags": ["auth"],
+        "summary": "Current session or API key identity",
+        "responses": {
+          "200": {
+            "description": "Auth info including apiKey when using a session",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AuthInfo"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/api/stats": {
+      "get": {
+        "tags": ["system"],
+        "summary": "Queue counts for Homepage and the dashboard",
+        "description": "Requires read:system:stats",
+        "responses": {
+          "200": {
+            "description": "Counts",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Stats"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/system": {
+      "get": {
+        "tags": ["system"],
+        "summary": "Version, uptime, listen address, auth mode",
+        "description": "Requires read:system:info",
+        "responses": {
+          "200": {
+            "description": "System info",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/SystemInfo"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": ["system"],
+        "summary": "Prometheus metrics (only registered when metrics = true)",
+        "description": "Requires read:system:metrics. Send Authorization: Bearer or X-Api-Key.",
+        "responses": {
+          "200": {
+            "description": "Prometheus text",
+            "content": {"text/plain": {"schema": {"type": "string"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/queue": {
+      "get": {
+        "tags": ["queue"],
+        "summary": "In-flight extracts",
+        "description": "Requires read:system:queue",
+        "responses": {
+          "200": {
+            "description": "Live queue",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/QueueItem"}}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/queue/retry": {
+      "post": {
+        "tags": ["queue"],
+        "summary": "Retry an extractfailed item",
+        "description": "Requires write:system:queue. Id is a path in the JSON body.",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Queued for retry",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
+          },
+          "404": {"description": "Not in the live map", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "409": {"description": "Not extractfailed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/queue/forget": {
+      "post": {
+        "tags": ["queue"],
+        "summary": "Drop an in-flight item from tracking",
+        "description": "Requires write:system:queue",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Forgotten",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
+          },
+          "404": {"description": "Not in the live map", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/history": {
+      "get": {
+        "tags": ["history"],
+        "summary": "Completed and failed items (newest first)",
+        "description": "Requires read:system:history. Capped by keep_history.",
+        "responses": {
+          "200": {
+            "description": "History",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/HistoryRecord"}}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/history/delete": {
+      "post": {
+        "tags": ["history"],
+        "summary": "Delete one history row",
+        "description": "Requires write:system:history",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
+          },
+          "404": {"description": "Unknown id", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/history/clear": {
+      "post": {
+        "tags": ["history"],
+        "summary": "Clear all history rows",
+        "description": "Requires write:system:history",
+        "responses": {
+          "200": {
+            "description": "Cleared",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/config/{section}": {
+      "parameters": [
+        {
+          "name": "section",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "enum": ["general", "webserver", "sonarr", "radarr", "lidarr", "readarr", "whisparr", "folders", "webhooks", "cmdhooks"]
+          }
+        }
+      ],
+      "get": {
+        "tags": ["config"],
+        "summary": "Read one config section",
+        "description": "Requires read:config:{section}. Starr API keys are visible. ui_password is the stored hash or auth mode, not plaintext.",
+        "responses": {
+          "200": {
+            "description": "Section payload",
+            "content": {"application/json": {"schema": {"description": "Shape depends on section"}}}
+          },
+          "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      },
+      "put": {
+        "tags": ["config"],
+        "summary": "Replace one config section and rewrite the TOML file",
+        "description": "Requires write:config:{section}. Replaces the section (GET then PUT). In-flight extracts are not cancelled. Some changes set restartRequired.",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"description": "Same shape as GET for this section"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Saved",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ConfigWriteReply"}}}
+          },
+          "400": {"description": "Validation error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    }
+  }
+}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -389,11 +389,11 @@
       ],
       "get": {
         "tags": ["config"],
-        "summary": "Read one config section",
-        "description": "Requires read:config:{section}. Starr API keys are visible. ui_password is the stored hash or auth mode, not plaintext.",
+        "summary": "Read the on-disk config section",
+        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
-            "description": "Section payload",
+            "description": "On-disk section payload",
             "content": {"application/json": {"schema": {"description": "Shape depends on section"}}}
           },
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
@@ -404,10 +404,10 @@
       "put": {
         "tags": ["config"],
         "summary": "Replace one config section and rewrite the TOML file",
-        "description": "Requires write:config:{section}. Replaces the section (GET then PUT). In-flight extracts are not cancelled. Some changes set restartRequired.",
+        "description": "Requires write:config:{section}. Body is the file-shaped GET payload. filepath: ui_password is expanded for the running process and kept as filepath: on disk. In-flight extracts are not cancelled. Some changes set restartRequired.",
         "requestBody": {
           "required": true,
-          "content": {"application/json": {"schema": {"description": "Same shape as GET for this section"}}}
+          "content": {"application/json": {"schema": {"description": "Same shape as GET /api/config/{section}"}}}
         },
         "responses": {
           "200": {
@@ -415,6 +415,33 @@
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ConfigWriteReply"}}}
           },
           "400": {"description": "Validation error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/config/{section}/live": {
+      "parameters": [
+        {
+          "name": "section",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "enum": ["general", "webserver", "sonarr", "radarr", "lidarr", "readarr", "whisparr", "folders", "webhooks", "cmdhooks"]
+          }
+        }
+      ],
+      "get": {
+        "tags": ["config"],
+        "summary": "Read the expanded running config section",
+        "description": "Requires read:config:{section}. filepath: values are already expanded. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
+        "responses": {
+          "200": {
+            "description": "Live section payload",
+            "content": {"application/json": {"schema": {"description": "Shape depends on section"}}}
+          },
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -308,8 +308,8 @@
     "/api/queue/forget": {
       "post": {
         "tags": ["queue"],
-        "summary": "Drop an in-flight item from tracking",
-        "description": "Requires write:system:queue",
+        "summary": "Drop a terminal queue item from tracking",
+        "description": "Requires write:system:queue. Only extractfailed, extractednothing, imported, deleted, and deletefailed items can be forgotten.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
@@ -320,6 +320,7 @@
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
           "404": {"description": "Not in the live map", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "409": {"description": "Still in progress", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -355,6 +356,7 @@
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
           "404": {"description": "Unknown id", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "500": {"description": "Failed to persist", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -370,6 +372,7 @@
             "description": "Cleared",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
+          "500": {"description": "Failed to persist", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -393,7 +393,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the on-disk config section",
-        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
+        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
             "description": "On-disk section payload",
@@ -439,7 +439,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the expanded running config section",
-        "description": "Requires read:config:{section}. Most filepath: values are expanded. Archive passwords that were filepath: stay as filepath: so secret-file contents are not returned. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
+        "description": "Requires read:config:{section}. Most filepath: values are expanded. Archive passwords are the post-env, pre-expansion slice, so filepath: from the file or UN_PASSWORDS is not replaced with secret-file contents. Unpackerr webserver apiKeys[].key is returned only to callers with *. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
         "responses": {
           "200": {
             "description": "Live section payload",

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -439,7 +439,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the expanded running config section",
-        "description": "Requires read:config:{section}. filepath: values are already expanded. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
+        "description": "Requires read:config:{section}. Most filepath: values are expanded. Archive passwords that were filepath: stay as filepath: so secret-file contents are not returned. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
         "responses": {
           "200": {
             "description": "Live section payload",

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -376,7 +376,6 @@
           },
           "404": {"description": "Unknown id", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "400": {"$ref": "#/components/responses/BadRequest"},
-          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -392,7 +391,6 @@
             "description": "Cleared",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
-          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -427,7 +425,7 @@
       "put": {
         "tags": ["config"],
         "summary": "Replace one config section and rewrite the TOML file",
-        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. The TOML file is written before live state changes; a persist failure is 500 and leaves runtime unchanged. filepath: ui_password is expanded for the running process and kept as filepath: on disk. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. Webserver listen_addr, urlbase, TLS, metrics, pprof, and HTTP log settings stay on the running server until restart. In-flight extracts are not cancelled. Some changes set restartRequired.",
+        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. Validation, the TOML write, and the live apply run on the main loop; a persist failure is 500 and leaves runtime unchanged. filepath: values in any section are expanded for the running process and kept as filepath: on disk. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. General interval changes reset the running tickers. Folder lists, webserver listen_addr, urlbase, TLS, metrics, pprof, log settings, debug, quiet, parallel, and file modes return restartRequired: true; the daemon then re-execs itself once nothing is queued, extracting, or awaiting delete. In-flight extracts are never cancelled.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"description": "Same shape as GET /api/config/{section}"}}}
@@ -439,6 +437,7 @@
           },
           "400": {"$ref": "#/components/responses/BadRequest"},
           "500": {"$ref": "#/components/responses/PersistError"},
+          "504": {"$ref": "#/components/responses/GatewayTimeout"},
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
@@ -467,6 +466,7 @@
             "content": {"application/json": {"schema": {"description": "Shape depends on section"}}}
           },
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "504": {"$ref": "#/components/responses/GatewayTimeout"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -8,7 +8,7 @@
   "servers": [
     {
       "url": "/",
-      "description": "This Unpackerr instance (respect urlbase)"
+      "description": "This Unpackerr instance; url is rewritten to the configured urlbase when the spec is served"
     }
   ],
   "tags": [
@@ -49,10 +49,10 @@
       },
       "LoginRequest": {
         "type": "object",
-        "required": ["name", "kdf"],
+        "required": ["kdf"],
         "properties": {
-          "name": {"type": "string", "description": "Username (default admin)"},
-          "kdf": {"type": "string", "description": "PBKDF2-HMAC-SHA-256 hex of the password; never send plaintext"}
+          "name": {"type": "string", "description": "Username; omitted or empty defaults to admin"},
+          "kdf": {"type": "string", "description": "PBKDF2-HMAC-SHA-256(password, salt=\"unpackerr:\"+username, 210000, 32) hex-encoded; never send plaintext"}
         }
       },
       "AuthInfo": {
@@ -163,6 +163,18 @@
       "Forbidden": {
         "description": "Authenticated but missing permission",
         "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "BadRequest": {
+        "description": "Invalid JSON or validation error",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "GatewayTimeout": {
+        "description": "Request canceled or timed out while waiting on the main loop",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "PersistError": {
+        "description": "Failed to persist to disk; live state unchanged",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
       }
     }
   },
@@ -194,7 +206,9 @@
             "description": "Logged in",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AuthInfo"}}}
           },
-          "401": {"$ref": "#/components/responses/Unauthorized"}
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"description": "Password login is disabled (webauth or noauth)", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
         }
       }
     },
@@ -258,7 +272,8 @@
       "get": {
         "tags": ["system"],
         "summary": "Prometheus metrics (only registered when metrics = true)",
-        "description": "Requires read:system:metrics. Send Authorization: Bearer or X-Api-Key.",
+        "description": "Requires read:system:metrics. API key only: X-Api-Key or Authorization: Bearer. Session cookies and proxy/webauth are rejected.",
+        "security": [{"apiKey": []}, {"bearer": []}],
         "responses": {
           "200": {
             "description": "Prometheus text",
@@ -300,6 +315,8 @@
           },
           "404": {"description": "Not in the live map", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "409": {"description": "Not extractfailed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "504": {"$ref": "#/components/responses/GatewayTimeout"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -321,6 +338,8 @@
           },
           "404": {"description": "Not in the live map", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "409": {"description": "Still in progress", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "504": {"$ref": "#/components/responses/GatewayTimeout"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -356,7 +375,8 @@
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
           "404": {"description": "Unknown id", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
-          "500": {"description": "Failed to persist", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -372,7 +392,7 @@
             "description": "Cleared",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
-          "500": {"description": "Failed to persist", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -393,7 +413,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the on-disk config section",
-        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
+        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *; PUT keeps a blank key of the same name. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
             "description": "On-disk section payload",
@@ -417,8 +437,8 @@
             "description": "Saved",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ConfigWriteReply"}}}
           },
-          "400": {"description": "Validation error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
-          "500": {"description": "Config file write failed; live state unchanged", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "500": {"$ref": "#/components/responses/PersistError"},
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -407,7 +407,7 @@
       "put": {
         "tags": ["config"],
         "summary": "Replace one config section and rewrite the TOML file",
-        "description": "Requires write:config:{section}. Body is the file-shaped GET payload. filepath: ui_password is expanded for the running process and kept as filepath: on disk. In-flight extracts are not cancelled. Some changes set restartRequired.",
+        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. The TOML file is written before live state changes; a persist failure is 500 and leaves runtime unchanged. filepath: ui_password is expanded for the running process and kept as filepath: on disk. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. Webserver listen_addr, urlbase, TLS, metrics, pprof, and HTTP log settings stay on the running server until restart. In-flight extracts are not cancelled. Some changes set restartRequired.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"description": "Same shape as GET /api/config/{section}"}}}
@@ -418,6 +418,7 @@
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ConfigWriteReply"}}}
           },
           "400": {"description": "Validation error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "500": {"description": "Config file write failed; live state unchanged", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "404": {"description": "Unknown section", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -173,7 +173,7 @@
         "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
       },
       "PersistError": {
-        "description": "Failed to persist to disk; live state unchanged",
+        "description": "Failed to write the change to disk; it will not survive a restart",
         "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
       }
     }
@@ -208,7 +208,8 @@
           },
           "400": {"$ref": "#/components/responses/BadRequest"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
-          "403": {"description": "Password login is disabled (webauth or noauth)", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+          "403": {"description": "Password login is disabled (webauth or noauth)", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "500": {"description": "Could not encode the session cookie", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
         }
       }
     },
@@ -376,6 +377,7 @@
           },
           "404": {"description": "Unknown id", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "400": {"$ref": "#/components/responses/BadRequest"},
+          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }
@@ -391,6 +393,7 @@
             "description": "Cleared",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatusReply"}}}
           },
+          "500": {"$ref": "#/components/responses/PersistError"},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -393,7 +393,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the on-disk config section",
-        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
+        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
             "description": "On-disk section payload",

--- a/pkg/unpackerr/openapi_test.go
+++ b/pkg/unpackerr/openapi_test.go
@@ -1,0 +1,32 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestOpenAPIUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+
+	rec := doAuth(t, unpack, http.MethodGet, "/api/openapi.json", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("openapi %d %s", rec.Code, rec.Body.String())
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	if doc["openapi"] != "3.0.3" {
+		t.Fatalf("openapi field %v", doc["openapi"])
+	}
+
+	paths, _ := doc["paths"].(map[string]any)
+	if _, ok := paths["/api/stats"]; !ok {
+		t.Fatal("missing /api/stats")
+	}
+}

--- a/pkg/unpackerr/openapi_test.go
+++ b/pkg/unpackerr/openapi_test.go
@@ -29,4 +29,8 @@ func TestOpenAPIUnauthenticated(t *testing.T) {
 	if _, ok := paths["/api/stats"]; !ok {
 		t.Fatal("missing /api/stats")
 	}
+
+	if _, ok := paths["/api/config/{section}/live"]; !ok {
+		t.Fatal("missing live config GET")
+	}
 }

--- a/pkg/unpackerr/openapi_test.go
+++ b/pkg/unpackerr/openapi_test.go
@@ -3,7 +3,10 @@ package unpackerr
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 func TestOpenAPIUnauthenticated(t *testing.T) {
@@ -16,13 +19,13 @@ func TestOpenAPIUnauthenticated(t *testing.T) {
 		t.Fatalf("openapi %d %s", rec.Code, rec.Body.String())
 	}
 
-	var doc map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
-		t.Fatal(err)
-	}
-
+	doc := decodeOpenAPI(t, rec.Body.Bytes())
 	if doc["openapi"] != "3.0.3" {
 		t.Fatalf("openapi field %v", doc["openapi"])
+	}
+
+	if openAPIDocServerURL(t, doc) != "/" {
+		t.Fatalf("root servers url %v", openAPIDocServerURL(t, doc))
 	}
 
 	paths, _ := doc["paths"].(map[string]any)
@@ -33,4 +36,132 @@ func TestOpenAPIUnauthenticated(t *testing.T) {
 	if _, ok := paths["/api/config/{section}/live"]; !ok {
 		t.Fatal("missing live config GET")
 	}
+
+	login := openAPIPath(t, paths, "/api/auth/login")
+	post, _ := login["post"].(map[string]any)
+	resps, _ := post["responses"].(map[string]any)
+
+	for _, code := range []string{"400", "401", "403"} {
+		if _, ok := resps[code]; !ok {
+			t.Fatalf("login missing %s", code)
+		}
+	}
+
+	metrics := openAPIPath(t, paths, "/metrics")
+	get, _ := metrics["get"].(map[string]any)
+
+	sec, _ := get["security"].([]any)
+	if len(sec) != 2 {
+		t.Fatalf("metrics security %v", sec)
+	}
+
+	retry := openAPIPath(t, paths, "/api/queue/retry")
+	retryPost, _ := retry["post"].(map[string]any)
+	retryResps, _ := retryPost["responses"].(map[string]any)
+
+	for _, code := range []string{"400", "504"} {
+		if _, ok := retryResps[code]; !ok {
+			t.Fatalf("retry missing %s", code)
+		}
+	}
+}
+
+func TestOpenAPIHonorsURLBase(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Webserver.URLBase = "/unpackerr/"
+	unpack.Webserver.router = httprouter.New()
+	unpack.webRoutes()
+
+	root := httptest.NewRecorder()
+	unpack.Webserver.router.ServeHTTP(root,
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/openapi.json", nil))
+
+	if root.Code != http.StatusNotFound {
+		t.Fatalf("root openapi %d", root.Code)
+	}
+
+	rec := httptest.NewRecorder()
+	unpack.Webserver.router.ServeHTTP(rec,
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/unpackerr/api/openapi.json", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("urlbase openapi %d %s", rec.Code, rec.Body.String())
+	}
+
+	doc := decodeOpenAPI(t, rec.Body.Bytes())
+	if got := openAPIDocServerURL(t, doc); got != "/unpackerr" {
+		t.Fatalf("servers url %q", got)
+	}
+}
+
+func TestOpenAPIServerURL(t *testing.T) {
+	t.Parallel()
+
+	if got := openAPIServerURL(""); got != "/" {
+		t.Fatalf("empty %q", got)
+	}
+
+	if got := openAPIServerURL("/"); got != "/" {
+		t.Fatalf("root %q", got)
+	}
+
+	if got := openAPIServerURL("/unpackerr/"); got != "/unpackerr" {
+		t.Fatalf("urlbase %q", got)
+	}
+}
+
+func TestOpenAPILoginRequestOnlyRequiresKDF(t *testing.T) {
+	t.Parallel()
+
+	var doc map[string]any
+	if err := json.Unmarshal(openapiJSON, &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	login, _ := schemas["LoginRequest"].(map[string]any)
+	required, _ := login["required"].([]any)
+
+	if len(required) != 1 || required[0] != "kdf" {
+		t.Fatalf("LoginRequest.required %v", required)
+	}
+}
+
+func decodeOpenAPI(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	return doc
+}
+
+func openAPIDocServerURL(t *testing.T, doc map[string]any) string {
+	t.Helper()
+
+	servers, _ := doc["servers"].([]any)
+	if len(servers) == 0 {
+		t.Fatal("missing servers")
+	}
+
+	server, _ := servers[0].(map[string]any)
+	url, _ := server["url"].(string)
+
+	return url
+}
+
+func openAPIPath(t *testing.T, paths map[string]any, name string) map[string]any {
+	t.Helper()
+
+	item, ok := paths[name].(map[string]any)
+	if !ok {
+		t.Fatalf("missing %s", name)
+	}
+
+	return item
 }

--- a/pkg/unpackerr/webserver.go
+++ b/pkg/unpackerr/webserver.go
@@ -129,6 +129,7 @@ func (u *Unpackerr) startWebServer() {
 
 func (u *Unpackerr) webRoutes() {
 	u.Webserver.router.GET(u.Webserver.URLBase, Index)
+	u.registerOpenAPIRoute()
 	u.registerAuthRoutes()
 	u.registerAPIRoutes()
 


### PR DESCRIPTION
Recreated from #689 so it can stack on #692 (GitHub does not allow retargeting a PR that is part of a stack).

## Why

The SPA API docs page (and operators) need a spec. Generating via swag would pull a CLI into the build; a committed OpenAPI 3 JSON is easier to review and cannot accidentally include secrets.

## What

- Embed `pkg/unpackerr/openapi.json`.
- `GET /api/openapi.json` is unauthenticated.
- `servers.url` is rewritten to the configured urlbase when the spec is served.
- Covers auth, stats, system, metrics, queue, history, file-shaped config GET/PUT, and `/live`.
- Login: only `kdf` is required; documents PBKDF2 salt/iterations; 400 invalid JSON and 403 when password login is disabled.
- Metrics: API key / Bearer only (no session cookies).
- Write endpoints document 400 / 504 / 500 via shared response objects.
- Documents GET redaction (`apiKeys[].key` needs `*`; plaintext `ui_password` is blanked; empty keys keep by name on PUT), live password provenance, main-loop apply, `filepath:` expansion for every section, ticker reset on general PUT, and the idle re-exec for `restartRequired` sections.