### PR TITLE
Add GET/POST /api/browse for listing and creating folders

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -271,7 +271,7 @@ Index is `GET {urlbase}{$}` so `GET /` is not a ServeMux prefix match (that woul
 | GET | `{urlbase}api/history` | yes | `read:system:history` | Durable JSONL-backed rows |
 | POST | `{urlbase}api/history/clear` | yes | `write:system:history` | |
 | POST | `{urlbase}api/history/delete` | yes | `write:system:history` | `{id}` |
-| GET | `{urlbase}api/browse` | yes | `read:system:browse` | `?dir=`; empty → home; file path lists parent; unreadable path with readable parent is 200 + `error`; both fail → 406. Windows empty/`/`/`\` lists `C:\`–`Z:\` that exist. |
+| GET | `{urlbase}api/browse` | yes | `read:system:browse` | `?dir=`; empty → home; file path lists parent; unreadable path (Stat or ReadDir) with readable parent is 200 + `error`; both fail → 406. `mom` is empty at a volume root. Windows empty/`/`/`\` lists `C:\`–`Z:\` that exist. |
 | POST | `{urlbase}api/browse` | yes | `write:system:browse` | `{path}`; folder `MkdirAll` 0755 (existing folders succeed) |
 | GET | `{urlbase}api/config/env` | yes | any auth | UN_* overlays from startup; secret values blank unless `*` |
 | GET | `{urlbase}api/config/{section}` | yes | `read:config:{section}` | File snapshot |

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -271,6 +271,8 @@ Index is `GET {urlbase}{$}` so `GET /` is not a ServeMux prefix match (that woul
 | GET | `{urlbase}api/history` | yes | `read:system:history` | Durable JSONL-backed rows |
 | POST | `{urlbase}api/history/clear` | yes | `write:system:history` | |
 | POST | `{urlbase}api/history/delete` | yes | `write:system:history` | `{id}` |
+| GET | `{urlbase}api/browse` | yes | `read:system:browse` | `?dir=`; empty → home; file path lists parent; unreadable path with readable parent is 200 + `error`; both fail → 406. Windows empty/`/`/`\` lists `C:\`–`Z:\` that exist. |
+| POST | `{urlbase}api/browse` | yes | `write:system:browse` | `{path}`; folder `MkdirAll` 0755 (existing folders succeed) |
 | GET | `{urlbase}api/config/env` | yes | any auth | UN_* overlays from startup; secret values blank unless `*` |
 | GET | `{urlbase}api/config/{section}` | yes | `read:config:{section}` | File snapshot |
 | GET | `{urlbase}api/config/{section}/live` | yes | `read:config:{section}` | Running copy |

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -141,6 +141,7 @@ passwords = []
 ## Nested [webserver.roles.<name>] tables. Names are letters, digits, _ or -.
 ## Built-in admin cannot be redefined. `*` is reserved for that built-in role.
 ## Each custom role needs at least one known permission.
+## File browser is read:system:browse (list) and write:system:browse (create folder).
 ## Env works but is picky: do not set UN_WEBSERVER_ROLES itself. Role names are
 ## case-sensitive and may contain underscores. Index permissions from 0:
 ## UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=read:system:stats
@@ -486,4 +487,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 10 SEP 2026 04:48 UTC
+## => Content Auto Generated, 10 SEP 2026 04:51 UTC

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -533,6 +533,7 @@ sections:
           Nested [webserver.roles.<name>] tables. Names are letters, digits, _ or -.
           Built-in admin cannot be redefined. `*` is reserved for that built-in role.
           Each custom role needs at least one known permission.
+          File browser is read:system:browse (list) and write:system:browse (create folder).
           Env works but is picky: do not set UN_WEBSERVER_ROLES itself. Role names are
           case-sensitive and may contain underscores. Index permissions from 0:
           UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=read:system:stats

--- a/pkg/unpackerr/api.go
+++ b/pkg/unpackerr/api.go
@@ -31,6 +31,8 @@ func (u *Unpackerr) registerAPIRoutes() {
 	u.Webserver.handleGet(basePath("history"), u.requirePerm(PermReadSystemHistory, u.historyHandler))
 	u.Webserver.handlePost(basePath("history/clear"), u.requirePerm(PermWriteSystemHistory, u.historyClearHandler))
 	u.Webserver.handlePost(basePath("history/delete"), u.requirePerm(PermWriteSystemHistory, u.historyDeleteHandler))
+	u.Webserver.handleGet(basePath("browse"), u.requirePerm(PermReadSystemBrowse, u.browseHandler))
+	u.Webserver.handlePost(basePath("browse"), u.requirePerm(PermWriteSystemBrowse, u.browseCreateHandler))
 	u.Webserver.handleGet(basePath("config/env"), u.requireAuth(u.configEnvHandler))
 	u.Webserver.handleGet(basePath("config/{section}/live"), u.requireConfigPerm(false, u.configGetLiveHandler))
 	u.Webserver.handleGet(basePath("config/{section}"), u.requireConfigPerm(false, u.configGetHandler))

--- a/pkg/unpackerr/apikeys_test.go
+++ b/pkg/unpackerr/apikeys_test.go
@@ -15,6 +15,10 @@ func TestAllPermissionsIncludeConfigSections(t *testing.T) {
 		t.Fatal("system permissions must be known")
 	}
 
+	if !KnownPermission(PermReadSystemBrowse) || !KnownPermission(PermWriteSystemBrowse) {
+		t.Fatal("browse permissions must be known")
+	}
+
 	if !KnownPermission(PermReadConfig(SectionSonarr)) || !KnownPermission(PermWriteConfig(SectionWebserver)) {
 		t.Fatal("config section permissions must be known")
 	}

--- a/pkg/unpackerr/browse.go
+++ b/pkg/unpackerr/browse.go
@@ -125,14 +125,17 @@ func browseDir(dir string) (*BrowseDir, error) {
 		return output, nil
 	}
 
-	if output.Path == "" || output.Path == windowsPathSep {
-		output.Path = "/"
-		output.Mom = ""
+	if err := fillBrowseEntries(output); err != nil {
+		return browseParentFallback(output, err)
 	}
 
+	return output, nil
+}
+
+func fillBrowseEntries(output *BrowseDir) error {
 	entries, err := os.ReadDir(output.Path)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errBrowseContent, err)
+		return fmt.Errorf("%w: %w", errBrowseContent, err)
 	}
 
 	for _, entry := range entries {
@@ -147,7 +150,30 @@ func browseDir(dir string) (*BrowseDir, error) {
 	slices.Sort(output.Dirs)
 	slices.Sort(output.Files)
 
-	return output, nil
+	return nil
+}
+
+// browseParentFallback lists one parent when the path exists but cannot be
+// read (chmod bits, etc.). A Stat fallback already moved Path up; if that
+// parent is also unlistable, both failed → 406.
+func browseParentFallback(output *BrowseDir, listErr error) (*BrowseDir, error) {
+	parent := filepath.Dir(output.Path)
+	if parent == output.Path || output.Error != "" {
+		return nil, listErr
+	}
+
+	listed, err := browsedDirMeta(parent)
+	if err != nil {
+		return nil, listErr
+	}
+
+	if err := fillBrowseEntries(listed); err != nil {
+		return nil, listErr
+	}
+
+	listed.Error = listErr.Error()
+
+	return listed, nil
 }
 
 func browsedDirMeta(dir string) (*BrowseDir, error) {
@@ -170,7 +196,6 @@ func browsedDirMeta(dir string) (*BrowseDir, error) {
 	if err != nil {
 		output.Error = errBrowsePathMsg + ": " + err.Error()
 		output.Path = filepath.Dir(dir)
-		output.Mom = filepath.Dir(output.Path)
 
 		if info, err = os.Stat(output.Path); err != nil { //nolint:gosec // G703: file browser list
 			return nil, fmt.Errorf("%w: %w", errBrowsePath, err)
@@ -182,7 +207,7 @@ func browsedDirMeta(dir string) (*BrowseDir, error) {
 	}
 
 	output.Mom = filepath.Dir(output.Path)
-	if (output.Mom == output.Path+"." || output.Mom == output.Path) && output.Path != "/" {
+	if output.Mom == output.Path {
 		output.Mom = ""
 	}
 
@@ -192,6 +217,10 @@ func browsedDirMeta(dir string) (*BrowseDir, error) {
 func expandBrowsePath(dir string) string {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
+		if isWindowsVolumeRoot("") {
+			return ""
+		}
+
 		dir = "~"
 	}
 

--- a/pkg/unpackerr/browse.go
+++ b/pkg/unpackerr/browse.go
@@ -1,0 +1,227 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+const (
+	maxBrowseBody       = 4096
+	windowsDriveFirst   = 'C'
+	windowsDriveLast    = 'Z'
+	windowsDriveSuffix  = `:\`
+	windowsPathSep      = `\`
+	errBrowsePathMsg    = "unable to read provided path"
+	errBrowseContentMsg = "unable to read content of provided path"
+)
+
+var (
+	errBrowsePath    = errors.New(errBrowsePathMsg)
+	errBrowseContent = errors.New(errBrowseContentMsg)
+	errMissingPath   = errors.New("path is required")
+)
+
+// BrowseDir is the JSON body for GET/POST /api/browse.
+type BrowseDir struct {
+	Sep   string   `json:"sep"`
+	Path  string   `json:"path"`
+	Mom   string   `json:"mom"`
+	Dirs  []string `json:"dirs"`
+	Files []string `json:"files"`
+	Error string   `json:"error"`
+}
+
+type browseCreateRequest struct {
+	Path string `json:"path"`
+}
+
+func (u *Unpackerr) browseHandler(response http.ResponseWriter, request *http.Request) {
+	output, err := browseDir(request.URL.Query().Get("dir"))
+	if err != nil {
+		writeJSON(response, http.StatusNotAcceptable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, output)
+}
+
+func (u *Unpackerr) browseCreateHandler(response http.ResponseWriter, request *http.Request) {
+	body, ok := readBrowseCreate(response, request)
+	if !ok {
+		return
+	}
+
+	u.Printf("[user requested] Creating folder: %s", body.Path)
+
+	output, err := mkdirBrowsePath(body.Path)
+	if err != nil {
+		writeJSON(response, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(response, http.StatusOK, output)
+}
+
+func readBrowseCreate(response http.ResponseWriter, request *http.Request) (browseCreateRequest, bool) {
+	var body browseCreateRequest
+
+	decoder := json.NewDecoder(http.MaxBytesReader(response, request.Body, maxBrowseBody))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&body); err != nil {
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return browseCreateRequest{}, false
+	}
+
+	switch err := decoder.Decode(&struct{}{}); {
+	case errors.Is(err, io.EOF):
+		if strings.TrimSpace(body.Path) == "" {
+			writeJSON(response, http.StatusBadRequest, map[string]string{"error": errMissingPath.Error()})
+			return browseCreateRequest{}, false
+		}
+
+		return body, true
+	case err != nil:
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return browseCreateRequest{}, false
+	default:
+		writeJSON(response, http.StatusBadRequest, map[string]string{"error": errExtraJSON.Error()})
+		return browseCreateRequest{}, false
+	}
+}
+
+func mkdirBrowsePath(path string) (*BrowseDir, error) {
+	path = expandBrowsePath(path)
+
+	if err := os.MkdirAll(path, defaultDirMode); err != nil {
+		return nil, fmt.Errorf("unable to create folder: %w", err)
+	}
+
+	return browseDir(path)
+}
+
+func browseDir(dir string) (*BrowseDir, error) {
+	output, err := browsedDirMeta(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if isWindowsVolumeRoot(output.Path) {
+		output.Dirs = windowsDriveRoots()
+		output.Files = []string{}
+		output.Mom = ""
+		output.Path = ""
+
+		return output, nil
+	}
+
+	if output.Path == "" || output.Path == windowsPathSep {
+		output.Path = "/"
+		output.Mom = ""
+	}
+
+	entries, err := os.ReadDir(output.Path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errBrowseContent, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			output.Dirs = append(output.Dirs, entry.Name())
+			continue
+		}
+
+		output.Files = append(output.Files, entry.Name())
+	}
+
+	slices.Sort(output.Dirs)
+	slices.Sort(output.Files)
+
+	return output, nil
+}
+
+func browsedDirMeta(dir string) (*BrowseDir, error) {
+	dir = expandBrowsePath(dir)
+
+	output := &BrowseDir{
+		Path:  dir,
+		Dirs:  []string{},
+		Files: []string{},
+		Sep:   string(filepath.Separator),
+		Mom:   filepath.Dir(dir),
+	}
+
+	if dir == "" {
+		output.Mom = ""
+		return output, nil
+	}
+
+	info, err := os.Stat(dir) //nolint:gosec // G703: file browser list
+	if err != nil {
+		output.Error = errBrowsePathMsg + ": " + err.Error()
+		output.Path = filepath.Dir(dir)
+		output.Mom = filepath.Dir(output.Path)
+
+		if info, err = os.Stat(output.Path); err != nil { //nolint:gosec // G703: file browser list
+			return nil, fmt.Errorf("%w: %w", errBrowsePath, err)
+		}
+	}
+
+	if !info.IsDir() {
+		output.Path = filepath.Dir(dir)
+	}
+
+	output.Mom = filepath.Dir(output.Path)
+	if (output.Mom == output.Path+"." || output.Mom == output.Path) && output.Path != "/" {
+		output.Mom = ""
+	}
+
+	return output, nil
+}
+
+func expandBrowsePath(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		dir = "~"
+	}
+
+	expanded, err := homedir.Expand(dir)
+	if err != nil || strings.TrimSpace(expanded) == "" {
+		return dir
+	}
+
+	return filepath.Clean(expanded)
+}
+
+func isWindowsVolumeRoot(path string) bool {
+	if runtime.GOOS != windows {
+		return false
+	}
+
+	return path == "" || path == "/" || path == windowsPathSep
+}
+
+func windowsDriveRoots() []string {
+	roots := make([]string, 0, windowsDriveLast-windowsDriveFirst+1)
+
+	for letter := windowsDriveFirst; letter <= windowsDriveLast; letter++ {
+		root := string(letter) + windowsDriveSuffix
+		if _, err := os.Stat(root); err != nil {
+			continue
+		}
+
+		roots = append(roots, root)
+	}
+
+	return roots
+}

--- a/pkg/unpackerr/browse_test.go
+++ b/pkg/unpackerr/browse_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -102,6 +103,80 @@ func TestBrowseDirFileUsesParent(t *testing.T) {
 
 	if !slices.Contains(got.Files, "log.txt") {
 		t.Fatalf("files %v", got.Files)
+	}
+}
+
+func TestBrowseDirUnixRootHasEmptyMom(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windows {
+		t.Skip("unix volume root")
+	}
+
+	got, err := browseDir("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != "/" {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if got.Mom != "" {
+		t.Fatalf("mom %q", got.Mom)
+	}
+}
+
+func TestBrowseDirUnlistableFallsBackToParent(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windows {
+		t.Skip("directory list bits are not POSIX")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root can list mode 0 directories")
+	}
+
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "secret")
+
+	if err := os.Mkdir(blocked, defaultDirMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(blocked, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chmod(blocked, defaultDirMode)
+	})
+
+	got, err := browseDir(blocked)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != dir {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if got.Error == "" {
+		t.Fatal("expected error for unlistable path")
+	}
+}
+
+func TestExpandBrowsePathEmptyIsHome(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windows {
+		t.Skip("empty is the volume-root list on windows")
+	}
+
+	got := expandBrowsePath("")
+	if got == "" || got == "~" {
+		t.Fatalf("empty should expand to home, got %q", got)
 	}
 }
 

--- a/pkg/unpackerr/browse_test.go
+++ b/pkg/unpackerr/browse_test.go
@@ -1,0 +1,283 @@
+package unpackerr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestBrowseDirListsSortedEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "zeta"), defaultDirMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, "alpha"), defaultDirMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b"), defaultFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), defaultFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := browseDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != dir {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if got.Error != "" {
+		t.Fatalf("error %q", got.Error)
+	}
+
+	if !slices.Equal(got.Dirs, []string{"alpha", "zeta"}) {
+		t.Fatalf("dirs %v", got.Dirs)
+	}
+
+	if !slices.Equal(got.Files, []string{"a.txt", "b.txt"}) {
+		t.Fatalf("files %v", got.Files)
+	}
+
+	if got.Mom != filepath.Dir(dir) {
+		t.Fatalf("mom %q", got.Mom)
+	}
+
+	if got.Sep != string(filepath.Separator) {
+		t.Fatalf("sep %q", got.Sep)
+	}
+}
+
+func TestBrowseDirFallsBackToParent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope")
+
+	got, err := browseDir(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != dir {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if got.Error == "" {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestBrowseDirFileUsesParent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "log.txt")
+	if err := os.WriteFile(file, []byte("x"), defaultFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := browseDir(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != dir {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if !slices.Contains(got.Files, "log.txt") {
+		t.Fatalf("files %v", got.Files)
+	}
+}
+
+func TestBrowseRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/browse?dir=/", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrowseForbiddenWithoutPermission(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	statKey := strings.Repeat("S", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"stats": {Permissions: []string{PermReadSystemStats}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "home",
+		Key:   statKey,
+		Roles: []string{"stats"},
+	})
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, statKey)
+	}
+
+	if rec := doAuth(t, unpack, http.MethodGet, "/api/browse?dir=/", "", withKey); rec.Code != http.StatusForbidden {
+		t.Fatalf("get %d %s", rec.Code, rec.Body.String())
+	}
+
+	body := `{"path":"/tmp/x"}`
+	if rec := doAuth(t, unpack, http.MethodPost, "/api/browse", body, withKey); rec.Code != http.StatusForbidden {
+		t.Fatalf("post %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrowseListsTempDir(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), defaultDirMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), defaultFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	target := "/api/browse?dir=" + url.QueryEscape(dir)
+
+	rec := doAuth(t, unpack, http.MethodGet, target, "", withAdminKey)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("browse %d %s", rec.Code, rec.Body.String())
+	}
+
+	got := decodeBrowse(t, rec.Body.Bytes())
+	if got.Path != dir {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	if !slices.Equal(got.Dirs, []string{"sub"}) || !slices.Equal(got.Files, []string{"f.txt"}) {
+		t.Fatalf("dirs %v files %v", got.Dirs, got.Files)
+	}
+}
+
+func TestBrowseCreateDir(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	dir := t.TempDir()
+	folder := filepath.Join(dir, "nested", "newdir")
+
+	folderRec := doAuth(t, unpack, http.MethodPost, "/api/browse",
+		`{"path":`+jsonString(t, folder)+`}`, withAdminKey)
+	if folderRec.Code != http.StatusOK {
+		t.Fatalf("mkdir %d %s", folderRec.Code, folderRec.Body.String())
+	}
+
+	if _, err := os.Stat(folder); err != nil {
+		t.Fatal(err)
+	}
+
+	got := decodeBrowse(t, folderRec.Body.Bytes())
+	if got.Path != folder {
+		t.Fatalf("path %q", got.Path)
+	}
+
+	again := doAuth(t, unpack, http.MethodPost, "/api/browse",
+		`{"path":`+jsonString(t, folder)+`}`, withAdminKey)
+	if again.Code != http.StatusOK {
+		t.Fatalf("exists %d %s", again.Code, again.Body.String())
+	}
+}
+
+func TestBrowseCreateRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	dir := t.TempDir()
+	body := `{"path":` + jsonString(t, filepath.Join(dir, "x")) + `,"dir":true}`
+
+	if rec := doAuth(t, unpack, http.MethodPost, "/api/browse", body, withAdminKey); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrowseCreateForbiddenWithoutWrite(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	readKey := strings.Repeat("R", apiKeyMinLen)
+	unpack.Webserver.Roles = map[string]Role{
+		"browser": {Permissions: []string{PermReadSystemBrowse}},
+	}
+	unpack.Webserver.APIKeys = append(unpack.Webserver.APIKeys, APIKey{
+		Name:  "reader",
+		Key:   readKey,
+		Roles: []string{"browser"},
+	})
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, readKey)
+	}
+
+	dir := t.TempDir()
+	target := "/api/browse?dir=" + url.QueryEscape(dir)
+
+	if rec := doAuth(t, unpack, http.MethodGet, target, "", withKey); rec.Code != http.StatusOK {
+		t.Fatalf("get %d %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doAuth(t, unpack, http.MethodPost, "/api/browse",
+		`{"path":`+jsonString(t, filepath.Join(dir, "x"))+`}`, withKey); rec.Code != http.StatusForbidden {
+		t.Fatalf("post %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrowseCreateRejectsEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	unpack := testAuthUnpackerr(t)
+	body := `{"path":"  "}`
+
+	if rec := doAuth(t, unpack, http.MethodPost, "/api/browse", body, withAdminKey); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func withAdminKey(req *http.Request) {
+	req.Header.Set(headerAPIKey, strings.Repeat("A", apiKeyMinLen))
+}
+
+func decodeBrowse(t *testing.T, body []byte) BrowseDir {
+	t.Helper()
+
+	var got BrowseDir
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	return got
+}
+
+func jsonString(t *testing.T, value string) string {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(raw)
+}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -16,6 +16,7 @@
     {"name": "system"},
     {"name": "queue"},
     {"name": "history"},
+    {"name": "files"},
     {"name": "config"}
   ],
   "security": [
@@ -162,6 +163,24 @@
           "status": {"type": "string"},
           "restartRequired": {"type": "boolean"}
         }
+      },
+      "BrowseDir": {
+        "type": "object",
+        "properties": {
+          "sep": {"type": "string", "description": "filepath.Separator on this host"},
+          "path": {"type": "string", "description": "Directory being listed; empty on Windows volume-root listing"},
+          "mom": {"type": "string", "description": "Parent directory; empty at a volume root"},
+          "dirs": {"type": "array", "items": {"type": "string"}},
+          "files": {"type": "array", "items": {"type": "string"}},
+          "error": {"type": "string", "description": "Set when the requested path was unreadable but the parent listed successfully"}
+        }
+      },
+      "BrowseCreate": {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+          "path": {"type": "string", "description": "Folder to create (MkdirAll 0755); existing folders succeed"}
+        }
       }
     },
     "responses": {
@@ -273,6 +292,50 @@
             "description": "System info",
             "content": {"application/json": {"schema": {"$ref": "#/components/schemas/SystemInfo"}}}
           },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/api/browse": {
+      "get": {
+        "tags": ["files"],
+        "summary": "List files and folders",
+        "description": "Requires read:system:browse. Empty dir expands to the process home directory. A file path lists its parent. An unreadable path that has a readable parent returns 200 with error set. Both unreadable is 406. On Windows, listing empty, / or \\ returns mounted drive letters C: through Z: that exist.",
+        "parameters": [
+          {
+            "name": "dir",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "string"},
+            "description": "Directory or file path; ~ is expanded"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Directory contents",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/BrowseDir"}}}
+          },
+          "406": {"description": "Path and parent are unreadable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      },
+      "post": {
+        "tags": ["files"],
+        "summary": "Create a folder",
+        "description": "Requires write:system:browse. Uses MkdirAll 0755. Existing folders succeed. Returns the listing of the new (or existing) folder.",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/BrowseCreate"}}}
+        },
+        "responses": {
+          "200": {
+            "description": "Directory contents after create",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/BrowseDir"}}}
+          },
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "500": {"description": "Create failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "403": {"$ref": "#/components/responses/Forbidden"}
         }

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -302,7 +302,7 @@
       "get": {
         "tags": ["files"],
         "summary": "List files and folders",
-        "description": "Requires read:system:browse. Empty dir expands to the process home directory. A file path lists its parent. An unreadable path that has a readable parent returns 200 with error set. Both unreadable is 406. On Windows, listing empty, / or \\ returns mounted drive letters C: through Z: that exist.",
+        "description": "Requires read:system:browse. Empty dir expands to the process home directory; on Windows empty, / or \\ lists mounted C:–Z: drives that exist. A file path lists its parent. An unreadable path that has a readable parent returns 200 with error set. Both unreadable is 406. mom is empty at a volume root.",
         "parameters": [
           {
             "name": "dir",

--- a/pkg/unpackerr/openapi_test.go
+++ b/pkg/unpackerr/openapi_test.go
@@ -27,16 +27,12 @@ func TestOpenAPIUnauthenticated(t *testing.T) {
 	}
 
 	paths, _ := doc["paths"].(map[string]any)
-	if _, ok := paths["/api/stats"]; !ok {
-		t.Fatal("missing /api/stats")
-	}
-
-	if _, ok := paths["/api/config/{section}/live"]; !ok {
-		t.Fatal("missing live config GET")
-	}
-
-	if _, ok := paths["/api/config/env"]; !ok {
-		t.Fatal("missing /api/config/env")
+	for _, route := range []string{
+		"/api/stats", "/api/config/{section}/live", "/api/config/env", "/api/browse",
+	} {
+		if _, ok := paths[route]; !ok {
+			t.Fatalf("missing %s", route)
+		}
 	}
 
 	login := openAPIPath(t, paths, "/api/auth/login")

--- a/pkg/unpackerr/permissions.go
+++ b/pkg/unpackerr/permissions.go
@@ -11,9 +11,11 @@ const (
 	PermReadSystemHistory  = "read:system:history"
 	PermWriteSystemHistory = "write:system:history"
 	PermReadSystemMetrics  = "read:system:metrics"
+	PermReadSystemBrowse   = "read:system:browse"
+	PermWriteSystemBrowse  = "write:system:browse"
 	PermAll                = "*"
 	RoleAdmin              = "admin"
-	systemPermCount        = 8
+	systemPermCount        = 10
 )
 
 // ConfigSection is a per-section config API resource name.
@@ -65,6 +67,8 @@ func AllPermissions() []string {
 		PermReadSystemHistory,
 		PermWriteSystemHistory,
 		PermReadSystemMetrics,
+		PermReadSystemBrowse,
+		PermWriteSystemBrowse,
 		PermAll,
 	)
 


### PR DESCRIPTION
## Summary
- Add `GET /api/browse?dir=` (`read:system:browse`) and `POST /api/browse` (`write:system:browse`) to list directories and `MkdirAll` folders.
- Empty dir is home; a file path lists its parent; an unreadable path with a readable parent is 200 plus `error`; both unreadable is 406. Windows empty/`/`/`\` lists existing `C:`–`Z:` roots.

Stacked on #705.

## Test plan
- [ ] GET `/api/browse` without auth is 401; admin key lists home
- [ ] File path lists the parent; missing path with readable parent returns `error`
- [ ] POST creates a nested folder and lists it
- [ ] Limited API key without browse perms is 403


Made with [Cursor](https://cursor.com)