### PR TITLE
Share logExtra, crossPlatformBase, and hookCounts

### DIFF
--- a/pkg/unpackerr/cmdhook.go
+++ b/pkg/unpackerr/cmdhook.go
@@ -128,19 +128,7 @@ func (u *Unpackerr) runCmdhook(hook *WebhookConfig, payload *WebhookPayload) (*b
 	return &out, nil
 }
 
-// CmdhookCounts returns the total count of requests and errors for all webhooks.
+// CmdhookCounts returns the total count of requests and errors for all command hooks.
 func (u *Unpackerr) CmdhookCounts() (uint, uint) {
-	var total, fails uint
-
-	for _, hook := range u.cmdhookList() {
-		if hook == nil {
-			continue
-		}
-
-		posts, failures := hook.Counts()
-		total += posts
-		fails += failures
-	}
-
-	return total, fails
+	return hookCounts(u.cmdhookList())
 }

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -18,6 +18,7 @@ type starrApp[T any] interface {
 	pollQueue() (total, retrieved int, err error)
 	queueViews() []queueView
 	tweakExtract(item *Extract, rec queueView)
+	logExtra() string
 }
 
 func (s *SonarrConfig) conf() *StarrConfig { return &s.StarrConfig }

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -17,6 +17,7 @@ type starrApp[T any] interface {
 	stripRuntime()    // nil the queue and client on a file-shaped clone.
 	pollQueue() (total, retrieved int, err error)
 	queueViews() []queueView
+	hasQueueTitle(name string) bool
 	tweakExtract(item *Extract, rec queueView)
 	logExtra() string
 }

--- a/pkg/unpackerr/configdump.go
+++ b/pkg/unpackerr/configdump.go
@@ -67,7 +67,7 @@ func (u *Unpackerr) writeRunningConfig(printf configLine, auth dumpAuth) {
 	}
 
 	if !auth.omit(printf, SectionLidarr, "Lidarr Config") {
-		u.logLidarr(printf)
+		logStarr(printf, starr.Lidarr, u.Lidarr)
 	}
 
 	if !auth.omit(printf, SectionReadarr, "Readarr Config") {
@@ -128,17 +128,15 @@ func (u *Unpackerr) logGeneral(printf configLine) {
 	}
 }
 
-func logStarr[T any, P interface {
-	*T
-	conf() *StarrConfig
-}](printf configLine, app starr.App, list []P) {
+func logStarr[T any, P starrApp[T]](printf configLine, app starr.App, list []P) {
 	count := len(list)
 	if count == 1 {
-		c := list[0].conf()
-		printf(" => %s Config: 1 server: "+starrLogLine,
+		item := list[0]
+		c := item.conf()
+		printf(" => %s Config: 1 server: "+starrLogLine+"%s",
 			app, c.URL, c.APIKey != "", c.Timeout.String(),
 			c.ValidSSL, c.Protocols, c.Syncthing,
-			c.DeleteOrig, c.DeleteDelay.String(), c.Paths)
+			c.DeleteOrig, c.DeleteDelay.String(), c.Paths, item.logExtra())
 
 		return
 	}
@@ -147,30 +145,9 @@ func logStarr[T any, P interface {
 
 	for _, item := range list {
 		c := item.conf()
-		printf(starrLogPfx+starrLogLine,
+		printf(starrLogPfx+starrLogLine+"%s",
 			c.URL, c.APIKey != "", c.Timeout.String(), c.ValidSSL, c.Protocols,
-			c.Syncthing, c.DeleteOrig, c.DeleteDelay.String(), c.Paths)
-	}
-}
-
-func (u *Unpackerr) logLidarr(printf configLine) {
-	count := len(u.Lidarr)
-	if count == 1 {
-		c := u.Lidarr[0]
-		printf(" => Lidarr Config: 1 server: "+starrLogLine+", split_flac:%v",
-			c.URL, c.APIKey != "", c.Timeout.String(),
-			c.ValidSSL, c.Protocols, c.Syncthing,
-			c.DeleteOrig, c.DeleteDelay.String(), c.Paths, c.SplitFlac)
-
-		return
-	}
-
-	printf(" => Lidarr Config: %d servers", count)
-
-	for _, c := range u.Lidarr {
-		printf(starrLogPfx+starrLogLine+", split_flac:%v",
-			c.URL, c.APIKey != "", c.Timeout.String(), c.ValidSSL, c.Protocols,
-			c.Syncthing, c.DeleteOrig, c.DeleteDelay.String(), c.Paths, c.SplitFlac)
+			c.Syncthing, c.DeleteOrig, c.DeleteDelay.String(), c.Paths, item.logExtra())
 	}
 }
 

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -401,7 +401,7 @@ func (u *Unpackerr) getDownloadPath(outputPath string, app starr.App, title stri
 	// directory on disk. This also handles cross-platform setups where outputPath is a UNC/Windows
 	// path but the configured paths are local Linux mounts of the same share.
 	if outputPath != "" {
-		outputFolder := filepath.Base(filepath.FromSlash(strings.ReplaceAll(outputPath, `\`, `/`)))
+		outputFolder := crossPlatformBase(outputPath)
 		if outputFolder != "" && outputFolder != "." && outputFolder != title {
 			for _, path := range paths {
 				candidate := filepath.Join(path, outputFolder)

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -64,6 +64,10 @@ func (l *LidarrConfig) tweakExtract(item *Extract, rec queueView) {
 	item.OutputPath = rec.OutputPath
 }
 
+func (l *LidarrConfig) logExtra() string {
+	return fmt.Sprintf(", split_flac:%v", l.SplitFlac)
+}
+
 // lidarrServerByURL returns the Lidarr server config that matches the given URL, or nil.
 func (u *Unpackerr) lidarrServerByURL(url string) *LidarrConfig {
 	for _, server := range u.Lidarr {

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -59,6 +59,20 @@ func (l *LidarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (l *LidarrConfig) hasQueueTitle(name string) bool {
+	if l.Queue == nil {
+		return false
+	}
+
+	for _, rec := range l.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l *LidarrConfig) tweakExtract(item *Extract, rec queueView) {
 	item.SplitFlac = l.SplitFlac
 	item.OutputPath = rec.OutputPath

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -51,6 +51,20 @@ func (r *RadarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (r *RadarrConfig) hasQueueTitle(name string) bool {
+	if r.Queue == nil {
+		return false
+	}
+
+	for _, rec := range r.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*RadarrConfig) tweakExtract(_ *Extract, _ queueView) {}
 
 func (*RadarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -52,3 +52,5 @@ func (r *RadarrConfig) queueViews() []queueView {
 }
 
 func (*RadarrConfig) tweakExtract(_ *Extract, _ queueView) {}
+
+func (*RadarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -53,3 +53,5 @@ func (r *ReadarrConfig) queueViews() []queueView {
 }
 
 func (*ReadarrConfig) tweakExtract(_ *Extract, _ queueView) {}
+
+func (*ReadarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -52,6 +52,20 @@ func (r *ReadarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (r *ReadarrConfig) hasQueueTitle(name string) bool {
+	if r.Queue == nil {
+		return false
+	}
+
+	for _, rec := range r.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*ReadarrConfig) tweakExtract(_ *Extract, _ queueView) {}
 
 func (*ReadarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -54,3 +54,5 @@ func (s *SonarrConfig) queueViews() []queueView {
 }
 
 func (*SonarrConfig) tweakExtract(_ *Extract, _ queueView) {}
+
+func (*SonarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -53,6 +53,20 @@ func (s *SonarrConfig) queueViews() []queueView {
 	return out
 }
 
+func (s *SonarrConfig) hasQueueTitle(name string) bool {
+	if s.Queue == nil {
+		return false
+	}
+
+	for _, rec := range s.Queue.Records {
+		if rec.Title == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (*SonarrConfig) tweakExtract(_ *Extract, _ queueView) {}
 
 func (*SonarrConfig) logExtra() string { return "" }

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -105,10 +105,8 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 
 func haveStarrQitem[T any, P starrApp[T]](list []P, name string) bool {
 	for _, server := range list {
-		for _, rec := range server.queueViews() {
-			if rec.Title == name {
-				return true
-			}
+		if server.hasQueueTitle(name) {
+			return true
 		}
 	}
 

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -331,9 +331,13 @@ func (w *WebhookConfig) HasEvent(e ExtractStatus) bool {
 
 // WebhookCounts returns the total count of requests and errors for all webhooks.
 func (u *Unpackerr) WebhookCounts() (uint, uint) {
+	return hookCounts(u.hookList())
+}
+
+func hookCounts(hooks []*WebhookConfig) (uint, uint) {
 	var total, fails uint
 
-	for _, hook := range u.hookList() {
+	for _, hook := range hooks {
 		if hook == nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Fold `logLidarr` into `logStarr` via `starrApp.logExtra`; Lidarr still prints `split_flac`.
- Reuse `crossPlatformBase` in `getDownloadPath`; share `hookCounts` for webhook and cmdhook totals.

## Test plan
- [x] `golangci-lint run ./pkg/unpackerr/...`
- [x] `go test ./pkg/unpackerr/`
- [ ] CI gotest + golangci matrix

Stacked: PR 3 of 6 (on #712). Leave open.


Made with [Cursor](https://cursor.com)