### PR TITLE
Share checkStarrQueue behind starrApp

### DIFF
--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -11,8 +11,8 @@ import (
 	"golift.io/starr"
 )
 
-/* Shared Starr poll/have lives in starrpoll.go. Per-app files still own check*Queue
-   until the next change; Lidarr SplitFlac stays Lidarr-only.
+/* Shared Starr poll/check/have lives in starrpoll.go. Lidarr SplitFlac is applied
+   via starrApp.tweakExtract so the other apps stay no-ops.
 */
 
 // DefaultQueuePageSize is how many queue items we request from each Starr app.
@@ -132,11 +132,11 @@ func (u *Unpackerr) retrieveAppQueues(now time.Time) {
 
 	wait.Wait()
 	// These are not thread safe because they call saveCompletedDownload.
-	u.checkLidarrQueue(now)
-	u.checkRadarrQueue(now)
-	u.checkReadarrQueue(now)
-	u.checkSonarrQueue(now)
-	u.checkWhisparrQueue(now)
+	checkStarrQueue(u, u.Lidarr, starr.Lidarr, now)
+	checkStarrQueue(u, u.Radarr, starr.Radarr, now)
+	checkStarrQueue(u, u.Readarr, starr.Readarr, now)
+	checkStarrQueue(u, u.Sonarr, starr.Sonarr, now)
+	checkStarrQueue(u, u.Whisparr, starr.Whisparr, now)
 	u.sweepForgotten()
 }
 

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -17,6 +17,7 @@ type starrApp[T any] interface {
 	stripRuntime()    // nil the queue and client on a file-shaped clone.
 	pollQueue() (total, retrieved int, err error)
 	queueViews() []queueView
+	tweakExtract(item *Extract, rec queueView)
 }
 
 func (s *SonarrConfig) conf() *StarrConfig { return &s.StarrConfig }

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -17,6 +17,7 @@ type starrApp[T any] interface {
 	stripRuntime()    // nil the queue and client on a file-shaped clone.
 	pollQueue() (total, retrieved int, err error)
 	queueViews() []queueView
+	hasQueueTitle(name string) bool
 	tweakExtract(item *Extract, rec queueView)
 }
 

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -5,9 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
-	"golift.io/starr"
 	"golift.io/starr/lidarr"
 )
 
@@ -61,51 +59,9 @@ func (l *LidarrConfig) queueViews() []queueView {
 	return out
 }
 
-// checkLidarrQueue saves completed Lidarr-queued downloads to u.Map.
-func (u *Unpackerr) checkLidarrQueue(now time.Time) {
-	u.lockHistory()
-	defer u.unlockHistory()
-
-	for _, server := range u.Lidarr {
-		if server.Queue == nil {
-			continue
-		}
-
-		for _, record := range server.Queue.Records {
-			switch x, ok := u.Map[record.Title]; {
-			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
-				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Lidarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
-				u.Map[record.Title] = &Extract{
-					App:         starr.Lidarr,
-					URL:         server.URL,
-					Updated:     now,
-					Status:      WAITING,
-					DeleteOrig:  server.DeleteOrig,
-					DeleteDelay: server.DeleteDelay.Duration,
-					Syncthing:   server.Syncthing,
-					MaxBytes:    server.maxBytes,
-					SplitFlac:   server.SplitFlac,
-					Path:        u.getDownloadPath(record.OutputPath, starr.Lidarr, record.Title, server.Paths),
-					OutputPath:  record.OutputPath,
-					IDs: map[string]any{
-						"title":      record.Title,
-						"artistId":   record.ArtistID,
-						"albumId":    record.AlbumID,
-						"downloadId": record.DownloadID,
-						"reason":     buildStatusReason(record.Status, record.StatusMessages),
-					},
-				}
-				u.Map[record.Title].XProg = &ExtractProgress{Extract: u.Map[record.Title]}
-
-				fallthrough
-			default:
-				u.Debugf("%s: (%s): %s (%s:%d%%): %v",
-					starr.Lidarr, server.URL, record.Status, record.Protocol,
-					percent(record.Sizeleft, record.Size), record.Title)
-			}
-		}
-	}
+func (l *LidarrConfig) tweakExtract(item *Extract, rec queueView) {
+	item.SplitFlac = l.SplitFlac
+	item.OutputPath = rec.OutputPath
 }
 
 // lidarrServerByURL returns the Lidarr server config that matches the given URL, or nil.

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -59,6 +59,20 @@ func (l *LidarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (l *LidarrConfig) hasQueueTitle(name string) bool {
+	if l.Queue == nil {
+		return false
+	}
+
+	for _, rec := range l.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l *LidarrConfig) tweakExtract(item *Extract, rec queueView) {
 	item.SplitFlac = l.SplitFlac
 	item.OutputPath = rec.OutputPath

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -198,7 +198,7 @@ func TestForgottenStarrTitle(t *testing.T) {
 		t.Fatalf("forget %d %s", forgetOK.Code, forgetOK.Body.String())
 	}
 
-	unpack.checkRadarrQueue(time.Now())
+	checkStarrQueue(unpack, unpack.Radarr, starr.Radarr, time.Now())
 
 	if _, exists := unpack.Map["Movie"]; exists {
 		t.Fatal("forgotten title recreated from Starr queue")
@@ -213,7 +213,7 @@ func TestForgottenStarrTitle(t *testing.T) {
 		Protocol:   starr.Protocol("torrent"),
 		OutputPath: "/dl/Movie",
 	}}
-	unpack.checkRadarrQueue(time.Now())
+	checkStarrQueue(unpack, unpack.Radarr, starr.Radarr, time.Now())
 
 	if _, exists := unpack.Map["Movie"]; !exists {
 		t.Fatal("title should track again after leaving the Starr queue")

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -2,9 +2,7 @@ package unpackerr
 
 import (
 	"fmt"
-	"time"
 
-	"golift.io/starr"
 	"golift.io/starr/radarr"
 )
 
@@ -53,46 +51,4 @@ func (r *RadarrConfig) queueViews() []queueView {
 	return out
 }
 
-// checkRadarrQueue saves completed Radarr-queued downloads to u.Map.
-func (u *Unpackerr) checkRadarrQueue(now time.Time) {
-	u.lockHistory()
-	defer u.unlockHistory()
-
-	for _, server := range u.Radarr {
-		if server.Queue == nil {
-			continue
-		}
-
-		for _, record := range server.Queue.Records {
-			switch x, ok := u.Map[record.Title]; {
-			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
-				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Radarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
-				u.Map[record.Title] = &Extract{ // Save the download to our map.
-					App:         starr.Radarr,
-					URL:         server.URL,
-					Updated:     now,
-					Status:      WAITING,
-					DeleteOrig:  server.DeleteOrig,
-					DeleteDelay: server.DeleteDelay.Duration,
-					Syncthing:   server.Syncthing,
-					MaxBytes:    server.maxBytes,
-					Path:        u.getDownloadPath(record.OutputPath, starr.Radarr, record.Title, server.Paths),
-					IDs: map[string]any{
-						"downloadId": record.DownloadID,
-						"title":      record.Title,
-						"movieId":    record.MovieID,
-						"reason":     buildStatusReason(record.Status, record.StatusMessages),
-					},
-				}
-				u.Map[record.Title].XProg = &ExtractProgress{Extract: u.Map[record.Title]}
-
-				fallthrough
-			default:
-				u.Debugf("%s: (%s): %s (%s:%d%%): %v",
-					starr.Radarr, server.URL, record.Status, record.Protocol,
-					percent(record.Sizeleft, record.Size), record.Title)
-			}
-		}
-	}
-}
+func (*RadarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -51,4 +51,18 @@ func (r *RadarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (r *RadarrConfig) hasQueueTitle(name string) bool {
+	if r.Queue == nil {
+		return false
+	}
+
+	for _, rec := range r.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*RadarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -52,4 +52,18 @@ func (r *ReadarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (r *ReadarrConfig) hasQueueTitle(name string) bool {
+	if r.Queue == nil {
+		return false
+	}
+
+	for _, rec := range r.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*ReadarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -2,9 +2,7 @@ package unpackerr
 
 import (
 	"fmt"
-	"time"
 
-	"golift.io/starr"
 	"golift.io/starr/readarr"
 )
 
@@ -54,47 +52,4 @@ func (r *ReadarrConfig) queueViews() []queueView {
 	return out
 }
 
-// checkReadarQueue saves completed Readarr-queued downloads to u.Map.
-func (u *Unpackerr) checkReadarrQueue(now time.Time) {
-	u.lockHistory()
-	defer u.unlockHistory()
-
-	for _, server := range u.Readarr {
-		if server.Queue == nil {
-			continue
-		}
-
-		for _, record := range server.Queue.Records {
-			switch x, ok := u.Map[record.Title]; {
-			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
-				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Readarr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
-				u.Map[record.Title] = &Extract{
-					App:         starr.Readarr,
-					URL:         server.URL,
-					Updated:     now,
-					Status:      WAITING,
-					DeleteOrig:  server.DeleteOrig,
-					DeleteDelay: server.DeleteDelay.Duration,
-					Syncthing:   server.Syncthing,
-					MaxBytes:    server.maxBytes,
-					Path:        u.getDownloadPath(record.OutputPath, starr.Readarr, record.Title, server.Paths),
-					IDs: map[string]any{
-						"title":      record.Title,
-						"authorId":   record.AuthorID,
-						"bookId":     record.BookID,
-						"downloadId": record.DownloadID,
-						"reason":     buildStatusReason(record.Status, record.StatusMessages),
-					},
-				}
-				u.Map[record.Title].XProg = &ExtractProgress{Extract: u.Map[record.Title]}
-
-				fallthrough
-			default:
-				u.Debugf("%s: (%s): %s (%s:%d%%): %v",
-					starr.Readarr, server.URL, record.Status, record.Protocol,
-					percent(record.Sizeleft, record.Size), record.Title)
-			}
-		}
-	}
-}
+func (*ReadarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -2,9 +2,7 @@ package unpackerr
 
 import (
 	"fmt"
-	"time"
 
-	"golift.io/starr"
 	"golift.io/starr/sonarr"
 )
 
@@ -55,47 +53,4 @@ func (s *SonarrConfig) queueViews() []queueView {
 	return out
 }
 
-// checkSonarrQueue saves completed Sonarr-queued downloads to u.Map.
-func (u *Unpackerr) checkSonarrQueue(now time.Time) {
-	u.lockHistory()
-	defer u.unlockHistory()
-
-	for _, server := range u.Sonarr {
-		if server.Queue == nil {
-			continue
-		}
-
-		for _, record := range server.Queue.Records {
-			switch x, ok := u.Map[record.Title]; {
-			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
-				u.Debugf("%s (%s): Item Waiting for Import: %v", starr.Sonarr, server.URL, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
-				u.Map[record.Title] = &Extract{
-					App:         starr.Sonarr,
-					URL:         server.URL,
-					Updated:     now,
-					Status:      WAITING,
-					DeleteOrig:  server.DeleteOrig,
-					DeleteDelay: server.DeleteDelay.Duration,
-					Syncthing:   server.Syncthing,
-					MaxBytes:    server.maxBytes,
-					Path:        u.getDownloadPath(record.OutputPath, starr.Sonarr, record.Title, server.Paths),
-					IDs: map[string]any{
-						"title":      record.Title,
-						"downloadId": record.DownloadID,
-						"seriesId":   record.SeriesID,
-						"episodeId":  record.EpisodeID,
-						"reason":     buildStatusReason(record.Status, record.StatusMessages),
-					},
-				}
-				u.Map[record.Title].XProg = &ExtractProgress{Extract: u.Map[record.Title]}
-
-				fallthrough
-			default:
-				u.Debugf("%s (%s): %s (%s:%d%%): %v (Ep: %v)",
-					starr.Sonarr, server.URL, record.Status, record.Protocol,
-					percent(record.Sizeleft, record.Size), record.Title, record.EpisodeID)
-			}
-		}
-	}
-}
+func (*SonarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -53,4 +53,18 @@ func (s *SonarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (s *SonarrConfig) hasQueueTitle(name string) bool {
+	if s.Queue == nil {
+		return false
+	}
+
+	for _, rec := range s.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*SonarrConfig) tweakExtract(_ *Extract, _ queueView) {}

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -105,10 +105,8 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 
 func haveStarrQitem[T any, P starrApp[T]](list []P, name string) bool {
 	for _, server := range list {
-		for _, rec := range server.queueViews() {
-			if rec.Title == name {
-				return true
-			}
+		if server.hasQueueTitle(name) {
+			return true
 		}
 	}
 

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -65,6 +65,44 @@ func (u *Unpackerr) getStarrQueue[T any, P starrApp[T]](server P, app starr.App,
 	}
 }
 
+func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app starr.App, now time.Time) {
+	unpack.lockHistory()
+	defer unpack.unlockHistory()
+
+	for _, server := range list {
+		cfg := server.conf()
+
+		for _, rec := range server.queueViews() {
+			switch item, ok := unpack.Map[rec.Title]; {
+			case ok && item.Status == EXTRACTED && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols):
+				unpack.Debugf("%s (%s): Item Waiting for Import (%s): %v", app, cfg.URL, rec.Protocol, rec.Title)
+			case !ok && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
+				waiting := &Extract{
+					App:         app,
+					URL:         cfg.URL,
+					Updated:     now,
+					Status:      WAITING,
+					DeleteOrig:  cfg.DeleteOrig,
+					DeleteDelay: cfg.DeleteDelay.Duration,
+					Syncthing:   cfg.Syncthing,
+					MaxBytes:    cfg.maxBytes,
+					Path:        unpack.getDownloadPath(rec.OutputPath, app, rec.Title, cfg.Paths),
+					IDs:         rec.IDs,
+				}
+				waiting.XProg = &ExtractProgress{Extract: waiting}
+				server.tweakExtract(waiting, rec)
+				unpack.Map[rec.Title] = waiting
+
+				fallthrough
+			default:
+				unpack.Debugf("%s (%s): %s (%s:%d%%): %v%s",
+					app, cfg.URL, rec.Status, rec.Protocol,
+					percent(rec.Sizeleft, rec.Size), rec.Title, rec.DebugExtra)
+			}
+		}
+	}
+}
+
 func haveStarrQitem[T any, P starrApp[T]](list []P, name string) bool {
 	for _, server := range list {
 		for _, rec := range server.queueViews() {

--- a/pkg/unpackerr/starrpoll_test.go
+++ b/pkg/unpackerr/starrpoll_test.go
@@ -1,8 +1,12 @@
 package unpackerr
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"golift.io/starr"
 	"golift.io/starr/lidarr"
 	"golift.io/starr/radarr"
 	"golift.io/starr/readarr"
@@ -47,5 +51,57 @@ func TestQueueViewsIDs(t *testing.T) {
 
 	if haveStarrQitem([]*SonarrConfig{son}, "Nope") {
 		t.Fatal("expected haveStarrQitem false for Nope")
+	}
+}
+
+func TestCheckStarrQueueLidarrTweak(t *testing.T) {
+	t.Parallel()
+
+	const (
+		title      = "Album"
+		outputPath = `/lidarr/host/Album`
+	)
+
+	mappedRoot := t.TempDir()
+	mappedPath := filepath.Join(mappedRoot, title)
+
+	if err := os.Mkdir(mappedPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := New()
+	unpack.Lidarr = []*LidarrConfig{{
+		Protocols: defaultProtocol,
+		Paths:     StringSlice{mappedRoot},
+		SplitFlac: true,
+		Queue: &lidarr.Queue{Records: []*lidarr.QueueRecord{{
+			Title:      title,
+			Status:     "completed",
+			Protocol:   starr.Protocol("torrent"),
+			OutputPath: outputPath,
+		}}},
+	}}
+
+	checkStarrQueue(unpack, unpack.Lidarr, starr.Lidarr, time.Now())
+
+	item, ok := unpack.Map[title]
+	if !ok {
+		t.Fatal("expected Lidarr queue item in extract map")
+	}
+
+	if !item.SplitFlac {
+		t.Fatal("expected SplitFlac from Lidarr tweakExtract")
+	}
+
+	if item.OutputPath != outputPath {
+		t.Fatalf("OutputPath: got %q want original Starr path %q", item.OutputPath, outputPath)
+	}
+
+	if item.Path == outputPath {
+		t.Fatal("Path should be the host-mapped download dir, not the Starr OutputPath")
+	}
+
+	if item.Path != mappedPath {
+		t.Fatalf("Path: got %q want mapped %q", item.Path, mappedPath)
 	}
 }

--- a/pkg/unpackerr/whisparr.go
+++ b/pkg/unpackerr/whisparr.go
@@ -1,12 +1,6 @@
 package unpackerr
 
-import (
-	"time"
-
-	"golift.io/starr"
-)
-
-// WhisparrConfig just uses radarr. Queue poll/have is shared via starrApp on *RadarrConfig.
+// WhisparrConfig just uses radarr. Queue poll/check/have is shared via starrApp on *RadarrConfig.
 /*
 type WhisparrConfig struct {
 	starr.Config
@@ -19,46 +13,3 @@ type WhisparrConfig struct {
 	sync.RWMutex   `json:"-" toml:"-" xml:"-" yaml:"-"`
 	*whisparr.Whisparr `json:"-" toml:"-" xml:"-" yaml:"-"`
 } */
-
-// checkWhisparrQueue saves completed Whisparr-queued downloads to u.Map.
-func (u *Unpackerr) checkWhisparrQueue(now time.Time) {
-	u.lockHistory()
-	defer u.unlockHistory()
-
-	for _, server := range u.Whisparr {
-		if server.Queue == nil {
-			continue
-		}
-
-		for _, record := range server.Queue.Records {
-			switch x, ok := u.Map[record.Title]; {
-			case ok && x.Status == EXTRACTED && u.isComplete(record.Status, record.Protocol, server.Protocols):
-				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", starr.Whisparr, server.URL, record.Protocol, record.Title)
-			case !ok && u.isComplete(record.Status, record.Protocol, server.Protocols) && !u.isForgotten(record.Title):
-				u.Map[record.Title] = &Extract{
-					App:         starr.Whisparr,
-					URL:         server.URL,
-					Updated:     now,
-					Status:      WAITING,
-					DeleteOrig:  server.DeleteOrig,
-					DeleteDelay: server.DeleteDelay.Duration,
-					MaxBytes:    server.maxBytes,
-					Path:        u.getDownloadPath(record.OutputPath, starr.Whisparr, record.Title, server.Paths),
-					IDs: map[string]any{
-						"downloadId": record.DownloadID,
-						"title":      record.Title,
-						"movieId":    record.MovieID,
-						"reason":     buildStatusReason(record.Status, record.StatusMessages),
-					},
-				}
-				u.Map[record.Title].XProg = &ExtractProgress{Extract: u.Map[record.Title]}
-
-				fallthrough
-			default:
-				u.Debugf("%s: (%s): %s (%s:%d%%): %v",
-					starr.Whisparr, server.URL, record.Status, record.Protocol,
-					percent(record.Sizeleft, record.Size), record.Title)
-			}
-		}
-	}
-}


### PR DESCRIPTION
## Summary
- Fold the five `check*Queue` copies into `checkStarrQueue`; Lidarr SplitFlac/OutputPath go through `starrApp.tweakExtract`.
- Stacks on #711 (validate/get/have). Whisparr stays `*RadarrConfig`.

## Test plan
- [x] `golangci-lint run ./pkg/unpackerr/...`
- [x] `go test ./pkg/unpackerr/`
- [ ] CI gotest + golangci matrix

Stacked: PR 2 of 6. Leave open.


Made with [Cursor](https://cursor.com)