### PR TITLE
Put permission verbs last (area:resource:verb)

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -174,7 +174,7 @@ Env overlays **live only**. They are not merged into `fileConfig`. A later PUT t
 
 ### GET `/api/config/{section}` (file)
 
-Permission: `read:config:{section}`.
+Permission: `config:{section}:read`.
 
 Returns `fileConfig` (cloned). Webserver GET:
 
@@ -196,7 +196,7 @@ Live GET of general/starr/folders/hooks runs `onMainLoop` so it does not race `R
 
 ### PUT `/api/config/{section}`
 
-Permission: `write:config:{section}`.
+Permission: `config:{section}:write`.
 
 Body **replaces** the section (not patch). Workflow the UI is built for: GET file → edit → PUT.
 
@@ -262,24 +262,24 @@ Index is `GET {urlbase}{$}` so `GET /` is not a ServeMux prefix match (that woul
 | GET | `{urlbase}api/openapi.json` | none | — | Spec; `servers[0].url` rewritten to urlbase |
 | POST | `{urlbase}api/auth/login` | none | — | JSON `{name?, kdf}`. 3s fail delay. 5s read deadline **outside** apache log wrapper. Missing if cookies failed to init. |
 | POST | `{urlbase}api/auth/logout` | none | — | Clears session cookie |
-| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions, `header`, `clientIP`, `upstreamAllowed`. `headers` (this request minus the Trust exclusion list) only with `read:system:headers` |
-| GET | `{urlbase}api/stats` | yes | `read:system:stats` | Queue counts + hook counters |
-| GET | `{urlbase}api/system` | yes | `read:system:info` | Version, uptime, bind addr, urlbase, auth type, metrics flag, config file, GOOS |
-| GET | `{urlbase}api/system/export` | yes | `read:system:info` | Startup-log style live rundown; each section also needs `read:config:{section}` (or `*`); omitted sections say so. Secrets omitted. |
-| GET | `{urlbase}api/queue` | yes | `read:system:queue` | In-flight items |
-| POST | `{urlbase}api/queue/retry` | yes | `write:system:queue` | `{id}`; only `extractfailed`; Starr → `WAITING`; folder resets on main loop |
-| POST | `{urlbase}api/queue/forget` | yes | `write:system:queue` | Terminal statuses only; in-progress **409**; Starr titles get a tombstone until they leave the upstream queue |
-| GET | `{urlbase}api/history` | yes | `read:system:history` | Durable JSONL-backed rows |
-| POST | `{urlbase}api/history/clear` | yes | `write:system:history` | |
-| POST | `{urlbase}api/history/delete` | yes | `write:system:history` | `{id}` |
-| GET | `{urlbase}api/browse` | yes | `read:system:browse` | `?dir=`; empty → home; file path lists parent; unreadable path (Stat or ReadDir) with readable parent is 200 + `error`; both fail → 406. `mom` is empty at a volume root. Windows empty/`/`/`\` lists `C:\`–`Z:\` that exist. |
-| POST | `{urlbase}api/browse` | yes | `write:system:browse` | `{path}`; folder `MkdirAll` 0755 (existing folders succeed) |
+| GET | `{urlbase}api/auth/me` | yes | any auth | Session / key / proxy identity + permissions, `header`, `clientIP`, `upstreamAllowed`. `headers` (this request minus the Trust exclusion list) only with `system:headers:read` |
+| GET | `{urlbase}api/stats` | yes | `system:stats:read` | Queue counts + hook counters |
+| GET | `{urlbase}api/system` | yes | `system:info:read` | Version, uptime, bind addr, urlbase, auth type, metrics flag, config file, GOOS |
+| GET | `{urlbase}api/system/export` | yes | `system:info:read` | Startup-log style live rundown; each section also needs `config:{section}:read` (or `*`); omitted sections say so. Secrets omitted. |
+| GET | `{urlbase}api/queue` | yes | `system:queue:read` | In-flight items |
+| POST | `{urlbase}api/queue/retry` | yes | `system:queue:write` | `{id}`; only `extractfailed`; Starr → `WAITING`; folder resets on main loop |
+| POST | `{urlbase}api/queue/forget` | yes | `system:queue:write` | Terminal statuses only; in-progress **409**; Starr titles get a tombstone until they leave the upstream queue |
+| GET | `{urlbase}api/history` | yes | `system:history:read` | Durable JSONL-backed rows |
+| POST | `{urlbase}api/history/clear` | yes | `system:history:write` | |
+| POST | `{urlbase}api/history/delete` | yes | `system:history:write` | `{id}` |
+| GET | `{urlbase}api/browse` | yes | `system:browse:read` | `?dir=`; empty → home; file path lists parent; unreadable path (Stat or ReadDir) with readable parent is 200 + `error`; both fail → 406. `mom` is empty at a volume root. Windows empty/`/`/`\` lists `C:\`–`Z:\` that exist. |
+| POST | `{urlbase}api/browse` | yes | `system:browse:write` | `{path}`; folder `MkdirAll` 0755 (existing folders succeed) |
 | GET | `{urlbase}api/config/help` | yes | any auth | English field help from definitions.yml |
 | GET | `{urlbase}api/config/env` | yes | any auth | UN_* overlays from startup; secret values blank unless `*` |
-| GET | `{urlbase}api/config/{section}` | yes | `read:config:{section}` | File snapshot |
-| GET | `{urlbase}api/config/{section}/live` | yes | `read:config:{section}` | Running copy |
-| PUT | `{urlbase}api/config/{section}` | yes | `write:config:{section}` | Replace section |
-| GET | `/metrics` (+ urlbase) | **API key / Bearer only** | `read:system:metrics` | No session cookie, no webauth/noauth |
+| GET | `{urlbase}api/config/{section}` | yes | `config:{section}:read` | File snapshot |
+| GET | `{urlbase}api/config/{section}/live` | yes | `config:{section}:read` | Running copy |
+| PUT | `{urlbase}api/config/{section}` | yes | `config:{section}:write` | Replace section |
+| GET | `/metrics` (+ urlbase) | **API key / Bearer only** | `system:metrics:read` | No session cookie, no webauth/noauth |
 | GET | `/debug/pprof/…` | none extra | — | Only if `pprof = true`. Treat as a loaded gun. |
 
 `{section}` is one of: `general`, `webserver`, `sonarr`, `radarr`, `lidarr`, `readarr`, `whisparr`, `folders`, `webhooks`, `cmdhooks`. Unknown → 404 from `requireConfigPerm`.
@@ -309,11 +309,11 @@ First start with listen enabled and no password: generate one, print once, hash,
 
 ## Permissions
 
-`verb:area:resource`. Built-in role `admin` is reserved and means `*`.
+`area:resource:verb`. Built-in role `admin` is reserved and means `*`.
 
-System: `read:system:stats|info|queue|history|metrics|headers|browse`, `write:system:queue|history|browse`.
+System: `system:{stats,info,queue,history,metrics,headers,browse}:read`, `system:{queue,history,browse}:write`.
 
-Config: `read:config:{section}`, `write:config:{section}` for each section above.
+Config: `config:{section}:read`, `config:{section}:write` for each section above.
 
 Custom roles are a map of name → permission list. Env for roles is picky: do **not** set `UN_WEBSERVER_ROLES` itself. Use `UN_WEBSERVER_ROLES_<name>_PERMISSIONS_0=…`.
 

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -101,7 +101,7 @@ passwords = []
 [webserver]
 ## Expose Prometheus metrics at /metrics. The HTTP server starts whenever listen_addr is set;
 ## this only controls the /metrics route. Scrapes must send an API key with
-## read:system:metrics via Authorization: Bearer or X-Api-Key.
+## system:metrics:read via Authorization: Bearer or X-Api-Key.
  metrics = false
 ## Expose Go pprof handlers at /debug/pprof/. Leave this false unless you
 ## are debugging the running process.
@@ -141,13 +141,13 @@ passwords = []
 ## Nested [webserver.roles.<name>] tables. Names are letters, digits, _ or -.
 ## Built-in admin cannot be redefined. `*` is reserved for that built-in role.
 ## Each custom role needs at least one known permission.
-## File browser is read:system:browse (list) and write:system:browse (create folder).
+## File browser is system:browse:read (list) and system:browse:write (create folder).
 ## Env works but is picky: do not set UN_WEBSERVER_ROLES itself. Role names are
 ## case-sensitive and may contain underscores. Index permissions from 0:
-## UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=read:system:stats
-## UN_WEBSERVER_ROLES_read_only_PERMISSIONS_0=read:system:stats
+## UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=system:stats:read
+## UN_WEBSERVER_ROLES_read_only_PERMISSIONS_0=system:stats:read
 ## [webserver.roles.stats]
-## permissions = ["read:system:stats"]
+## permissions = ["system:stats:read"]
 
 ## Global Folder configuration that affects all watched folders.
 [folders]
@@ -487,4 +487,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 10 SEP 2026 04:55 UTC
+## => Content Auto Generated, 10 SEP 2026 07:22 UTC

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -459,7 +459,7 @@ sections:
         desc: |
           Expose Prometheus metrics at /metrics. The HTTP server starts whenever listen_addr is set;
           this only controls the /metrics route. Scrapes must send an API key with
-          read:system:metrics via Authorization: Bearer or X-Api-Key.
+          system:metrics:read via Authorization: Bearer or X-Api-Key.
       - name: pprof
         envvar: PPROF
         default: false
@@ -550,13 +550,13 @@ sections:
           Nested [webserver.roles.<name>] tables. Names are letters, digits, _ or -.
           Built-in admin cannot be redefined. `*` is reserved for that built-in role.
           Each custom role needs at least one known permission.
-          File browser is read:system:browse (list) and write:system:browse (create folder).
+          File browser is system:browse:read (list) and system:browse:write (create folder).
           Env works but is picky: do not set UN_WEBSERVER_ROLES itself. Role names are
           case-sensitive and may contain underscores. Index permissions from 0:
-          UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=read:system:stats
-          UN_WEBSERVER_ROLES_read_only_PERMISSIONS_0=read:system:stats
+          UN_WEBSERVER_ROLES_stats_PERMISSIONS_0=system:stats:read
+          UN_WEBSERVER_ROLES_read_only_PERMISSIONS_0=system:stats:read
           [webserver.roles.stats]
-          permissions = ["read:system:stats"]
+          permissions = ["system:stats:read"]
 
   starr_header:
     no_header: true

--- a/pkg/configdef/live_test.go
+++ b/pkg/configdef/live_test.go
@@ -185,7 +185,7 @@ func TestRenderLiveAPIKeysAndRoles(t *testing.T) {
 				Roles: []string{"stats"},
 			}},
 			Roles: map[string]liveRole{
-				"stats": {Permissions: []string{"read:system:stats"}},
+				"stats": {Permissions: []string{"system:stats:read"}},
 			},
 		},
 	}
@@ -219,7 +219,7 @@ func TestRenderLiveAPIKeysAndRoles(t *testing.T) {
 		t.Fatalf("decoded keys %+v", decoded.Webserver.APIKeys)
 	}
 
-	if decoded.Webserver.Roles["stats"].Permissions[0] != "read:system:stats" {
+	if decoded.Webserver.Roles["stats"].Permissions[0] != "system:stats:read" {
 		t.Fatalf("decoded roles %+v", decoded.Webserver.Roles)
 	}
 }
@@ -335,7 +335,7 @@ func TestRenderLiveNestedAPIKeysAndRoles(t *testing.T) {
 				Roles: []string{"admin"},
 			}},
 			Roles: map[string]liveRole{
-				"stats": {Permissions: []string{"read:system:stats"}},
+				"stats": {Permissions: []string{"system:stats:read"}},
 			},
 		},
 	}
@@ -362,7 +362,7 @@ func TestRenderLiveNestedAPIKeysAndRoles(t *testing.T) {
 		t.Fatalf("missing [webserver.roles.stats]:\n%s", snippet(body, "roles"))
 	}
 
-	if !strings.Contains(body, `permissions = ["read:system:stats"]`) {
+	if !strings.Contains(body, `permissions = ["system:stats:read"]`) {
 		t.Fatalf("missing role permissions:\n%s", snippet(body, "permissions"))
 	}
 }

--- a/pkg/unpackerr/api_test.go
+++ b/pkg/unpackerr/api_test.go
@@ -298,8 +298,8 @@ func TestLiveExportOmitsWithoutConfigRead(t *testing.T) {
 	}
 
 	text := out["text"]
-	if !strings.Contains(text, "omitted (need read:config:webhooks)") ||
-		!strings.Contains(text, "omitted (need read:config:cmdhooks)") {
+	if !strings.Contains(text, "omitted (need "+PermReadConfig(SectionWebhooks)+")") ||
+		!strings.Contains(text, "omitted (need "+PermReadConfig(SectionCmdhooks)+")") {
 		t.Fatalf("export missing omit lines %q", text)
 	}
 

--- a/pkg/unpackerr/apikeys_test.go
+++ b/pkg/unpackerr/apikeys_test.go
@@ -24,7 +24,7 @@ func TestAllPermissionsIncludeConfigSections(t *testing.T) {
 		t.Fatal("config section permissions must be known")
 	}
 
-	if KnownPermission("read:system:nope") {
+	if KnownPermission("system:nope:read") {
 		t.Fatal("unknown permission")
 	}
 

--- a/pkg/unpackerr/cnfgfile_test.go
+++ b/pkg/unpackerr/cnfgfile_test.go
@@ -619,13 +619,13 @@ func TestEnvSuffixesAndSecrets(t *testing.T) {
 	got := envSuffixes(cnfg.Pairs{
 		"UN_DEBUG":                               "true",
 		"UN_SONARR_0_API_KEY":                    "k",
-		"UN_WEBSERVER_ROLES_stats_PERMISSIONS_0": "read:system:stats",
+		"UN_WEBSERVER_ROLES_stats_PERMISSIONS_0": "system:stats:read",
 	}, "UN")
 	if got["DEBUG"] != "true" || got["SONARR_0_API_KEY"] != "k" {
 		t.Fatalf("%v", got)
 	}
 
-	if got["WEBSERVER_ROLES_stats_PERMISSIONS_0"] != "read:system:stats" {
+	if got["WEBSERVER_ROLES_stats_PERMISSIONS_0"] != "system:stats:read" {
 		t.Fatalf("mixed-case suffix lost: %v", got)
 	}
 

--- a/pkg/unpackerr/configapi.go
+++ b/pkg/unpackerr/configapi.go
@@ -177,7 +177,7 @@ func (u *Unpackerr) liveGeneralConfig() generalConfig {
 }
 
 // redactAPIKeysUnlessAll blanks webserver API key secrets unless the caller has *.
-// Starr API keys are not webserver.APIKeys and stay visible to read:config:*.
+// Starr API keys are not webserver.APIKeys and stay visible to config:*:read.
 func redactAPIKeysUnlessAll(request *http.Request, web *WebServer) *WebServer {
 	info, _ := request.Context().Value(authCtxKey).(authInfo)
 	if web == nil || info.allows(PermAll) {

--- a/pkg/unpackerr/configdump.go
+++ b/pkg/unpackerr/configdump.go
@@ -32,7 +32,7 @@ func (d dumpAuth) omit(printf configLine, section ConfigSection, label string) b
 
 // liveConfigText is the same rundown as the startup log: what's actually running,
 // with secrets omitted (API keys as present/absent, UI password as auth type).
-// Per-section details require read:config:{section} (or *); missing sections say so.
+// Per-section details require config:{section}:read (or *); missing sections say so.
 func (u *Unpackerr) liveConfigText(info authInfo) string {
 	var buf strings.Builder
 

--- a/pkg/unpackerr/configdump_test.go
+++ b/pkg/unpackerr/configdump_test.go
@@ -63,18 +63,11 @@ func TestLiveConfigOmitsWithoutSectionRead(t *testing.T) {
 		info:  authInfo{Permissions: []string{PermReadSystemInfo}},
 	})
 
-	for _, need := range []string{
-		"omitted (need read:config:sonarr)",
-		"omitted (need read:config:radarr)",
-		"omitted (need read:config:lidarr)",
-		"omitted (need read:config:readarr)",
-		"omitted (need read:config:whisparr)",
-		"omitted (need read:config:folders)",
-		"omitted (need read:config:general)",
-		"omitted (need read:config:webhooks)",
-		"omitted (need read:config:cmdhooks)",
-		"omitted (need read:config:webserver)",
+	for _, section := range []ConfigSection{
+		SectionSonarr, SectionRadarr, SectionLidarr, SectionReadarr, SectionWhisparr,
+		SectionFolders, SectionGeneral, SectionWebhooks, SectionCmdhooks, SectionWebserver,
 	} {
+		need := "omitted (need " + PermReadConfig(section) + ")"
 		if !strings.Contains(got, need) {
 			t.Errorf("missing %q in:\n%s", need, got)
 		}

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -68,7 +68,7 @@
           "headers": {
             "type": "object",
             "additionalProperties": {"type": "array", "items": {"type": "string"}},
-            "description": "Incoming request headers for the proxy-auth picker, minus the Trust exclusion list (and X-Api-Key / Authorization). Omitted unless the caller has read:system:headers"
+            "description": "Incoming request headers for the proxy-auth picker, minus the Trust exclusion list (and X-Api-Key / Authorization). Omitted unless the caller has system:headers:read"
           },
           "clientIP": {"type": "string", "description": "RemoteAddr host of this request"},
           "upstreamAllowed": {"type": "boolean", "description": "True when RemoteAddr is in webserver upstreams"},
@@ -275,7 +275,7 @@
       "get": {
         "tags": ["auth"],
         "summary": "Current session or API key identity",
-        "description": "headers is included only when the caller has read:system:headers (admin / * included)",
+        "description": "headers is included only when the caller has system:headers:read (admin / * included)",
         "responses": {
           "200": {
             "description": "Auth info including apiKey when using a session",
@@ -289,7 +289,7 @@
       "get": {
         "tags": ["system"],
         "summary": "Queue counts for Homepage and the dashboard",
-        "description": "Requires read:system:stats",
+        "description": "Requires system:stats:read",
         "responses": {
           "200": {
             "description": "Counts",
@@ -304,7 +304,7 @@
       "get": {
         "tags": ["system"],
         "summary": "Version, uptime, listen address, auth mode, config file path",
-        "description": "Requires read:system:info",
+        "description": "Requires system:info:read",
         "responses": {
           "200": {
             "description": "System info",
@@ -319,7 +319,7 @@
       "get": {
         "tags": ["system"],
         "summary": "Live config rundown (startup-log style, secrets omitted)",
-        "description": "Requires read:system:info. Same shape of information as the startup log: apps, folders, intervals, webserver. Each section also needs read:config:{section} (or *); otherwise the dump prints an omit line naming the missing permission. API keys are present/absent booleans, UI password is the auth type only.",
+        "description": "Requires system:info:read. Same shape of information as the startup log: apps, folders, intervals, webserver. Each section also needs config:{section}:read (or *); otherwise the dump prints an omit line naming the missing permission. API keys are present/absent booleans, UI password is the auth type only.",
         "responses": {
           "200": {
             "description": "Plain-text rundown in JSON",
@@ -335,7 +335,7 @@
       "get": {
         "tags": ["files"],
         "summary": "List files and folders",
-        "description": "Requires read:system:browse. Empty dir expands to the process home directory; on Windows empty, / or \\ lists mounted C:–Z: drives that exist. A file path lists its parent. An unreadable path that has a readable parent returns 200 with error set. Both unreadable is 406. mom is empty at a volume root.",
+        "description": "Requires system:browse:read. Empty dir expands to the process home directory; on Windows empty, / or \\ lists mounted C:–Z: drives that exist. A file path lists its parent. An unreadable path that has a readable parent returns 200 with error set. Both unreadable is 406. mom is empty at a volume root.",
         "parameters": [
           {
             "name": "dir",
@@ -358,7 +358,7 @@
       "post": {
         "tags": ["files"],
         "summary": "Create a folder",
-        "description": "Requires write:system:browse. Uses MkdirAll 0755. Existing folders succeed. Returns the listing of the new (or existing) folder.",
+        "description": "Requires system:browse:write. Uses MkdirAll 0755. Existing folders succeed. Returns the listing of the new (or existing) folder.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"$ref": "#/components/schemas/BrowseCreate"}}}
@@ -379,7 +379,7 @@
       "get": {
         "tags": ["system"],
         "summary": "Prometheus metrics (only registered when metrics = true)",
-        "description": "Requires read:system:metrics. API key only: X-Api-Key or Authorization: Bearer. Session cookies and proxy/webauth are rejected.",
+        "description": "Requires system:metrics:read. API key only: X-Api-Key or Authorization: Bearer. Session cookies and proxy/webauth are rejected.",
         "security": [{"apiKey": []}, {"bearer": []}],
         "responses": {
           "200": {
@@ -395,7 +395,7 @@
       "get": {
         "tags": ["queue"],
         "summary": "In-flight extracts",
-        "description": "Requires read:system:queue",
+        "description": "Requires system:queue:read",
         "responses": {
           "200": {
             "description": "Live queue",
@@ -410,7 +410,7 @@
       "post": {
         "tags": ["queue"],
         "summary": "Retry an extractfailed item",
-        "description": "Requires write:system:queue. Id is a path in the JSON body.",
+        "description": "Requires system:queue:write. Id is a path in the JSON body.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
@@ -433,7 +433,7 @@
       "post": {
         "tags": ["queue"],
         "summary": "Drop a terminal queue item from tracking",
-        "description": "Requires write:system:queue. Only extractfailed, extractednothing, imported, deleted, and deletefailed items can be forgotten.",
+        "description": "Requires system:queue:write. Only extractfailed, extractednothing, imported, deleted, and deletefailed items can be forgotten.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
@@ -456,7 +456,7 @@
       "get": {
         "tags": ["history"],
         "summary": "Completed and failed items (newest first)",
-        "description": "Requires read:system:history. Capped by keep_history.",
+        "description": "Requires system:history:read. Capped by keep_history.",
         "responses": {
           "200": {
             "description": "History",
@@ -471,7 +471,7 @@
       "post": {
         "tags": ["history"],
         "summary": "Delete one history row",
-        "description": "Requires write:system:history",
+        "description": "Requires system:history:write",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IDRequest"}}}
@@ -493,7 +493,7 @@
       "post": {
         "tags": ["history"],
         "summary": "Clear all history rows",
-        "description": "Requires write:system:history",
+        "description": "Requires system:history:write",
         "responses": {
           "200": {
             "description": "Cleared",
@@ -554,7 +554,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the on-disk config section",
-        "description": "Requires read:config:{section}. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *; PUT keeps a blank key of the same name. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. PUT a new password as user:<kdf-hex> (same digest as login), not plaintext. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
+        "description": "Requires config:{section}:read. Returns file-shaped values (filepath: prefixes kept). Starr API keys are visible as stored. Unpackerr webserver apiKeys[].key is returned only to callers with *; PUT keeps a blank key of the same name. ui_password is !!cryptd!!, webauth, noauth, or filepath:; plaintext user:pass is blanked. PUT a new password as user:<kdf-hex> (same digest as login), not plaintext. Use GET /api/config/{section}/live for expanded running values. PUT this payload back to save.",
         "responses": {
           "200": {
             "description": "On-disk section payload",
@@ -568,7 +568,7 @@
       "put": {
         "tags": ["config"],
         "summary": "Replace one config section and rewrite the TOML file",
-        "description": "Requires write:config:{section}. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. Validation, the TOML write, and the live apply run on the main loop; a persist failure is 500 and leaves runtime unchanged. An existing filepath: string in the same section is expanded for the running process and kept as filepath: on disk. A new or changed filepath: is 400; the API will not read a file that was not already referenced in that section. Replacing filepath: with a literal value is allowed. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. webserver uiPassword on PUT is !!cryptd!!, webauth, noauth, an existing filepath:, or user:<64-char PBKDF2 hex> (the same kdf as login); plaintext user:pass is 400. Changing the live password hash or auth type while local password auth is on requires uiCurrentKdf (KDF of the current username+password). General interval changes reset the running tickers. Folder lists, webserver listen_addr, urlbase, TLS, metrics, pprof, log settings, debug, quiet, parallel, and file modes return restartRequired: true; the daemon then re-execs itself once nothing is queued, extracting, or awaiting delete. In-flight extracts are never cancelled.",
+        "description": "Requires config:{section}:write. Body is the file-shaped GET payload (not /live). Unknown JSON fields, extra values, empty object sections, and nil list entries return 400. Arrays may be [] to clear. Validation, the TOML write, and the live apply run on the main loop; a persist failure is 500 and leaves runtime unchanged. An existing filepath: string in the same section is expanded for the running process and kept as filepath: on disk. A new or changed filepath: is 400; the API will not read a file that was not already referenced in that section. Replacing filepath: with a literal value is allowed. Empty apiKeys[].key keeps the existing key of the same name so a redacted GET can round-trip without *. webserver uiPassword on PUT is !!cryptd!!, webauth, noauth, an existing filepath:, or user:<64-char PBKDF2 hex> (the same kdf as login); plaintext user:pass is 400. Changing the live password hash or auth type while local password auth is on requires uiCurrentKdf (KDF of the current username+password). General interval changes reset the running tickers. Folder lists, webserver listen_addr, urlbase, TLS, metrics, pprof, log settings, debug, quiet, parallel, and file modes return restartRequired: true; the daemon then re-execs itself once nothing is queued, extracting, or awaiting delete. In-flight extracts are never cancelled.",
         "requestBody": {
           "required": true,
           "content": {"application/json": {"schema": {"description": "Same shape as GET /api/config/{section}"}}}
@@ -602,7 +602,7 @@
       "get": {
         "tags": ["config"],
         "summary": "Read the expanded running config section",
-        "description": "Requires read:config:{section}. Most filepath: values are expanded. Archive passwords are the post-env, pre-expansion slice, so filepath: from the file or UN_PASSWORDS is not replaced with secret-file contents. Unpackerr webserver apiKeys[].key is returned only to callers with *. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
+        "description": "Requires config:{section}:read. Most filepath: values are expanded. Archive passwords are the post-env, pre-expansion slice, so filepath: from the file or UN_PASSWORDS is not replaced with secret-file contents. Unpackerr webserver apiKeys[].key is returned only to callers with *. ui_password is the stored hash or auth mode, not plaintext. Do not PUT this payload if you need to keep filepath: lines.",
         "responses": {
           "200": {
             "description": "Live section payload",

--- a/pkg/unpackerr/permissions.go
+++ b/pkg/unpackerr/permissions.go
@@ -2,18 +2,19 @@ package unpackerr
 
 import "slices"
 
-// Permission names are verb:area:resource. Built-in role admin grants all of them.
+// Permission names are area:resource:verb so later verbs (execute, …) stay
+// on the same resource. Built-in role admin grants all of them.
 const (
-	PermReadSystemStats    = "read:system:stats"
-	PermReadSystemInfo     = "read:system:info"
-	PermReadSystemQueue    = "read:system:queue"
-	PermWriteSystemQueue   = "write:system:queue"
-	PermReadSystemHistory  = "read:system:history"
-	PermWriteSystemHistory = "write:system:history"
-	PermReadSystemMetrics  = "read:system:metrics"
-	PermReadSystemHeaders  = "read:system:headers"
-	PermReadSystemBrowse   = "read:system:browse"
-	PermWriteSystemBrowse  = "write:system:browse"
+	PermReadSystemStats    = "system:stats:read"
+	PermReadSystemInfo     = "system:info:read"
+	PermReadSystemQueue    = "system:queue:read"
+	PermWriteSystemQueue   = "system:queue:write"
+	PermReadSystemHistory  = "system:history:read"
+	PermWriteSystemHistory = "system:history:write"
+	PermReadSystemMetrics  = "system:metrics:read"
+	PermReadSystemHeaders  = "system:headers:read"
+	PermReadSystemBrowse   = "system:browse:read"
+	PermWriteSystemBrowse  = "system:browse:write"
 	PermAll                = "*"
 	RoleAdmin              = "admin"
 	systemPermCount        = 11
@@ -45,11 +46,11 @@ func ConfigSections() []ConfigSection {
 }
 
 func PermReadConfig(section ConfigSection) string {
-	return "read:config:" + string(section)
+	return "config:" + string(section) + ":read"
 }
 
 func PermWriteConfig(section ConfigSection) string {
-	return "write:config:" + string(section)
+	return "config:" + string(section) + ":write"
 }
 
 func KnownSection(name ConfigSection) bool {


### PR DESCRIPTION
## Summary
- Rename permission strings from `read:system:info` / `write:config:lidarr` to `system:info:read` / `config:lidarr:write` so later verbs (execute, …) stay on the same resource.
- Docs, OpenAPI, definitions, and the example conf follow the same shape. No frontend in this PR.

## Test plan
- [ ] Config with `[webserver.roles.stats] permissions = ["system:stats:read"]` can hit `GET /api/stats`
- [ ] Old `read:system:stats` role names are rejected as unknown
- [ ] Live export omit lines name `config:{section}:read`


Made with [Cursor](https://cursor.com)