### PR TITLE
Restore Makefile and source-build Docker for forks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.idea
+/dist
+/unpackerr
+**/.DS_Store
+/README.md
+/INTERNALS.md

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,20 @@
 # GitHub Actions
 
-Two workflows. `test-and-lint` (`codetests.yml`) runs tests and golangci-lint on push and `pull_request_target`. `build-and-release` (`release.yml`) is the only publisher.
+Three workflows:
+
+| Workflow | File | Who runs it |
+|---|---|---|
+| `test-and-lint` | `codetests.yml` | Every clone. `push` and `pull_request`. |
+| `build-and-release` | `release.yml` | **`Unpackerr/unpackerr` only** (GoReleaser Pro). |
+| `fork-docker` | `fork.yml` | Forks only (`github.repository != 'Unpackerr/unpackerr'`). |
+
+Local builds: `make` / `make build`, `make generate`, `make docker`, `make dev`. See the root `Makefile`. Official images copy a prebuilt binary with `init/docker/Dockerfile.goreleaser`; `Dockerfile` at the repo root compiles from source.
+
+`fork.yml` is `workflow_dispatch` plus `v*` tags. It builds `Dockerfile` and pushes `ghcr.io/<owner>/<repo>` (`linux/amd64`, `linux/arm64`). Dispatch can skip the push. Tagged builds also get `latest` plus semver tags. No Apple/Windows signing, packagecloud, or AUR.
 
 ## Channels
 
-`release.yml` maps the GitHub event to a `CHANNEL` env that `.goreleaser.yaml` reads (`dockers_v2.disable`, packagecloud repo, unstable upload). `--nightly` is a GoReleaser flag: it bumps the version and turns off GitHub Releases / AUR.
+`release.yml` runs only when `github.repository == 'Unpackerr/unpackerr'`. It maps the GitHub event to a `CHANNEL` env that `.goreleaser.yaml` reads (`dockers_v2.disable`, packagecloud repo, unstable upload). `--nightly` is a GoReleaser flag: it bumps the version and turns off GitHub Releases / AUR.
 
 | Trigger | CHANNEL | GoReleaser extra | What it publishes |
 |---|---|---|---|
@@ -52,7 +62,7 @@ nFPM `release` is not templated (GoReleaser copies it verbatim). `${PKG_RELEASE}
 
 ## Merge destinations
 
-- **Docker** — always `ghcr.io/unpackerr/unpackerr` and Hub `docker.io/golift/unpackerr` (`DOCKERHUB_PUBLISH=1`). Empty `DOCKERHUB_PASSWORD` fails the merge job. Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`. `upload-artifact` zip stores files as `0644`; the merge job `chmod 0755`s `dist/linux/**/unpackerr` and the Dockerfile `COPY --chmod=755` so the image entrypoint is executable.
+- **Docker** — always `ghcr.io/unpackerr/unpackerr` and Hub `docker.io/golift/unpackerr` (`DOCKERHUB_PUBLISH=1`). Empty `DOCKERHUB_PASSWORD` fails the merge job. Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`. `upload-artifact` zip stores files as `0644`; the merge job `chmod 0755`s `dist/linux/**/unpackerr` and `init/docker/Dockerfile.goreleaser` `COPY --chmod=755` so the image entrypoint is executable. Runtime images install `curl` and `jq` alongside `ca-certificates`, `openssl`, and `tzdata`.
 - **GitHub Release** — tagged `v*` only (`release.disable: "{{ .IsNightly }}"`). macOS is the notarized `Unpackerr.dmg`. Windows assets are `unpackerr.amd64.exe.zip`. FreeBSD assets are pkgng `unpackerr-<version>.{amd64,i386,armhf,arm64}.txz`. Homebrew is unsupported.
 - **AUR** — tagged `CHANNEL=release` only, after packagecloud. `.github/scripts/aur_publish.sh` uses `dist/unpackerr-VERSION.tar.gz` from `continue --merge` (CI fails if that file is missing). GoReleaser `aur_sources` cannot split/merge: `--split` fatals `no linux archives found` (source tarball is merge-only), and merge Publish finds no PKGBUILD artifacts. Skip nightly/unstable. nFPM `.pkg.tar.zst` on the GitHub Release is a separate binary package.
 - **packagecloud** — `golift/pkgs` vs `golift/unstable`. Skip when `CHANNEL=nightly`.
@@ -87,8 +97,8 @@ Set on the `Unpackerr/unpackerr` repo (or org, granted to this public repo). `.g
 
 ## Action pins
 
-`release.yml` and `codetests.yml` pin `owner/repo@<commit-sha> # vX.Y.Z`. Floating major tags (`@v4`) are not used.
+`release.yml`, `fork.yml`, and `codetests.yml` pin `owner/repo@<commit-sha> # vX.Y.Z`. Floating major tags (`@v4`) are not used.
 
-The Docker base image in `init/docker/Dockerfile` is pinned as `alpine:<tag>@sha256:<digest>`. Renovate keeps Action and Dockerfile digest pins current (`helpers:pinGitHubActionDigestsToSemver`; Dockerfile `pinDigests`). Compose examples stay unpinned.
+The Alpine runtime in `Dockerfile` and `init/docker/Dockerfile.goreleaser` is pinned as `alpine:<tag>@sha256:<digest>` (the source-build builder is `golang:1.27-alpine@sha256:<digest>`). Renovate keeps Action and Dockerfile digest pins current (`helpers:pinGitHubActionDigestsToSemver`; Dockerfile `pinDigests`). Compose examples stay unpinned.
 
 Renovate automerges Go and Docker non-major updates, and GitHub Actions updates including majors, after a 7-day release age when checks pass.

--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -1,7 +1,7 @@
 name: test-and-lint
 on:
   push:
-  pull_request_target:
+  pull_request:
 permissions:
   contents: read
 jobs:
@@ -12,15 +12,7 @@ jobs:
         os: [ubuntu, macos, windows]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: checkout PR head (pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: checkout branch (push)
-        if: github.event_name == 'push'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 'stable'
@@ -40,15 +32,7 @@ jobs:
     env:
       GOOS: ${{ matrix.os }}
     steps:
-      - name: checkout PR head (pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: checkout branch (push)
-        if: github.event_name == 'push'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
@@ -69,15 +53,7 @@ jobs:
     env:
       GOOS: ${{ matrix.os }}
     steps:
-      - name: checkout PR head (pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: checkout branch (push)
-        if: github.event_name == 'push'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -1,0 +1,94 @@
+name: fork-docker
+# Source-build GHCR image for forks. Unpackerr/unpackerr uses release.yml (GoReleaser Pro).
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: Push the image to GHCR
+        type: boolean
+        default: true
+      platforms:
+        description: Target platforms
+        type: string
+        default: linux/amd64,linux/arm64
+  push:
+    tags:
+      - v*
+permissions:
+  contents: read
+jobs:
+  docker:
+    if: github.repository != 'Unpackerr/unpackerr'
+    name: GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Log into GHCR
+        if: github.event_name == 'push' || inputs.push
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=sha
+            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Build args
+        id: args
+        run: |
+          set -euo pipefail
+          DATE="$(date -u +%Y-%m-%dT%H:%M:00Z)"
+          if [ "${GITHUB_REF_TYPE}" = tag ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')"
+          fi
+          [ -n "${VERSION}" ] || VERSION=development
+          REVISION="$(git rev-list --count --all || echo 0)"
+          COMMIT="$(git rev-parse --short HEAD || echo unknown)"
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          VERSION="$(printf '%s' "${VERSION}" | tr -cd 'A-Za-z0-9._/-')"
+          BRANCH="$(printf '%s' "${BRANCH}" | tr -cd 'A-Za-z0-9._/-')"
+          {
+            echo "BUILD_DATE=${DATE}"
+            echo "VERSION=${VERSION}"
+            echo "REVISION=${REVISION}"
+            echo "COMMIT=${COMMIT}"
+            echo "BRANCH=${BRANCH}"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name == 'push' || inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_DATE=${{ steps.args.outputs.BUILD_DATE }}
+            VERSION=${{ steps.args.outputs.VERSION }}
+            REVISION=${{ steps.args.outputs.REVISION }}
+            COMMIT=${{ steps.args.outputs.COMMIT }}
+            BRANCH=${{ steps.args.outputs.BRANCH }}

--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
         with:
-          platforms: arm64
+          platforms: arm64,arm
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Log into GHCR
         if: github.event_name == 'push' || inputs.push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ permissions:
 # See README.md in this folder.
 jobs:
   channel:
+    if: github.repository == 'Unpackerr/unpackerr'
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.channel.outputs.channel }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -339,7 +339,7 @@ nfpms:
 dockers_v2:
   - id: unpackerr-release
     disable: '{{ ne .Env.CHANNEL "release" }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - ghcr.io/unpackerr/unpackerr
@@ -366,7 +366,7 @@ dockers_v2:
       org.opencontainers.image.licenses: MIT
   - id: unpackerr-release-hub
     disable: '{{ or (ne .Env.CHANNEL "release") (not (isEnvSet "DOCKERHUB_PUBLISH")) }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - docker.io/golift/unpackerr
@@ -380,7 +380,7 @@ dockers_v2:
     labels: *docker_labels
   - id: unpackerr-unstable
     disable: '{{ ne .Env.CHANNEL "unstable" }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - ghcr.io/unpackerr/unpackerr
@@ -390,7 +390,7 @@ dockers_v2:
     labels: *docker_labels
   - id: unpackerr-unstable-hub
     disable: '{{ or (ne .Env.CHANNEL "unstable") (not (isEnvSet "DOCKERHUB_PUBLISH")) }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - docker.io/golift/unpackerr
@@ -400,7 +400,7 @@ dockers_v2:
     labels: *docker_labels
   - id: unpackerr-nightly
     disable: '{{ ne .Env.CHANNEL "nightly" }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - ghcr.io/unpackerr/unpackerr
@@ -410,7 +410,7 @@ dockers_v2:
     labels: *docker_labels
   - id: unpackerr-nightly-hub
     disable: '{{ or (ne .Env.CHANNEL "nightly") (not (isEnvSet "DOCKERHUB_PUBLISH")) }}'
-    dockerfile: init/docker/Dockerfile
+    dockerfile: init/docker/Dockerfile.goreleaser
     ids: [unpackerr]
     images:
       - docker.io/golift/unpackerr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+# Source-build image for local `make docker` and forks.
+# Official Unpackerr/unpackerr releases copy a prebuilt binary via
+# init/docker/Dockerfile.goreleaser.
+
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY main.go ./
+COPY pkg pkg
+COPY examples examples
+COPY init/config init/config
+RUN go generate ./...
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG VERSION=development
+ARG REVISION=0
+ARG BRANCH=unknown
+ARG COMMIT=unknown
+ARG BUILD_DATE
+ARG BUILD_USER=docker
+
+ENV CGO_ENABLED=0
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+
+RUN GOARM="${TARGETVARIANT#v}" go build -trimpath -tags osusergo,netgo \
+    -ldflags "-s -w \
+    -X golift.io/version.Version=${VERSION} \
+    -X golift.io/version.Revision=${REVISION} \
+    -X \"golift.io/version.Branch=${BRANCH} (${COMMIT})\" \
+    -X golift.io/version.BuildDate=${BUILD_DATE} \
+    -X golift.io/version.BuildUser=${BUILD_USER}" \
+    -o /unpackerr
+
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+RUN apk add --no-cache ca-certificates openssl tzdata curl jq
+
+COPY --from=builder --chmod=755 /unpackerr /unpackerr
+
+ENV TZ=UTC
+
+EXPOSE 5656
+ENTRYPOINT ["/unpackerr"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Local development. Official releases are GoReleaser Pro — see .github/workflows/README.md.
+
+VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')
+REVISION ?= $(shell git rev-list --count --all 2>/dev/null || echo 0)
+COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+DATE     ?= $(shell date -u +%Y-%m-%dT%H:%M:00Z)
+IMAGE    ?= unpackerr:dev
+
+UN_WEBSERVER_LISTEN_ADDR ?= 127.0.0.1:5656
+UN_WEBSERVER_UI_PASSWORD ?= admin:supersecret123
+
+BUILD_FLAGS = -tags osusergo,netgo
+VERSION_LDFLAGS := -X \"golift.io/version.Branch=$(BRANCH) ($(COMMIT))\" \
+	-X \"golift.io/version.BuildDate=$(DATE)\" \
+	-X \"golift.io/version.BuildUser=$(shell whoami 2>/dev/null || echo unknown)\" \
+	-X \"golift.io/version.Revision=$(REVISION)\" \
+	-X \"golift.io/version.Version=$(VERSION)\"
+
+.DEFAULT_GOAL := build
+
+.PHONY: all build generate dev docker clean
+
+all: build
+
+generate:
+	go generate ./...
+
+build: generate
+	go build -trimpath $(BUILD_FLAGS) -o unpackerr -ldflags "-w -s $(VERSION_LDFLAGS) $(EXTRA_LDFLAGS)"
+
+dev:
+	USEGUI=false \
+	UN_WEBSERVER_LISTEN_ADDR="$(UN_WEBSERVER_LISTEN_ADDR)" \
+	UN_WEBSERVER_UI_PASSWORD="$(UN_WEBSERVER_UI_PASSWORD)" \
+	UN_DEBUG=true \
+	go run . $(ARGS)
+
+docker:
+	docker build \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg REVISION="$(REVISION)" \
+		--build-arg BRANCH="$(BRANCH)" \
+		--build-arg COMMIT="$(COMMIT)" \
+		--build-arg BUILD_DATE="$(DATE)" \
+		--build-arg BUILD_USER="$(shell whoami 2>/dev/null || echo unknown)" \
+		-t "$(IMAGE)" .
+
+clean:
+	rm -f unpackerr unpackerr.*.{macos,freebsd,linux,exe}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Local development. Official releases are GoReleaser Pro — see .github/workflows/README.md.
 
-VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')
+VERSION  ?= $(or $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//'),development)
 REVISION ?= $(shell git rev-list --count --all 2>/dev/null || echo 0)
 COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
@@ -47,4 +47,4 @@ docker:
 		-t "$(IMAGE)" .
 
 clean:
-	rm -f unpackerr unpackerr.*.{macos,freebsd,linux,exe}
+	rm -f unpackerr unpackerr.*.macos unpackerr.*.freebsd unpackerr.*.linux unpackerr.*.exe

--- a/init/docker/Dockerfile.goreleaser
+++ b/init/docker/Dockerfile.goreleaser
@@ -1,6 +1,8 @@
+# Copy-binary image used by GoReleaser Pro (dockers_v2).
+# Local and fork builds use the repo-root Dockerfile.
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-RUN apk add --no-cache ca-certificates openssl tzdata
+RUN apk add --no-cache ca-certificates openssl tzdata curl jq
 
 ARG TARGETPLATFORM
 # Actions zip artifacts store every file as 0644; without --chmod the image


### PR DESCRIPTION
## Summary
- Add a source-build `Dockerfile` and `Makefile` (`make`, `make docker`, `make dev`) so local work and forks do not need GoReleaser Pro.
- Rename the copy-binary image to `init/docker/Dockerfile.goreleaser`, install `curl` and `jq` in both images, and gate Pro `release.yml` to `Unpackerr/unpackerr`.
- Add a forks-only `fork.yml` (dispatch + `v*` tags → GHCR) and run `codetests.yml` on `pull_request` instead of `pull_request_target`.

## Test plan
- [ ] `make` produces a local `unpackerr` binary with version ldflags
- [ ] `make docker` builds `unpackerr:dev` from the repo-root Dockerfile (`curl`/`jq` present)
- [ ] On this PR, `test-and-lint` runs from `pull_request` (not `pull_request_target`)
- [ ] After merge, `release.yml` is skipped on forks; `fork.yml` is skipped on `Unpackerr/unpackerr`
- [ ] Dispatch `fork.yml` on a fork pushes `ghcr.io/<owner>/unpackerr`


Made with [Cursor](https://cursor.com)