### PR TITLE
Require KDF for UI password PUT and expose Trust fields on /api/auth/me

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -215,6 +215,8 @@ Env-only (no config path): skip write, still apply live.
 
 **Omitted / blank `ui_password` on PUT:** keep live password. An already-stored `filepath:` on PUT: expand for live, store the `filepath:` string on disk. A new `filepath:` is 400.
 
+**New `ui_password` on PUT:** `!!cryptd!!…`, `webauth`, `noauth`, or `user:<64-char hex>` where the hex is the same PBKDF2 digest as login (`CryptPass.Set`, then bcrypt). Plaintext `user:pass` is **400**. While live auth is local password, changing the hash or switching to header/noauth requires `uiCurrentKdf` (login `Valid()` on the current username). Header/noauth live mode does not. `uiCurrentKdf` is a PUT-only JSON field and is never written to TOML. Omitting `uiPassword` or sending the on-disk value unchanged keeps the live overlay, so `UN_WEBSERVER_UI_PASSWORD` is not replaced by the file hash.
+
 **Starr PUT:** invalid URL/key is **400** (startup *skips* bad apps; PUT does not). `path` merges into `paths` without dupes. Last poll `Queue` carries over when `url` + expanded `apiKey` match. Work thread pool **grows** to `starrAppCount`.
 
 **Folders PUT:** always `restartRequired: true`. Watcher is built once; rebuilding in-process was rejected (leak / dual poller).
@@ -260,7 +262,7 @@ Index is `GET {urlbase}{$}` so `GET /` is not a ServeMux prefix match (that woul
 | GET | `{urlbase}api/openapi.json` | none | — | Spec; `servers[0].url` rewritten to urlbase |
 | POST | `{urlbase}api/auth/login` | none | — | JSON `{name?, kdf}`. 3s fail delay. 5s read deadline **outside** apache log wrapper. Missing if cookies failed to init. |
 | POST | `{urlbase}api/auth/logout` | none | — | Clears session cookie |
-| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions |
+| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions, `header`, `headers` (this request minus the Trust exclusion list), `clientIP`, `upstreamAllowed` |
 | GET | `{urlbase}api/stats` | yes | `read:system:stats` | Queue counts + hook counters |
 | GET | `{urlbase}api/system` | yes | `read:system:info` | Version, uptime, bind addr, urlbase, auth type, metrics flag |
 | GET | `{urlbase}api/queue` | yes | `read:system:queue` | In-flight items |

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -200,7 +200,7 @@ Permission: `write:config:{section}`.
 
 Body **replaces** the section (not patch). Workflow the UI is built for: GET file → edit → PUT.
 
-Handler on HTTP goroutine: read ≤1 MiB, reject trailing JSON, reject `null` / empty object `{}` for object sections, reject `[null]` in lists. `DisallowUnknownFields`.
+Handler on HTTP goroutine: read ≤1 MiB, reject trailing JSON, reject `null` / empty object `{}` for object sections, reject `[null]` in lists. `DisallowUnknownFields`. Webserver PUT that is only `uiCurrentKdf` is the same empty-section 400 (`uiCurrentKdf` is a sidecar, not a config field).
 
 Then `onMainLoop` → `replaceConfigSection` → `commitConfig`:
 
@@ -215,7 +215,7 @@ Env-only (no config path): skip write, still apply live.
 
 **Omitted / blank `ui_password` on PUT:** keep live password. An already-stored `filepath:` on PUT: expand for live, store the `filepath:` string on disk. A new `filepath:` is 400.
 
-**New `ui_password` on PUT:** `!!cryptd!!…`, `webauth`, `noauth`, or `user:<64-char hex>` where the hex is the same PBKDF2 digest as login (`CryptPass.Set`, then bcrypt). Plaintext `user:pass` is **400**. While live auth is local password, changing the hash or switching to header/noauth requires `uiCurrentKdf` (login `Valid()` on the current username). Header/noauth live mode does not. `uiCurrentKdf` is a PUT-only JSON field and is never written to TOML. Omitting `uiPassword` or sending the on-disk value unchanged keeps the live overlay, so `UN_WEBSERVER_UI_PASSWORD` is not replaced by the file hash.
+**New `ui_password` on PUT:** `!!cryptd!!…`, `webauth`, `noauth`, or `user:<64-char hex>` where the hex is the same PBKDF2 digest as login (`CryptPass.Set`, then bcrypt; mixed-case hex is stored lowercase). Plaintext `user:pass` is **400**. While live auth is local password, changing the hash or switching to header/noauth requires `uiCurrentKdf` (login `Valid()` on the current username). Header/noauth live mode does not. `uiCurrentKdf` is a PUT-only JSON field and is never written to TOML. A body that contains only `uiCurrentKdf` is **400** (empty section), so it cannot wipe `listen_addr` / keys / roles. Omitting `uiPassword` or sending the on-disk value unchanged keeps the live overlay, so `UN_WEBSERVER_UI_PASSWORD` is not replaced by the file hash.
 
 **Starr PUT:** invalid URL/key is **400** (startup *skips* bad apps; PUT does not). `path` merges into `paths` without dupes. Last poll `Queue` carries over when `url` + expanded `apiKey` match. Work thread pool **grows** to `starrAppCount`.
 
@@ -262,7 +262,7 @@ Index is `GET {urlbase}{$}` so `GET /` is not a ServeMux prefix match (that woul
 | GET | `{urlbase}api/openapi.json` | none | — | Spec; `servers[0].url` rewritten to urlbase |
 | POST | `{urlbase}api/auth/login` | none | — | JSON `{name?, kdf}`. 3s fail delay. 5s read deadline **outside** apache log wrapper. Missing if cookies failed to init. |
 | POST | `{urlbase}api/auth/logout` | none | — | Clears session cookie |
-| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions, `header`, `headers` (this request minus the Trust exclusion list), `clientIP`, `upstreamAllowed` |
+| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions, `header`, `clientIP`, `upstreamAllowed`. `headers` (this request minus the Trust exclusion list) only with `read:system:headers` |
 | GET | `{urlbase}api/stats` | yes | `read:system:stats` | Queue counts + hook counters |
 | GET | `{urlbase}api/system` | yes | `read:system:info` | Version, uptime, bind addr, urlbase, auth type, metrics flag |
 | GET | `{urlbase}api/queue` | yes | `read:system:queue` | In-flight items |
@@ -307,7 +307,7 @@ First start with listen enabled and no password: generate one, print once, hash,
 
 `verb:area:resource`. Built-in role `admin` is reserved and means `*`.
 
-System: `read:system:stats|info|queue|history|metrics`, `write:system:queue|history`.
+System: `read:system:stats|info|queue|history|metrics|headers`, `write:system:queue|history`.
 
 Config: `read:config:{section}`, `write:config:{section}` for each section above.
 

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -109,9 +109,10 @@ passwords = []
 ## This may be set to a port or an ip:port to bind a specific IP. 0.0.0.0 binds ALL IPs.
 ## Set this to an empty string to disable the HTTP server.
  listen_addr = "0.0.0.0:5656"
-## Local UI login (HTTP auth is the next PR; this stores the credential). Use user:pass
-## (hashed on startup), !!cryptd!!user:$2a$... for a stored hash, webauth:X-Webauth-User
-## for a reverse-proxy header, or noauth.
+## Local UI login. Use user:pass (hashed on startup), !!cryptd!!user:$2a$...
+## for a stored hash, webauth:X-Webauth-User for a reverse-proxy header, or
+## noauth. The HTTP API does not accept plaintext; send user:<PBKDF2 hex>
+## (same digest as login) and uiCurrentKdf when changing a live password.
 ## filepath:/path reads that file for the live password and keeps filepath: in the
 ## config. Empty generates a temporary password when the HTTP server is enabled.
 ## Reset with --reset. Do not set an empty
@@ -485,4 +486,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 04 SEP 2026 07:36 UTC
+## => Content Auto Generated, 10 SEP 2026 04:48 UTC

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -464,9 +464,10 @@ sections:
         omit_compose: true
         short: Web UI password (user:pass, hashed, proxy header, or noauth).
         desc: |
-          Local UI login (HTTP auth is the next PR; this stores the credential). Use user:pass
-          (hashed on startup), !!cryptd!!user:$2a$... for a stored hash, webauth:X-Webauth-User
-          for a reverse-proxy header, or noauth.
+          Local UI login. Use user:pass (hashed on startup), !!cryptd!!user:$2a$...
+          for a stored hash, webauth:X-Webauth-User for a reverse-proxy header, or
+          noauth. The HTTP API does not accept plaintext; send user:<PBKDF2 hex>
+          (same digest as login) and uiCurrentKdf when changing a live password.
           filepath:/path reads that file for the live password and keeps filepath: in the
           config. Empty generates a temporary password when the HTTP server is enabled.
           Reset with --reset. Do not set an empty

--- a/pkg/unpackerr/apikeys.go
+++ b/pkg/unpackerr/apikeys.go
@@ -106,6 +106,10 @@ func (w *WebServer) validateAuth() error {
 		return nil
 	}
 
+	if w.UIPassword.Type() == AuthHeader && strings.TrimSpace(w.UIPassword.Header()) == "" {
+		return errEmptyAuthHeader
+	}
+
 	for name, role := range w.Roles {
 		if err := role.validate(name); err != nil {
 			return err

--- a/pkg/unpackerr/apikeys_test.go
+++ b/pkg/unpackerr/apikeys_test.go
@@ -11,7 +11,8 @@ func TestAllPermissionsIncludeConfigSections(t *testing.T) {
 
 	perms := AllPermissions()
 
-	if !KnownPermission(PermReadSystemStats) || !KnownPermission(PermAll) {
+	if !KnownPermission(PermReadSystemStats) || !KnownPermission(PermReadSystemHeaders) ||
+		!KnownPermission(PermAll) {
 		t.Fatal("system permissions must be known")
 	}
 

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -42,6 +42,12 @@ var (
 	ErrInvalidKey = fmt.Errorf("provided application API Key is invalid, must be at least %d characters", apiKeyMinLength)
 )
 
+// skipInvalidApp reports whether a Starr instance should be dropped at
+// startup (missing/short URL or API key) rather than aborting the process.
+func skipInvalidApp(err error) bool {
+	return errors.Is(err, ErrInvalidURL) || errors.Is(err, ErrInvalidKey)
+}
+
 // Config defines the configuration data used to start the application.
 //
 //nolint:lll

--- a/pkg/unpackerr/auth.go
+++ b/pkg/unpackerr/auth.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"runtime"
 	"strings"
 	"time"
 
@@ -37,11 +38,16 @@ type ctxKey int
 const authCtxKey ctxKey = 1
 
 type authInfo struct {
-	Username    string   `json:"username"`
-	APIKey      string   `json:"apiKey"`
-	Auth        string   `json:"auth"`
-	Via         string   `json:"via"`
-	Permissions []string `json:"permissions"`
+	Username        string      `json:"username"`
+	APIKey          string      `json:"apiKey"`
+	Auth            string      `json:"auth"`
+	Via             string      `json:"via"`
+	GOOS            string      `json:"goos"`
+	Header          string      `json:"header,omitempty"`
+	Headers         http.Header `json:"headers"`
+	ClientIP        string      `json:"clientIP,omitempty"`
+	Permissions     []string    `json:"permissions"`
+	UpstreamAllowed bool        `json:"upstreamAllowed"`
 }
 
 type loginRequest struct {
@@ -182,6 +188,7 @@ func (u *Unpackerr) authAPIKey(key string) (authInfo, bool) {
 		APIKey:      key,
 		Auth:        pass.Type().String(),
 		Via:         "key",
+		GOOS:        runtime.GOOS,
 		Permissions: perms,
 	}, true
 }
@@ -273,6 +280,7 @@ func (u *Unpackerr) sessionAuth(user string) authInfo {
 		APIKey:      admin,
 		Auth:        pass.Type().String(),
 		Via:         "session",
+		GOOS:        runtime.GOOS,
 		Permissions: AllPermissions(),
 	}
 	if pass.Webauth() {
@@ -424,7 +432,7 @@ func (u *Unpackerr) handleLogin(response http.ResponseWriter, request *http.Requ
 		return false
 	}
 
-	writeJSON(response, http.StatusOK, u.sessionAuth(name))
+	writeJSON(response, http.StatusOK, u.withRequestAuth(u.sessionAuth(name), request))
 
 	return true
 }
@@ -456,14 +464,113 @@ func (u *Unpackerr) logoutHandler(response http.ResponseWriter, request *http.Re
 
 func (u *Unpackerr) meHandler(response http.ResponseWriter, request *http.Request) {
 	info, _ := request.Context().Value(authCtxKey).(authInfo)
-	writeJSON(response, http.StatusOK, info)
+	writeJSON(response, http.StatusOK, u.withRequestAuth(info, request))
+}
+
+func (u *Unpackerr) withRequestAuth(info authInfo, request *http.Request) authInfo {
+	info.ClientIP = hostFromRemoteAddr(request.RemoteAddr)
+	info.Header = u.uiPassword().Header()
+	info.Headers = profileHeaders(request)
+
+	if request.RemoteAddr != "" && strings.LastIndex(request.RemoteAddr, ":") >= 0 {
+		info.UpstreamAllowed = u.webAllowContains(request.RemoteAddr)
+	}
+
+	return info
+}
+
+// profileIgnoredHeaders filters headers shown in the proxy-auth picker on GET /api/auth/me.
+// The list matches Notifiarr's Trust Profile picker, plus Unpackerr credential headers.
+var profileIgnoredHeaders = map[string]struct{}{ //nolint:gochecknoglobals
+	"accept":                    {},
+	"accept-encoding":           {},
+	"accept-language":           {},
+	"authorization":             {},
+	"cache-control":             {},
+	"content-length":            {},
+	"content-type":              {},
+	"cdn-loop":                  {},
+	"cf-connecting-ip":          {},
+	"cf-ipcity":                 {},
+	"cf-ipcontinent":            {},
+	"cf-ipcountry":              {},
+	"cf-iplatitude":             {},
+	"cf-iplongitude":            {},
+	"cf-metro-code":             {},
+	"cf-postal-code":            {},
+	"cf-ray":                    {},
+	"cf-region":                 {},
+	"cf-region-code":            {},
+	"cf-timezone":               {},
+	"cf-visitor":                {},
+	"connection":                {},
+	"cookie":                    {},
+	"dnt":                       {},
+	"expect":                    {},
+	"pragma":                    {},
+	"priority":                  {},
+	"referer":                   {},
+	"sec-ch-ua":                 {},
+	"sec-ch-ua-mobile":          {},
+	"sec-ch-ua-platform":        {},
+	"sec-fetch-dest":            {},
+	"sec-fetch-mode":            {},
+	"sec-fetch-site":            {},
+	"strict-transport-security": {},
+	"te":                        {},
+	"upgrade-insecure-requests": {},
+	"user-agent":                {},
+	"x-api-key":                 {},
+	"x-content-type-options":    {},
+	"x-forwarded-for":           {},
+	"x-forwarded-host":          {},
+	"x-forwarded-method":        {},
+	"x-forwarded-port":          {},
+	"x-forwarded-proto":         {},
+	"x-forwarded-server":        {},
+	"x-forwarded-ssl":           {},
+	"x-forwarded-uri":           {},
+	"x-noticlient-username":     {},
+	"x-original-method":         {},
+	"x-original-uri":            {},
+	"x-original-url":            {},
+	"x-real-ip":                 {},
+	"x-redacted-uri":            {},
+	"x-request-id":              {},
+}
+
+func profileHeaders(req *http.Request) http.Header {
+	headers := make(http.Header)
+	if req == nil {
+		return headers
+	}
+
+	for name, values := range req.Header {
+		if _, skip := profileIgnoredHeaders[strings.ToLower(name)]; skip {
+			continue
+		}
+
+		for _, value := range values {
+			headers.Add(name, value)
+		}
+	}
+
+	return headers
+}
+
+func hostFromRemoteAddr(addr string) string {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return addr
+	}
+
+	return strings.Trim(addr[:idx], "[]")
 }
 
 func writeJSON(response http.ResponseWriter, code int, msg any) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		http.Error(response, `{"error":"encode"}`, http.StatusInternalServerError)
-
 		return
 	}
 

--- a/pkg/unpackerr/auth.go
+++ b/pkg/unpackerr/auth.go
@@ -44,7 +44,7 @@ type authInfo struct {
 	Via             string      `json:"via"`
 	GOOS            string      `json:"goos"`
 	Header          string      `json:"header,omitempty"`
-	Headers         http.Header `json:"headers"`
+	Headers         http.Header `json:"headers,omitempty"`
 	ClientIP        string      `json:"clientIP,omitempty"`
 	Permissions     []string    `json:"permissions"`
 	UpstreamAllowed bool        `json:"upstreamAllowed"`
@@ -470,7 +470,10 @@ func (u *Unpackerr) meHandler(response http.ResponseWriter, request *http.Reques
 func (u *Unpackerr) withRequestAuth(info authInfo, request *http.Request) authInfo {
 	info.ClientIP = hostFromRemoteAddr(request.RemoteAddr)
 	info.Header = u.uiPassword().Header()
-	info.Headers = profileHeaders(request)
+
+	if info.allows(PermReadSystemHeaders) {
+		info.Headers = profileHeaders(request)
+	}
 
 	if request.RemoteAddr != "" && strings.LastIndex(request.RemoteAddr, ":") >= 0 {
 		info.UpstreamAllowed = u.webAllowContains(request.RemoteAddr)

--- a/pkg/unpackerr/auth_test.go
+++ b/pkg/unpackerr/auth_test.go
@@ -884,3 +884,63 @@ func TestAuthMeProfileHeaders(t *testing.T) {
 		t.Errorf("cookie leaked: %v", vals)
 	}
 }
+
+func TestAuthMeHeadersRequirePermission(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	statsKey := strings.Repeat("H", apiKeyMinLen)
+	headerKey := strings.Repeat("h", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"stats":   {Permissions: []string{PermReadSystemStats}},
+		"headers": {Permissions: []string{PermReadSystemHeaders}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys,
+		APIKey{Name: "stats", Key: statsKey, Roles: []string{"stats"}},
+		APIKey{Name: "headers", Key: headerKey, Roles: []string{"headers"}},
+	)
+
+	authMe := func(key string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		rec := doAuth(t, unpack, http.MethodGet, "/api/auth/me", "", func(req *http.Request) {
+			req.Header.Set(headerAPIKey, key)
+			req.Header.Set("Remote-User", "alice")
+			req.Header.Set("Proxy-Authorization", "Basic leaked")
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("me %d %s", rec.Code, rec.Body.String())
+		}
+
+		return rec
+	}
+
+	limited := authMe(statsKey)
+	if strings.Contains(limited.Body.String(), "Basic leaked") {
+		t.Fatalf("proxy auth leaked: %s", limited.Body.String())
+	}
+
+	var limitedInfo authInfo
+	if err := json.Unmarshal(limited.Body.Bytes(), &limitedInfo); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(limitedInfo.Headers) != 0 {
+		t.Fatalf("limited headers %+v", limitedInfo.Headers)
+	}
+
+	granted := authMe(headerKey)
+
+	var info authInfo
+	if err := json.Unmarshal(granted.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Headers.Get("Remote-User") != "alice" {
+		t.Fatalf("headers %+v", info.Headers)
+	}
+
+	if info.Headers.Get("Proxy-Authorization") != "Basic leaked" {
+		t.Fatalf("proxy auth %+v", info.Headers)
+	}
+}

--- a/pkg/unpackerr/auth_test.go
+++ b/pkg/unpackerr/auth_test.go
@@ -819,3 +819,68 @@ func TestLoginRejectsTrailingJSON(t *testing.T) {
 		t.Fatalf("trailing json %d %s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestProfileHeaders(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/me", nil)
+	req.Header.Set("User-Agent", "test-agent")
+	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set(headerAPIKey, "super-secret-key")
+	req.Header.Set("Authorization", "Bearer super-secret-key")
+	req.Header.Set("Remote-User", "alice")
+	req.Header.Set("X-Webauth-User", "bob")
+	req.Header.Set("X-Remote-User", "carol")
+
+	got := profileHeaders(req)
+
+	if got.Get("Remote-User") != "alice" || got.Get("X-Webauth-User") != "bob" || got.Get("X-Remote-User") != "carol" {
+		t.Fatalf("auth headers: %+v", got)
+	}
+
+	for _, name := range []string{
+		"User-Agent", "Cookie", "Accept", "X-Forwarded-For", "X-Forwarded-Proto",
+		headerAPIKey, "Authorization",
+	} {
+		if vals := got.Values(name); len(vals) > 0 {
+			t.Errorf("ignored header %s leaked: %v", name, vals)
+		}
+	}
+}
+
+func TestAuthMeProfileHeaders(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	key := unpack.Webserver.adminAPIKey()
+	rec := doAuth(t, unpack, http.MethodGet, "/api/auth/me", "", func(req *http.Request) {
+		req.Header.Set(headerAPIKey, key)
+		req.Header.Set("Remote-User", "alice")
+		req.Header.Set("Cookie", "session=secret")
+		req.Header.Set("User-Agent", "test-agent")
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me %d %s", rec.Code, rec.Body.String())
+	}
+
+	var info authInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Headers.Get("Remote-User") != "alice" {
+		t.Fatalf("headers %+v", info.Headers)
+	}
+
+	if vals := info.Headers.Values(headerAPIKey); len(vals) > 0 {
+		t.Errorf("api key leaked: %v", vals)
+	}
+
+	if vals := info.Headers.Values("Cookie"); len(vals) > 0 {
+		t.Errorf("cookie leaked: %v", vals)
+	}
+}

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -466,6 +466,9 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 	}
 
 	if len(conf.APIKey) < apiKeyMinLength {
+		u.Errorf("%s (%s) API Key is too short (%d < %d), skipped and ignored.",
+			app, conf.URL, len(conf.APIKey), apiKeyMinLength)
+
 		return fmt.Errorf("%s (%s) %w, your key length: %d",
 			app, conf.URL, ErrInvalidKey, len(conf.APIKey))
 	}

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -453,7 +453,7 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 
 	if conf.APIKey == "" {
 		u.Errorf("Missing %s API Key in one of your configurations, skipped and ignored.", app)
-		return ErrInvalidURL // this error is not printed.
+		return ErrInvalidKey // this error is not printed at startup; PUT returns it.
 	}
 
 	if !strings.HasPrefix(conf.URL, "http://") && !strings.HasPrefix(conf.URL, "https://") {

--- a/pkg/unpackerr/cnfgfile_test.go
+++ b/pkg/unpackerr/cnfgfile_test.go
@@ -657,3 +657,21 @@ func TestEnvSuffixesAndSecrets(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSonarrSkipsShortAPIKey(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{
+		URL:    "http://127.0.0.1:8989",
+		APIKey: "short",
+	}}
+
+	if err := unpack.validateSonarr(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(unpack.Sonarr) != 0 {
+		t.Fatalf("short key must skip, got %d", len(unpack.Sonarr))
+	}
+}

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -397,9 +397,14 @@ func generalRestartRequired(cur, next *Config) bool {
 		next.DeleteDelay != cur.DeleteDelay
 }
 
+type webserverPut struct {
+	WebServer
+	UICurrentKDF string `json:"uiCurrentKdf"`
+}
+
 //nolint:funlen // break it up more one day.
 func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
-	var next WebServer
+	var next webserverPut
 	if err := unmarshalObject(raw, &next); err != nil {
 		return false, err
 	}
@@ -410,33 +415,38 @@ func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
 		return false, err
 	}
 
+	currentKDF := strings.TrimSpace(next.UICurrentKDF)
 	submitted := next.UIPassword
 	omitted := submitted.Val() == ""
 	fromFile := strings.HasPrefix(submitted.Val(), filePrefix)
 
-	if err := u.rejectNewFilepaths(SectionWebserver, &next); err != nil {
+	if err := u.rejectNewFilepaths(SectionWebserver, &next.WebServer); err != nil {
 		return false, err
 	}
+
+	liveSnap := u.cloneLiveWebserver()
+	fileSnap := u.cloneFileWebserver()
 
 	if !omitted {
 		if err := expandCryptPassFile(&next.UIPassword); err != nil {
 			return false, err
 		}
 
-		if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser()); err != nil {
+		if err := normalizeStoredPassword(&next.UIPassword, u.uiPasswordUser(), fromFile); err != nil {
+			return false, err
+		}
+
+		if err := u.confirmUIPasswordChange(submitted, fileSnap.UIPassword, currentKDF, fromFile); err != nil {
 			return false, err
 		}
 	}
-
-	liveSnap := u.cloneLiveWebserver()
-	fileSnap := u.cloneFileWebserver()
 
 	// Blank keys round-trip from a redacted GET. File keys fill from the file
 	// only so an env-overlay key never lands on disk; live fills from live then file.
 	fileOnly := &WebServer{APIKeys: cloneAPIKeys(next.APIKeys)}
 	keepNamedAPIKeys(fileOnly, fileSnap)
 	dropEmptyAPIKeys(fileOnly)
-	keepNamedAPIKeys(&next, liveSnap, fileSnap)
+	keepNamedAPIKeys(&next.WebServer, liveSnap, fileSnap)
 
 	if omitted {
 		next.UIPassword = liveSnap.UIPassword
@@ -448,7 +458,7 @@ func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
 
 	next.allow = MakeIPs(next.Upstreams)
 
-	fileWeb := cloneWebserver(&next)
+	fileWeb := cloneWebserver(&next.WebServer)
 	fileWeb.APIKeys = fileOnly.APIKeys
 
 	switch {
@@ -462,25 +472,38 @@ func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
 		return false, err
 	}
 
-	restart := webserverRestartRequired(liveSnap, &next)
+	// Round-tripping the file hash must not replace a live overlay (env password).
+	if keepLiveUIPassword(omitted, fromFile, submitted, fileSnap.UIPassword) {
+		next.UIPassword = liveSnap.UIPassword
+	}
+
+	// GET/PUT are file-shaped. Env can overlay live listen/metrics, so compare
+	// the file snapshot to what we are about to write, not live vs the PUT body.
+	restart := webserverRestartRequired(fileSnap, fileWeb)
 
 	return restart, u.commitConfig(func(cfg *Config) {
 		cfg.Webserver = fileWeb
 	}, func() {
-		u.applyLiveWebserverAuth(&next)
+		u.applyLiveWebserverAuth(&next.WebServer)
 	})
 }
 
 func webserverRestartRequired(cur, next *WebServer) bool {
-	return cur.ListenAddr != next.ListenAddr ||
-		cur.URLBase != next.URLBase ||
-		cur.SSLCrtFile != next.SSLCrtFile ||
-		cur.SSLKeyFile != next.SSLKeyFile ||
-		cur.Metrics != next.Metrics ||
-		cur.Pprof != next.Pprof ||
-		cur.LogFile != next.LogFile ||
-		cur.LogFiles != next.LogFiles ||
-		cur.LogFileMb != next.LogFileMb
+	curCopy := cloneWebserver(cur)
+	nextCopy := cloneWebserver(next)
+
+	curCopy.normalizeURLBase()
+	nextCopy.normalizeURLBase()
+
+	return curCopy.ListenAddr != nextCopy.ListenAddr ||
+		curCopy.URLBase != nextCopy.URLBase ||
+		curCopy.SSLCrtFile != nextCopy.SSLCrtFile ||
+		curCopy.SSLKeyFile != nextCopy.SSLKeyFile ||
+		curCopy.Metrics != nextCopy.Metrics ||
+		curCopy.Pprof != nextCopy.Pprof ||
+		curCopy.LogFile != nextCopy.LogFile ||
+		curCopy.LogFiles != nextCopy.LogFiles ||
+		curCopy.LogFileMb != nextCopy.LogFileMb
 }
 
 func dropEmptyAPIKeys(web *WebServer) {
@@ -571,14 +594,47 @@ func (u *Unpackerr) uiPasswordUser() string {
 	return defaultUIUser
 }
 
-func normalizeStoredPassword(pass *CryptPass, fallback string) error {
+func keepLiveUIPassword(omitted, fromFile bool, submitted, file CryptPass) bool {
+	return omitted || (!fromFile && submitted.Val() == file.Val())
+}
+
+func (u *Unpackerr) confirmUIPasswordChange(submitted, file CryptPass, currentKDF string, fromFile bool) error {
+	live := u.uiPassword()
+	if live.Type() != AuthPassword {
+		return nil
+	}
+
+	raw := submitted.Val()
+	if raw == "" || raw == live.Val() || raw == file.Val() || fromFile {
+		return nil
+	}
+
+	if !live.Valid(live.Username(), currentKDF) {
+		return errCurrentUIPassword
+	}
+
+	return nil
+}
+
+func normalizeStoredPassword(pass *CryptPass, fallback string, allowPlain bool) error {
 	if pass.Val() == "" || pass.IsCrypted() || pass.Webauth() {
 		return nil
 	}
 
-	user, plain := splitUserPass(pass.Val(), fallback)
+	user, secret := splitUserPass(pass.Val(), fallback)
+	if allowPlain {
+		return pass.SetPlain(user, secret)
+	}
 
-	return pass.SetPlain(user, plain)
+	if !isKDFHex(secret) {
+		return errPlaintextUIPassword
+	}
+
+	if reservedUIUser(user) {
+		return errReservedUIUser
+	}
+
+	return pass.Set(user, secret)
 }
 
 // putStarrList replaces one Starr app list. The file copy keeps filepath:

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -154,11 +154,16 @@ func unmarshalStrict(raw json.RawMessage, dest any) error {
 }
 
 // unmarshalObject is unmarshalStrict plus a guard against a bare {}, which
-// would otherwise zero every field in an object section.
-func unmarshalObject(raw json.RawMessage, dest any) error {
+// would otherwise zero every field in an object section. ignore keys (PUT-only
+// sidecars such as uiCurrentKdf) do not count as section content.
+func unmarshalObject(raw json.RawMessage, dest any, ignore ...string) error {
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		return wrapJSONErr(err)
+	}
+
+	for _, key := range ignore {
+		delete(probe, key)
 	}
 
 	if len(probe) == 0 {
@@ -405,7 +410,7 @@ type webserverPut struct {
 //nolint:funlen // break it up more one day.
 func (u *Unpackerr) putWebserver(raw json.RawMessage) (bool, error) {
 	var next webserverPut
-	if err := unmarshalObject(raw, &next); err != nil {
+	if err := unmarshalObject(raw, &next, "uiCurrentKdf"); err != nil {
 		return false, err
 	}
 

--- a/pkg/unpackerr/configput_auth_test.go
+++ b/pkg/unpackerr/configput_auth_test.go
@@ -67,6 +67,56 @@ func TestConfigPutWebserverAcceptsKDFPassword(t *testing.T) {
 	}
 }
 
+func TestConfigPutWebserverAcceptsUppercaseKDFPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = CryptPass("admin:" + strings.ToUpper(DeriveKDF("admin", "new-secret-99")))
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("uppercase kdf put %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain("admin", "new-secret-99") {
+		t.Fatal("live password must accept the new secret after uppercase hex PUT")
+	}
+
+	if !unpack.Webserver.UIPassword.Valid("admin", strings.ToUpper(DeriveKDF("admin", "new-secret-99"))) {
+		t.Fatal("login must accept mixed-case kdf hex")
+	}
+}
+
+func TestConfigPutWebserverRejectsKDFOnlyBody(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	admin := unpack.Webserver.adminAPIKey()
+	listen := unpack.Webserver.ListenAddr
+	body := `{"uiCurrentKdf":"` + DeriveKDF(defaultUIUser, "correct-horse") + `"}`
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", body, putKey(unpack))
+	if put.Code != http.StatusBadRequest || !strings.Contains(put.Body.String(), "empty config section") {
+		t.Fatalf("kdf-only put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.adminAPIKey() != admin {
+		t.Fatal("kdf-only PUT wiped live admin key")
+	}
+
+	if unpack.Webserver.ListenAddr != listen {
+		t.Fatalf("kdf-only PUT wiped listen_addr %q", unpack.Webserver.ListenAddr)
+	}
+}
+
 func TestConfigPutWebserverKDFNeedsCurrentPassword(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unpackerr/configput_auth_test.go
+++ b/pkg/unpackerr/configput_auth_test.go
@@ -1,0 +1,304 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func getWebserverPUT(t *testing.T, unpack *Unpackerr) WebServer {
+	t.Helper()
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", putKey(unpack))
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	return web
+}
+
+func TestConfigPutWebserverRejectsPlaintextPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = "admin:new-secret-99"
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusBadRequest || !strings.Contains(put.Body.String(), "kdf-hex") {
+		t.Fatalf("plaintext put %d %s", put.Code, put.Body.String())
+	}
+}
+
+func TestConfigPutWebserverAcceptsKDFPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = CryptPass("admin:" + DeriveKDF("admin", "new-secret-99"))
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("kdf put %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain("admin", "new-secret-99") {
+		t.Fatal("live password must accept the new secret")
+	}
+
+	if unpack.fileConfig.Webserver.UIPassword.Val() != "" &&
+		!unpack.fileConfig.Webserver.UIPassword.IsCrypted() {
+		t.Fatalf("file must store hash, got %q", unpack.fileConfig.Webserver.UIPassword)
+	}
+}
+
+func TestConfigPutWebserverKDFNeedsCurrentPassword(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = CryptPass("admin:" + DeriveKDF("admin", "new-secret-99"))
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", mustJSON(t, web), putKey(unpack))
+	if put.Code != http.StatusBadRequest || !strings.Contains(put.Body.String(), "current ui password") {
+		t.Fatalf("missing current %d %s", put.Code, put.Body.String())
+	}
+
+	put = doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "wrong-horse1")), putKey(unpack))
+	if put.Code != http.StatusBadRequest {
+		t.Fatalf("wrong current %d %s", put.Code, put.Body.String())
+	}
+}
+
+func TestConfigPutWebserverRoundTripHashNeedsNoCurrent(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", mustJSON(t, web), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("round-trip %d %s", put.Code, put.Body.String())
+	}
+}
+
+func TestConfigPutWebserverSwitchToHeader(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = "webauth:X-Remote-User"
+	web.Upstreams = StringSlice{"192.0.2.1/32"}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("header put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.UIPassword.Type() != AuthHeader ||
+		unpack.Webserver.UIPassword.Header() != "X-Remote-User" {
+		t.Fatalf("live auth %s %s", unpack.Webserver.UIPassword.Type(), unpack.Webserver.UIPassword.Header())
+	}
+
+	web = getWebserverPUT(t, unpack)
+	web.UIPassword = CryptPass("dave:" + DeriveKDF("dave", "header-to-pass"))
+
+	put = doAuth(t, unpack, http.MethodPut, "/api/config/webserver", mustJSON(t, web), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("header to password %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain("dave", "header-to-pass") {
+		t.Fatal("switching from header must not require a current password")
+	}
+}
+
+func TestConfigPutWebserverSwitchToNoauth(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = authNone
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("noauth put %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.UIPassword.Type() != AuthNone {
+		t.Fatalf("live auth %s", unpack.Webserver.UIPassword.Type())
+	}
+}
+
+func TestConfigPutWebserverEnvPasswordRoundTripKeepsLive(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	var filePass, livePass CryptPass
+	if err := filePass.SetPlain("fileuser", "filepass99"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := livePass.SetPlain("envuser", "envsecret1"); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.fileConfig.Webserver.UIPassword = filePass
+	unpack.Webserver.UIPassword = livePass
+
+	web := getWebserverPUT(t, unpack)
+	if web.UIPassword.Val() != filePass.Val() {
+		t.Fatalf("GET must return file password, got %q", web.UIPassword)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", mustJSON(t, web), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("round-trip overlay %d %s", put.Code, put.Body.String())
+	}
+
+	if !unpack.Webserver.UIPassword.ValidPlain("envuser", "envsecret1") {
+		t.Fatal("live overlay password must remain")
+	}
+
+	if unpack.fileConfig.Webserver.UIPassword.Val() != filePass.Val() {
+		t.Fatalf("file password %q", unpack.fileConfig.Webserver.UIPassword)
+	}
+}
+
+func TestConfigPutWebserverOmitsPasswordKeepsLiveAndFile(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	live := unpack.Webserver.UIPassword
+	file := unpack.fileConfig.Webserver.UIPassword
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = ""
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", mustJSON(t, web), putKey(unpack))
+	if put.Code != http.StatusOK {
+		t.Fatalf("omit password %d %s", put.Code, put.Body.String())
+	}
+
+	if unpack.Webserver.UIPassword != live {
+		t.Fatal("live password changed")
+	}
+
+	if unpack.fileConfig.Webserver.UIPassword != file {
+		t.Fatal("file password changed")
+	}
+}
+
+func TestConfigPutWebserverRejectsEmptyAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	web := getWebserverPUT(t, unpack)
+	web.UIPassword = "webauth:"
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver",
+		mustWebPUT(t, web, DeriveKDF(defaultUIUser, "correct-horse")), putKey(unpack))
+	if put.Code != http.StatusBadRequest {
+		t.Fatalf("empty header %d %s", put.Code, put.Body.String())
+	}
+}
+
+func TestAuthMeIncludesUpstreamHints(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+
+	rec := doAuth(t, unpack, http.MethodGet, "/api/auth/me", "", putKey(unpack))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me %d %s", rec.Code, rec.Body.String())
+	}
+
+	var info authInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Header != defaultAuthHeader {
+		t.Fatalf("header %q", info.Header)
+	}
+
+	if info.ClientIP == "" {
+		t.Fatal("expected clientIP")
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(body)
+}
+
+func mustWebPUT(t *testing.T, web WebServer, currentKDF string) string {
+	t.Helper()
+
+	if currentKDF == "" {
+		return mustJSON(t, web)
+	}
+
+	raw, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	obj["uiCurrentKdf"] = currentKDF
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(out)
+}

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -267,6 +267,57 @@ func TestConfigPutSonarrValidates(t *testing.T) {
 	}
 }
 
+func TestConfigPutLidarrURLNeedsAPIKey(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	emptyKey := doAuth(t, unpack, http.MethodPut, "/api/config/lidarr",
+		`[{"url":"http://sdfsdf.sdsd.com/lidarr","apiKey":""}]`, withKey)
+	if emptyKey.Code != http.StatusBadRequest {
+		t.Fatalf("empty key %d %s", emptyKey.Code, emptyKey.Body.String())
+	}
+
+	if !strings.Contains(emptyKey.Body.String(), "API Key") {
+		t.Fatalf("want API key error, got %s", emptyKey.Body.String())
+	}
+
+	good := doAuth(t, unpack, http.MethodPut, "/api/config/lidarr",
+		`[{"url":"http://sdfsdf.sdsd.com/lidarr","apiKey":"`+
+			strings.Repeat("k", apiKeyMinLength)+`","split_flac":true}]`, withKey)
+	if good.Code != http.StatusOK {
+		t.Fatalf("lidarr %d %s", good.Code, good.Body.String())
+	}
+}
+
+func TestConfigPutSonarrRejectsSplitFlac(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	rec := doAuth(t, unpack, http.MethodPut, "/api/config/sonarr",
+		`[{"url":"http://127.0.0.1:8989","apiKey":"`+strings.Repeat("k", apiKeyMinLength)+`","split_flac":false}]`, withKey)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("split_flac %d %s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.Contains(rec.Body.String(), "split_flac") {
+		t.Fatalf("want unknown field, got %s", rec.Body.String())
+	}
+}
+
 func TestConfigPutNeedsWritePerm(t *testing.T) {
 	t.Parallel()
 
@@ -571,6 +622,76 @@ func TestConfigPutURLBaseRoundTripNeedsNoRestart(t *testing.T) {
 
 	if reply.RestartRequired {
 		t.Fatal("normalized urlbase round trip must not require restart")
+	}
+}
+
+// Saving a role (or any auth-only field) must not re-exec when live listen
+// differs from the file because of UN_WEBSERVER_LISTEN_ADDR.
+func TestConfigPutWebserverRoleWithEnvListenNeedsNoRestart(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	unpack.ConfigFile = filepath.Join(t.TempDir(), "unpackerr.conf")
+	unpack.snapshotFileConfig()
+	unpack.Webserver.ListenAddr = "127.0.0.1:5656"
+	unpack.fileConfig.Webserver.ListenAddr = "0.0.0.0:5656"
+	key := putKey(unpack)
+
+	got := doAuth(t, unpack, http.MethodGet, "/api/config/webserver", "", key)
+	if got.Code != http.StatusOK {
+		t.Fatalf("get %d %s", got.Code, got.Body.String())
+	}
+
+	var web WebServer
+	if err := json.Unmarshal(got.Body.Bytes(), &web); err != nil {
+		t.Fatal(err)
+	}
+
+	if web.ListenAddr != "0.0.0.0:5656" {
+		t.Fatalf("GET must return file listen, got %s", web.ListenAddr)
+	}
+
+	if web.Roles == nil {
+		web.Roles = map[string]Role{}
+	}
+
+	web.Roles["stats"] = Role{Permissions: []string{PermReadSystemStats}}
+
+	if len(web.APIKeys) == 0 {
+		t.Fatal("expected admin key on GET")
+	}
+
+	web.APIKeys[0].Key = ""
+
+	body, err := json.Marshal(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	put := doAuth(t, unpack, http.MethodPut, "/api/config/webserver", string(body), key)
+	if put.Code != http.StatusOK {
+		t.Fatalf("put %d %s", put.Code, put.Body.String())
+	}
+
+	var reply configWriteReply
+	if err := json.Unmarshal(put.Body.Bytes(), &reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if reply.RestartRequired || unpack.pendingRestart {
+		t.Fatal("adding a role must not restart when only env listen differs from the file")
+	}
+
+	if unpack.Webserver.ListenAddr != "127.0.0.1:5656" {
+		t.Fatalf("live listen changed to %s", unpack.Webserver.ListenAddr)
+	}
+
+	if _, ok := unpack.fileConfig.Webserver.Roles["stats"]; !ok {
+		t.Fatalf("role missing from file: %+v", unpack.fileConfig.Webserver.Roles)
+	}
+
+	if _, ok := unpack.Webserver.Roles["stats"]; !ok {
+		t.Fatalf("role missing from live: %+v", unpack.Webserver.Roles)
 	}
 }
 

--- a/pkg/unpackerr/configput_test.go
+++ b/pkg/unpackerr/configput_test.go
@@ -288,6 +288,16 @@ func TestConfigPutLidarrURLNeedsAPIKey(t *testing.T) {
 		t.Fatalf("want API key error, got %s", emptyKey.Body.String())
 	}
 
+	shortKey := doAuth(t, unpack, http.MethodPut, "/api/config/lidarr",
+		`[{"url":"http://sdfsdf.sdsd.com/lidarr","apiKey":"tooshort"}]`, withKey)
+	if shortKey.Code != http.StatusBadRequest {
+		t.Fatalf("short key %d %s", shortKey.Code, shortKey.Body.String())
+	}
+
+	if !strings.Contains(shortKey.Body.String(), "key length") {
+		t.Fatalf("want short-key error, got %s", shortKey.Body.String())
+	}
+
 	good := doAuth(t, unpack, http.MethodPut, "/api/config/lidarr",
 		`[{"url":"http://sdfsdf.sdsd.com/lidarr","apiKey":"`+
 			strings.Repeat("k", apiKeyMinLength)+`","split_flac":true}]`, withKey)

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -160,9 +160,11 @@ func (u *Unpackerr) PollFolders() {
 		u.Folder.Interval.Duration = defaultPollInterval
 	}
 
-	u.Folders, flist = checkFolders(u.Folders, u.Logger)
+	// Abs-expand a clone so GET /api/config/folders/live keeps the configured
+	// path (file vs env), not the runtime filepath.Abs rewrite.
+	watched, flist := checkFolders(cloneFolderList(u.Folders), u.Logger)
 
-	folders, err := u.Folder.newWatcher(u.Folders, u.Logger)
+	folders, err := u.Folder.newWatcher(watched, u.Logger)
 	if err != nil {
 		u.Errorf("Watching Folders: %s", err)
 		return
@@ -171,7 +173,7 @@ func (u *Unpackerr) PollFolders() {
 	u.folders = folders
 	// do not close either watcher.
 
-	if len(u.Folders) == 0 {
+	if len(watched) == 0 {
 		return
 	}
 

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -1,7 +1,6 @@
 package unpackerr
 
 import (
-	"errors"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -27,7 +26,7 @@ func (u *Unpackerr) validateLidarr() error {
 
 	for idx := range u.Lidarr {
 		if err := u.validateApp(&u.Lidarr[idx].StarrConfig, starr.Lidarr); err != nil {
-			if errors.Is(err, ErrInvalidURL) {
+			if skipInvalidApp(err) {
 				continue // We ignore these errors, just remove the instance from the list.
 			}
 

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -67,7 +67,7 @@
           "headers": {
             "type": "object",
             "additionalProperties": {"type": "array", "items": {"type": "string"}},
-            "description": "Incoming request headers for the proxy-auth picker, minus the Trust exclusion list (and X-Api-Key / Authorization)"
+            "description": "Incoming request headers for the proxy-auth picker, minus the Trust exclusion list (and X-Api-Key / Authorization). Omitted unless the caller has read:system:headers"
           },
           "clientIP": {"type": "string", "description": "RemoteAddr host of this request"},
           "upstreamAllowed": {"type": "boolean", "description": "True when RemoteAddr is in webserver upstreams"},
@@ -239,6 +239,7 @@
       "get": {
         "tags": ["auth"],
         "summary": "Current session or API key identity",
+        "description": "headers is included only when the caller has read:system:headers (admin / * included)",
         "responses": {
           "200": {
             "description": "Auth info including apiKey when using a session",

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -62,6 +62,15 @@
           "apiKey": {"type": "string"},
           "auth": {"type": "string"},
           "via": {"type": "string"},
+          "goos": {"type": "string"},
+          "header": {"type": "string", "description": "Configured proxy auth header name (default X-Webauth-User)"},
+          "headers": {
+            "type": "object",
+            "additionalProperties": {"type": "array", "items": {"type": "string"}},
+            "description": "Incoming request headers for the proxy-auth picker, minus the Trust exclusion list (and X-Api-Key / Authorization)"
+          },
+          "clientIP": {"type": "string", "description": "RemoteAddr host of this request"},
+          "upstreamAllowed": {"type": "boolean", "description": "True when RemoteAddr is in webserver upstreams"},
           "permissions": {"type": "array", "items": {"type": "string"}}
         }
       },
@@ -431,7 +440,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the on-disk config section",
-        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *; PUT keeps a blank key of the same name. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
+        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *; PUT keeps a blank key of the same name. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. PUT a new password as user:<kdf-hex> (same digest as login), not plaintext. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
             "description": "On-disk section payload",
@@ -445,7 +454,7 @@
       "put": {
         "tags": ["config"],
         "summary": "Replace one config section and rewrite the TOML file",
-        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. Validation, the TOML write, and the live apply run on the main loop; a persist failure is 500 and leaves runtime unchanged. An existing filepath: string in the same section is expanded for the running process and kept as filepath: on disk. A new or changed filepath: is 400; the API will not read a file that was not already referenced in that section. Replacing filepath: with a literal value is allowed. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. General interval changes reset the running tickers. Folder lists, webserver listen_addr, urlbase, TLS, metrics, pprof, log settings, debug, quiet, parallel, and file modes return restartRequired: true; the daemon then re-execs itself once nothing is queued, extracting, or awaiting delete. In-flight extracts are never cancelled.",
+        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. Validation, the TOML write, and the live apply run on the main loop; a persist failure is 500 and leaves runtime unchanged. An existing filepath: string in the same section is expanded for the running process and kept as filepath: on disk. A new or changed filepath: is 400; the API will not read a file that was not already referenced in that section. Replacing filepath: with a literal value is allowed. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. webserver uiPassword on PUT is !!cryptd!!, webauth, noauth, an existing filepath:, or user:<64-char PBKDF2 hex> (the same kdf as login); plaintext user:pass is 400. Changing the live password hash or auth type while local password auth is on requires uiCurrentKdf (KDF of the current username+password). General interval changes reset the running tickers. Folder lists, webserver listen_addr, urlbase, TLS, metrics, pprof, log settings, debug, quiet, parallel, and file modes return restartRequired: true; the daemon then re-execs itself once nothing is queued, extracting, or awaiting delete. In-flight extracts are never cancelled.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"description": "Same shape as GET /api/config/{section}"}}}

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -29,21 +29,25 @@ const (
 )
 
 const (
-	authPassword  = "!!cryptd!!"
-	authHeader    = "webauth"
-	authNone      = "noauth"
-	defaultUIUser = "admin"
-	kdfIters      = 210000
-	kdfKeyLen     = 32
-	kdfSaltPrefix = "unpackerr:"
-	minUIPassword = 8
-	genPasswordN  = 12
+	authPassword      = "!!cryptd!!"
+	authHeader        = "webauth"
+	authNone          = "noauth"
+	defaultUIUser     = "admin"
+	defaultAuthHeader = "X-Webauth-User"
+	kdfIters          = 210000
+	kdfKeyLen         = 32
+	kdfSaltPrefix     = "unpackerr:"
+	minUIPassword     = 8
+	genPasswordN      = 12
 )
 
 var (
 	errShortUIPassword     = errors.New("ui password must be at least 8 characters")
 	errEmptyAuthHeader     = errors.New("auth header may not be empty")
 	errMalformedUIPassword = errors.New("ui_password stored hash is invalid")
+	errPlaintextUIPassword = errors.New("ui_password must be !!cryptd!!, webauth, noauth, filepath:, or user:<kdf-hex>")
+	errCurrentUIPassword   = errors.New("current ui password is invalid")
+	errReservedUIUser      = errors.New("username webauth, noauth, and filepath are reserved")
 )
 
 func (t AuthType) String() string {
@@ -130,11 +134,16 @@ func (p CryptPass) Type() AuthType {
 }
 
 func (p CryptPass) Header() string {
-	if user, rest, found := strings.Cut(p.Val(), ":"); found && user == authHeader {
+	kind, rest, found := strings.Cut(p.Val(), ":")
+	if found && kind == authHeader {
 		return rest
 	}
 
-	return "X-Webauth-User"
+	if found && kind == authNone && rest != "" {
+		return rest
+	}
+
+	return defaultAuthHeader
 }
 
 func (p CryptPass) Username() string {
@@ -231,6 +240,25 @@ func (p CryptPass) Valid(username, kdfHex string) bool {
 
 func (p CryptPass) ValidPlain(username, password string) bool {
 	return p.Valid(username, DeriveKDF(username, password))
+}
+
+func isKDFHex(secret string) bool {
+	if len(secret) != hex.EncodedLen(kdfKeyLen) {
+		return false
+	}
+
+	_, err := hex.DecodeString(secret)
+
+	return err == nil
+}
+
+func reservedUIUser(user string) bool {
+	switch strings.ToLower(strings.TrimSpace(user)) {
+	case authHeader, authNone, "filepath":
+		return true
+	default:
+		return strings.Contains(user, ":")
+	}
 }
 
 func isBcryptHash(value string) bool {

--- a/pkg/unpackerr/password.go
+++ b/pkg/unpackerr/password.go
@@ -192,6 +192,8 @@ func (p *CryptPass) Set(username, secret string) error {
 		username = defaultUIUser
 	}
 
+	secret = strings.ToLower(secret)
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(secret), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("encrypting password: %w", err)
@@ -235,7 +237,7 @@ func (p CryptPass) Valid(username, kdfHex string) bool {
 		return false
 	}
 
-	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(kdfHex)) == nil
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(strings.ToLower(kdfHex))) == nil
 }
 
 func (p CryptPass) ValidPlain(username, password string) bool {

--- a/pkg/unpackerr/password_test.go
+++ b/pkg/unpackerr/password_test.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"strings"
@@ -68,12 +69,20 @@ func TestCryptPassHeaderAndNone(t *testing.T) {
 		t.Fatalf("header %s %s", pass.Type(), pass.Header())
 	}
 
+	if err := pass.Set("noauth", "X-User"); err != nil {
+		t.Fatal(err)
+	}
+
+	if pass.Type() != AuthNone || !pass.Noauth() || pass.Header() != "X-User" {
+		t.Fatalf("noauth %s header %s", pass.Type(), pass.Header())
+	}
+
 	if err := pass.Set("noauth", ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if pass.Type() != AuthNone || !pass.Noauth() {
-		t.Fatalf("noauth %s", pass.Type())
+	if pass.Type() != AuthNone || !pass.Noauth() || pass.Header() != defaultAuthHeader {
+		t.Fatalf("noauth default header %s %s", pass.Type(), pass.Header())
 	}
 }
 
@@ -426,5 +435,66 @@ func TestPublicCryptPass(t *testing.T) {
 		if got := publicCryptPass(test.in); got != test.out {
 			t.Fatalf("%q -> %q, want %q", test.in, got, test.out)
 		}
+	}
+}
+
+func TestNormalizeStoredPasswordKDF(t *testing.T) {
+	t.Parallel()
+
+	plain := CryptPass("admin:correct-horse")
+	if err := normalizeStoredPassword(&plain, defaultUIUser, false); !errors.Is(err, errPlaintextUIPassword) {
+		t.Fatalf("plaintext: %v", err)
+	}
+
+	kdf := DeriveKDF("admin", "correct-horse")
+
+	hashed := CryptPass("admin:" + kdf)
+	if err := normalizeStoredPassword(&hashed, defaultUIUser, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if !hashed.IsCrypted() || !hashed.ValidPlain("admin", "correct-horse") {
+		t.Fatal("kdf must bcrypt via Set")
+	}
+
+	header := CryptPass("webauth:X-Webauth-User")
+	if err := normalizeStoredPassword(&header, defaultUIUser, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if header.Val() != "webauth:X-Webauth-User" {
+		t.Fatalf("webauth round-trip %q", header)
+	}
+
+	reserved := CryptPass("webauth:" + kdf)
+	if err := normalizeStoredPassword(&reserved, defaultUIUser, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if reserved.Type() != AuthHeader {
+		t.Fatalf("webauth:kdf is header mode, got %s", reserved.Type())
+	}
+
+	plainOK := CryptPass("admin:correct-horse")
+	if err := normalizeStoredPassword(&plainOK, defaultUIUser, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if !plainOK.ValidPlain("admin", "correct-horse") {
+		t.Fatal("allowPlain should SetPlain")
+	}
+}
+
+func TestReservedUIUser(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"webauth", "noauth", "filepath", "WebAuth", "a:b"} {
+		if !reservedUIUser(name) {
+			t.Fatalf("%q should be reserved", name)
+		}
+	}
+
+	if reservedUIUser("admin") {
+		t.Fatal("admin is not reserved")
 	}
 }

--- a/pkg/unpackerr/permissions.go
+++ b/pkg/unpackerr/permissions.go
@@ -11,9 +11,10 @@ const (
 	PermReadSystemHistory  = "read:system:history"
 	PermWriteSystemHistory = "write:system:history"
 	PermReadSystemMetrics  = "read:system:metrics"
+	PermReadSystemHeaders  = "read:system:headers"
 	PermAll                = "*"
 	RoleAdmin              = "admin"
-	systemPermCount        = 8
+	systemPermCount        = 9
 )
 
 // ConfigSection is a per-section config API resource name.
@@ -65,6 +66,7 @@ func AllPermissions() []string {
 		PermReadSystemHistory,
 		PermWriteSystemHistory,
 		PermReadSystemMetrics,
+		PermReadSystemHeaders,
 		PermAll,
 	)
 

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -1,7 +1,6 @@
 package unpackerr
 
 import (
-	"errors"
 	"time"
 
 	"golift.io/starr"
@@ -20,7 +19,7 @@ func (u *Unpackerr) validateRadarr() error {
 
 	for idx := range u.Radarr {
 		if err := u.validateApp(&u.Radarr[idx].StarrConfig, starr.Radarr); err != nil {
-			if errors.Is(err, ErrInvalidURL) {
+			if skipInvalidApp(err) {
 				continue // We ignore these errors, just remove the instance from the list.
 			}
 

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -1,7 +1,6 @@
 package unpackerr
 
 import (
-	"errors"
 	"time"
 
 	"golift.io/starr"
@@ -20,7 +19,7 @@ func (u *Unpackerr) validateReadarr() error {
 
 	for idx := range u.Readarr {
 		if err := u.validateApp(&u.Readarr[idx].StarrConfig, starr.Readarr); err != nil {
-			if errors.Is(err, ErrInvalidURL) {
+			if skipInvalidApp(err) {
 				continue // We ignore these errors, just remove the instance from the list.
 			}
 

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -1,7 +1,6 @@
 package unpackerr
 
 import (
-	"errors"
 	"time"
 
 	"golift.io/starr"
@@ -20,7 +19,7 @@ func (u *Unpackerr) validateSonarr() error {
 
 	for idx := range u.Sonarr {
 		if err := u.validateApp(&u.Sonarr[idx].StarrConfig, starr.Sonarr); err != nil {
-			if errors.Is(err, ErrInvalidURL) {
+			if skipInvalidApp(err) {
 				continue // We ignore these errors, just remove the instance from the list.
 			}
 

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -1,7 +1,6 @@
 package unpackerr
 
 import (
-	"errors"
 	"time"
 
 	"golift.io/starr"
@@ -27,7 +26,7 @@ func (u *Unpackerr) validateWhisparr() error {
 
 	for idx := range u.Whisparr {
 		if err := u.validateApp(&u.Whisparr[idx].StarrConfig, starr.Whisparr); err != nil {
-			if errors.Is(err, ErrInvalidURL) {
+			if skipInvalidApp(err) {
 				continue // We ignore these errors, just remove the instance from the list.
 			}
 


### PR DESCRIPTION
## Summary
- PUT `ui_password` as `user:<kdf-hex>` (same digest as login); plaintext is 400. Changing a live local password requires `uiCurrentKdf`.
- `GET /api/auth/me` returns `goos`, configured proxy `header`, this request's `headers` (minus the Trust exclusion list), `clientIP`, and `upstreamAllowed`.
- Missing Starr API keys are `ErrInvalidKey` (PUT 400; startup still skips). Folder watch Abs-expands a clone so live GET keeps the configured path. Webserver restart compares file snapshot to file PUT, so an env listen overlay does not force a re-exec.

Stacked on #704.

## Test plan
- [ ] PUT webserver with plaintext `user:pass` is 400; `user:<kdf>` plus `uiCurrentKdf` succeeds
- [ ] GET `/api/auth/me` includes header picker fields
- [ ] PUT that only adds a role does not set `restartRequired` when live listen differs from the file via env
- [ ] Empty Starr API key on PUT is 400 mentioning API Key


Made with [Cursor](https://cursor.com)