### PR TITLE
Move folder watcher and path tracking into pkg/folders

### DIFF
--- a/pkg/folders/config.go
+++ b/pkg/folders/config.go
@@ -1,0 +1,95 @@
+// Package folders watches configured paths for archives to extract.
+package folders
+
+import (
+	"os"
+	"time"
+
+	"github.com/Unpackerr/unpackerr/pkg/extract"
+	"github.com/fsnotify/fsnotify"
+	"github.com/radovskyb/watcher"
+	"golift.io/cnfg"
+	"golift.io/xtractr"
+)
+
+// defaultPollInterval is used if Docker is detected.
+const (
+	DefaultPollInterval = time.Second
+	MinimumPollInterval = 5 * time.Millisecond
+	DefaultDeleteAfter  = 10 * time.Minute
+)
+
+// FolderConfig defines the input data for a watched folder.
+//
+//nolint:lll
+type FolderConfig struct {
+	DeleteOrig       bool           `json:"delete_original"  toml:"delete_original"   xml:"delete_original"   yaml:"delete_original"`
+	DeleteFiles      bool           `json:"delete_files"     toml:"delete_files"      xml:"delete_files"      yaml:"delete_files"`
+	DisableLog       bool           `json:"disable_log"      toml:"disable_log"       xml:"disable_log"       yaml:"disable_log"`
+	MoveBack         bool           `json:"move_back"        toml:"move_back"         xml:"move_back"         yaml:"move_back"`
+	DeleteAfter      *cnfg.Duration `json:"delete_after"     toml:"delete_after"      xml:"delete_after"      yaml:"delete_after"`
+	ExtractPath      string         `json:"extract_path"     toml:"extract_path"      xml:"extract_path"      yaml:"extract_path"`
+	ExtractISOs      bool           `json:"extract_isos"     toml:"extract_isos"      xml:"extract_isos"      yaml:"extract_isos"`
+	DisableRecursion bool           `json:"disableRecursion" toml:"disable_recursion" xml:"disable_recursion" yaml:"disableRecursion"`
+	MaxNested        int            `json:"maxNested"        toml:"max_nested"        xml:"max_nested"        yaml:"maxNested"`
+	ExtrasMaxDepth   int            `json:"extrasMaxDepth"   toml:"extras_max_depth"  xml:"extras_max_depth"  yaml:"extrasMaxDepth"`
+	AllowSymlinks    bool           `json:"allowSymlinks"    toml:"allow_symlinks"    xml:"allow_symlinks"    yaml:"allowSymlinks"`
+	MaxBytes         string         `json:"maxBytes"         toml:"max_bytes"         xml:"max_bytes"         yaml:"maxBytes"`
+	MaxFiles         int            `json:"maxFiles"         toml:"max_files"         xml:"max_files"         yaml:"maxFiles"`
+	MaxRatio         float64        `json:"maxRatio"         toml:"max_ratio"         xml:"max_ratio"         yaml:"maxRatio"`
+	// ResolvedMaxBytes is 0 when unset: folder watcher is uncapped.
+	ResolvedMaxBytes uint64   `json:"-"             toml:"-"             xml:"-"            yaml:"-"`
+	ExcludePaths     []string `json:"exclude_paths" toml:"exclude_paths" xml:"exclude_path" yaml:"exclude_paths"`
+	Path             string   `json:"path"          toml:"path"          xml:"path"         yaml:"path"`
+}
+
+// WatchConfig is the undocumented folders buffer/interval settings.
+type WatchConfig struct {
+	Buffer   uint          `json:"buffer"   toml:"buffer"   xml:"buffer"   yaml:"buffer"`
+	Interval cnfg.Duration `json:"interval" toml:"interval" xml:"interval" yaml:"interval"`
+}
+
+// Folders holds all known (created) folders in all watch paths.
+type Folders struct {
+	Logs
+	Interval     time.Duration
+	Config       []*FolderConfig
+	Folders      map[string]*Folder
+	Events       chan *Event
+	Updates      chan *xtractr.Response
+	FSNotify     *fsnotify.Watcher
+	Watcher      *watcher.Watcher
+	IgnoreSuffix string
+}
+
+// Logs interface for folders.
+type Logs interface {
+	Printf(msg string, v ...any)
+	Errorf(msg string, v ...any)
+	Debugf(msg string, v ...any)
+}
+
+// Folder is a "new" watched folder.
+type Folder struct {
+	Updated  time.Time
+	Status   extract.Status
+	Config   *FolderConfig
+	Files    []string
+	Retries  uint
+	Archives xtractr.ArchiveList
+	// PreFiles is the snapshot of each archive dest before extraction
+	// (MoveBack only). Dest folders come from FindCompressedFiles so nested
+	// archive dirs are included. Kept across retries so failed cleanups are
+	// not recaptured as download content. Nil means remnant handling is skipped.
+	PreFiles map[string]os.FileInfo
+	// NoRetry is set when remnant_action=off leaves a blocker.
+	NoRetry bool
+}
+
+// Event is a filesystem event for a watched folder.
+type Event struct {
+	Config *FolderConfig
+	Name   string
+	File   string
+	Op     string
+}

--- a/pkg/folders/folder_test.go
+++ b/pkg/folders/folder_test.go
@@ -1,4 +1,4 @@
-package unpackerr
+package folders
 
 import (
 	"os"
@@ -13,14 +13,14 @@ func (noopLogger) Printf(string, ...any) {}
 func (noopLogger) Errorf(string, ...any) {}
 func (noopLogger) Debugf(string, ...any) {}
 
-func TestNormalizeFolderExcludePaths(t *testing.T) {
+func TestNormalizeExcludePaths(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
 	relative := "permanent"
 	absolute := filepath.Join(base, "keep")
 
-	paths := normalizeFolderExcludePaths(base, []string{"", "  ", relative, absolute})
+	paths := NormalizeExcludePaths(base, []string{"", "  ", relative, absolute})
 	if len(paths) != 2 {
 		t.Fatalf("expected 2 normalized paths, got %d: %v", len(paths), paths)
 	}
@@ -41,15 +41,15 @@ func TestFolderConfigIsExcludedPath(t *testing.T) {
 	excluded := filepath.Join(base, "permanent")
 	cfg := &FolderConfig{ExcludePaths: []string{excluded}}
 
-	if !cfg.isExcludedPath(excluded) {
+	if !cfg.IsExcludedPath(excluded) {
 		t.Fatal("expected exact excluded path to match")
 	}
 
-	if !cfg.isExcludedPath(filepath.Join(excluded, "sub", "file.rar")) {
+	if !cfg.IsExcludedPath(filepath.Join(excluded, "sub", "file.rar")) {
 		t.Fatal("expected child path of excluded folder to match")
 	}
 
-	if cfg.isExcludedPath(excluded + "_other") {
+	if cfg.IsExcludedPath(excluded + "_other") {
 		t.Fatal("did not expect prefix-only sibling path to match")
 	}
 }
@@ -59,21 +59,21 @@ func TestFoldersProcessEventCurrentBehavior(t *testing.T) {
 
 	watchPath := t.TempDir()
 	cfg := &FolderConfig{Path: watchPath}
-	folders := newTestFolders(t, cfg)
+	tracker := newTestFolders(t, cfg)
 
 	archive := filepath.Join(watchPath, "movie.rar")
 	if err := os.WriteFile(archive, []byte("x"), 0o600); err != nil {
 		t.Fatalf("creating archive test file: %v", err)
 	}
 
-	folders.processEvent(&eventData{
-		cnfg: cfg,
-		name: filepath.Base(archive),
-		file: archive,
-		op:   "test",
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   filepath.Base(archive),
+		File:   archive,
+		Op:     "test",
 	}, time.Now())
 
-	if _, ok := folders.Folders[archive]; !ok {
+	if _, ok := tracker.Folders[archive]; !ok {
 		t.Fatalf("expected archive path to be tracked: %s", archive)
 	}
 
@@ -82,14 +82,14 @@ func TestFoldersProcessEventCurrentBehavior(t *testing.T) {
 		t.Fatalf("creating non-archive test file: %v", err)
 	}
 
-	folders.processEvent(&eventData{
-		cnfg: cfg,
-		name: filepath.Base(plain),
-		file: plain,
-		op:   "test",
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   filepath.Base(plain),
+		File:   plain,
+		Op:     "test",
 	}, time.Now())
 
-	if _, ok := folders.Folders[plain]; ok {
+	if _, ok := tracker.Folders[plain]; ok {
 		t.Fatalf("did not expect non-archive file to be tracked: %s", plain)
 	}
 
@@ -98,14 +98,14 @@ func TestFoldersProcessEventCurrentBehavior(t *testing.T) {
 		t.Fatalf("creating folder test dir: %v", err)
 	}
 
-	folders.processEvent(&eventData{
-		cnfg: cfg,
-		name: filepath.Base(dir),
-		file: dir,
-		op:   "test",
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   filepath.Base(dir),
+		File:   dir,
+		Op:     "test",
 	}, time.Now())
 
-	if _, ok := folders.Folders[dir]; !ok {
+	if _, ok := tracker.Folders[dir]; !ok {
 		t.Fatalf("expected folder path to be tracked: %s", dir)
 	}
 }
@@ -129,30 +129,30 @@ func TestFoldersProcessEventExcludedPath(t *testing.T) {
 		Path:         watchPath,
 		ExcludePaths: []string{excluded},
 	}
-	folders := newTestFolders(t, cfg)
+	tracker := newTestFolders(t, cfg)
 
 	// Direct excluded folder.
-	folders.processEvent(&eventData{
-		cnfg: cfg,
-		name: "permanent",
-		file: excluded,
-		op:   "test",
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   "permanent",
+		File:   excluded,
+		Op:     "test",
 	}, time.Now())
 
-	if len(folders.Folders) != 0 {
-		t.Fatalf("expected no tracked folders for excluded path, got: %v", folders.Folders)
+	if len(tracker.Folders) != 0 {
+		t.Fatalf("expected no tracked folders for excluded path, got: %v", tracker.Folders)
 	}
 
 	// Nested event from an excluded folder should also be ignored.
-	folders.processEvent(&eventData{
-		cnfg: cfg,
-		name: "sub",
-		file: nested,
-		op:   "test",
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   "sub",
+		File:   nested,
+		Op:     "test",
 	}, time.Now())
 
-	if len(folders.Folders) != 0 {
-		t.Fatalf("expected no tracked folders for nested excluded event, got: %v", folders.Folders)
+	if len(tracker.Folders) != 0 {
+		t.Fatalf("expected no tracked folders for nested excluded event, got: %v", tracker.Folders)
 	}
 }
 
@@ -162,19 +162,19 @@ func TestFoldersHandleFileEventExcludedPath(t *testing.T) {
 	watchPath := t.TempDir()
 	excluded := filepath.Join(watchPath, "permanent")
 
-	folders := &Folders{
+	tracker := &Folders{
 		Config: []*FolderConfig{{
 			Path:         watchPath,
 			ExcludePaths: []string{excluded},
 		}},
-		Events: make(chan *eventData, 1),
+		Events: make(chan *Event, 1),
 		Logs:   noopLogger{},
 	}
 
-	folders.handleFileEvent(filepath.Join(excluded, "file.rar"), "test")
+	tracker.handleFileEvent(filepath.Join(excluded, "file.rar"), "test")
 
 	select {
-	case event := <-folders.Events:
+	case event := <-tracker.Events:
 		t.Fatalf("did not expect event for excluded path: %+v", event)
 	default:
 	}
@@ -183,20 +183,20 @@ func TestFoldersHandleFileEventExcludedPath(t *testing.T) {
 func newTestFolders(t *testing.T, cfg *FolderConfig) *Folders {
 	t.Helper()
 
-	folders, err := (FoldersConfig{Buffer: 32}).newWatcher([]*FolderConfig{cfg}, noopLogger{})
+	tracker, err := (WatchConfig{Buffer: 32}).NewWatcher([]*FolderConfig{cfg}, noopLogger{}, 1, "")
 	if err != nil {
 		t.Fatalf("creating watcher: %v", err)
 	}
 
 	t.Cleanup(func() {
-		if folders.Watcher != nil {
-			folders.Watcher.Close()
+		if tracker.Watcher != nil {
+			tracker.Watcher.Close()
 		}
 
-		if folders.FSNotify != nil {
-			_ = folders.FSNotify.Close()
+		if tracker.FSNotify != nil {
+			_ = tracker.FSNotify.Close()
 		}
 	})
 
-	return folders
+	return tracker
 }

--- a/pkg/folders/path.go
+++ b/pkg/folders/path.go
@@ -1,0 +1,99 @@
+package folders
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+func expandHomedir(filePath string) string {
+	expanded, err := homedir.Expand(filePath)
+	if err != nil {
+		return filePath
+	}
+
+	return expanded
+}
+
+// Check stats all configured folders and returns only "good" ones.
+func Check(list []*FolderConfig, log Logs) ([]*FolderConfig, []string) {
+	var (
+		err         error
+		goodFolders = list[:0]
+		goodFlist   = []string{}
+	)
+
+	for _, folder := range list {
+		folder.Path, err = filepath.Abs(expandHomedir(folder.Path))
+		if err != nil {
+			log.Errorf("Folder '%s' (bad path): %v", folder.Path, err)
+			continue
+		}
+
+		if folder.ExtractPath != "" {
+			folder.ExtractPath, err = filepath.Abs(expandHomedir(folder.ExtractPath))
+			if err != nil {
+				log.Errorf("Folder '%s' (bad extract path): %v", folder.ExtractPath, err)
+				continue
+			}
+		}
+
+		folder.ExcludePaths = NormalizeExcludePaths(folder.Path, folder.ExcludePaths)
+
+		if stat, err := os.Stat(folder.Path); err != nil {
+			log.Errorf("Folder '%s' (cannot watch): %v", folder.Path, err)
+			continue
+		} else if !stat.IsDir() {
+			log.Errorf("Folder '%s' (cannot watch): not a folder", folder.Path)
+			continue
+		}
+
+		goodFolders = append(goodFolders, folder)
+		goodFlist = append(goodFlist, folder.Path)
+	}
+
+	return goodFolders, goodFlist
+}
+
+// NormalizeExcludePaths expands and cleans exclude paths relative to a watch folder.
+func NormalizeExcludePaths(basePath string, excludes []string) []string {
+	cleaned := make([]string, 0, len(excludes))
+
+	for _, exclude := range excludes {
+		exclude = strings.TrimSpace(exclude)
+		if exclude == "" {
+			continue
+		}
+
+		exclude = expandHomedir(exclude)
+		if !filepath.IsAbs(exclude) {
+			exclude = filepath.Join(basePath, exclude)
+		}
+
+		if abs, err := filepath.Abs(exclude); err == nil {
+			cleaned = append(cleaned, filepath.Clean(abs))
+		}
+	}
+
+	return cleaned
+}
+
+// IsExcludedPath returns true if path is the exclude or a child of it.
+func (c *FolderConfig) IsExcludedPath(path string) bool {
+	if len(c.ExcludePaths) == 0 || path == "" {
+		return false
+	}
+
+	path = filepath.Clean(path)
+
+	for _, exclude := range c.ExcludePaths {
+		exclude = filepath.Clean(exclude)
+		if path == exclude || strings.HasPrefix(path, exclude+string(os.PathSeparator)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/folders/validate.go
+++ b/pkg/folders/validate.go
@@ -1,0 +1,54 @@
+package folders
+
+import (
+	"errors"
+	"fmt"
+
+	"golift.io/cnfg"
+)
+
+// ErrNilConfig is returned when a folder list contains a nil entry.
+var ErrNilConfig = errors.New("nil config entry")
+
+// ValidateList applies folder defaults and parses max_bytes.
+func ValidateList(list []*FolderConfig, parseMax func(string) (uint64, bool, error)) error {
+	for idx := range list {
+		if list[idx] == nil {
+			return ErrNilConfig
+		}
+
+		if list[idx].DeleteAfter == nil {
+			list[idx].DeleteAfter = &cnfg.Duration{Duration: DefaultDeleteAfter}
+		}
+
+		n, _, err := parseMax(list[idx].MaxBytes)
+		if err != nil {
+			return fmt.Errorf("folder %s: %w", list[idx].Path, err)
+		}
+
+		list[idx].ResolvedMaxBytes = n
+	}
+
+	return nil
+}
+
+// CloneList copies folder configs without sharing DeleteAfter or ExcludePaths.
+func CloneList(src []*FolderConfig) []*FolderConfig {
+	if src == nil {
+		return nil
+	}
+
+	out := make([]*FolderConfig, len(src))
+	for idx, folder := range src {
+		cloned := *folder
+		if folder.DeleteAfter != nil {
+			dur := *folder.DeleteAfter
+			cloned.DeleteAfter = &dur
+		}
+
+		cloned.ExcludePaths = append([]string(nil), folder.ExcludePaths...)
+		out[idx] = &cloned
+	}
+
+	return out
+}

--- a/pkg/folders/watch.go
+++ b/pkg/folders/watch.go
@@ -1,0 +1,210 @@
+package folders
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Unpackerr/unpackerr/pkg/extract"
+	"github.com/fsnotify/fsnotify"
+	"github.com/radovskyb/watcher"
+	"golift.io/xtractr"
+)
+
+// NewWatcher returns a new folder watcher.
+// You must call folders.FSNotify.Close() when you're done with it.
+func (c WatchConfig) NewWatcher(
+	folderConfig []*FolderConfig,
+	logger Logs,
+	updateBuf int,
+	ignoreSuffix string,
+) (*Folders, error) {
+	folders := &Folders{
+		Interval:     c.Interval.Duration,
+		Config:       folderConfig,
+		Folders:      make(map[string]*Folder),
+		Events:       make(chan *Event, c.Buffer),
+		Updates:      make(chan *xtractr.Response, updateBuf),
+		Logs:         logger,
+		IgnoreSuffix: ignoreSuffix,
+	}
+
+	if len(folderConfig) == 0 {
+		return folders, nil // do not initialize watcher
+	}
+
+	folders.Watcher = watcher.New()
+	folders.Watcher.FilterOps(watcher.Rename, watcher.Move, watcher.Write, watcher.Create)
+	folders.Watcher.IgnoreHiddenFiles(true)
+
+	fsn, err := fsnotify.NewWatcher()
+	if err != nil {
+		return folders, fmt.Errorf("fsnotify.NewWatcher: %w", err)
+	}
+
+	folders.FSNotify = fsn
+
+	for _, folder := range folderConfig {
+		if err := folders.Watcher.Add(folder.Path); err != nil {
+			logger.Errorf("Folder '%s' (cannot poll): %v", folder.Path, err)
+		}
+
+		if err := fsn.Add(folder.Path); err != nil {
+			logger.Errorf("Folder '%s' (cannot watch): %v", folder.Path, err)
+		}
+	}
+
+	return folders, nil
+}
+
+// Add uses either fsnotify or watcher.
+func (f *Folders) Add(folder string) error {
+	if f.Interval >= MinimumPollInterval {
+		if err := f.Watcher.Add(folder); err != nil {
+			return fmt.Errorf("watcher: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := f.FSNotify.Add(folder); err != nil {
+		return fmt.Errorf("fsnotify: %w", err)
+	}
+
+	return nil
+}
+
+// Remove uses either fsnotify or watcher.
+func (f *Folders) Remove(folder string) {
+	if f.Watcher != nil {
+		_ = f.Watcher.Remove(folder)
+	}
+
+	if f.FSNotify != nil {
+		_ = f.FSNotify.Remove(folder)
+	}
+}
+
+// StartPoller starts the radovskyb poll watcher.
+func (f *Folders) StartPoller(interval time.Duration) error {
+	if err := f.Watcher.Start(interval); err != nil {
+		return fmt.Errorf("folder poller stopped: %w", err)
+	}
+
+	return nil
+}
+
+// WatchFSNotify reads file system events from a channel and processes them.
+// This runs in its own go routine, and eventually sends the event back into the main routine.
+func (f *Folders) WatchFSNotify() {
+	defer log.Println("Folder watcher routine exited. No longer watching any folders.")
+
+	for {
+		select {
+		case err := <-f.Watcher.Error:
+			f.Errorf("watcher: %v", err)
+		case err := <-f.FSNotify.Errors:
+			f.Errorf("fsnotify: %v", err)
+		case event, ok := <-f.FSNotify.Events:
+			if !ok {
+				return
+			}
+
+			f.handleFileEvent(event.Name, "f "+event.Op.String())
+		case event := <-f.Watcher.Event:
+			f.handleFileEvent(event.Path, "w "+event.Op.String())
+		case <-f.Watcher.Closed:
+			return
+		}
+	}
+}
+
+func (f *Folders) handleFileEvent(name, operation string) {
+	if f.IgnoreSuffix != "" && strings.HasSuffix(name, f.IgnoreSuffix) {
+		return
+	}
+
+	for _, cfg := range f.Config {
+		// Do not handle events on the watched folder itself.
+		if name == cfg.Path {
+			return
+		}
+
+		if !strings.HasPrefix(name, cfg.Path) {
+			continue // Not the configured folder for the event we just got.
+		}
+
+		if cfg.IsExcludedPath(name) {
+			f.Debugf("Folder: Ignored event from excluded path: %v", name)
+			continue
+		}
+
+		if dir := filepath.Dir(name); dir == cfg.Path {
+			f.Events <- &Event{Name: filepath.Base(name), Config: cfg, File: name, Op: operation}
+		} else {
+			f.Events <- &Event{Name: filepath.Base(dir), Config: cfg, File: name, Op: operation}
+		}
+
+		return
+	}
+
+	f.Debugf("Folder: Ignored event from non-configured path: %v", name)
+}
+
+// ProcessEvent processes the event that was received.
+func (f *Folders) ProcessEvent(event *Event, now time.Time) {
+	dirPath := filepath.Join(event.Config.Path, event.Name)
+
+	if event.Config.IsExcludedPath(event.File) || event.Config.IsExcludedPath(dirPath) {
+		f.Debugf("Folder: Ignored File Event (%s) '%s' (excluded path)", event.Op, event.File)
+		return
+	}
+
+	stat, err := os.Stat(dirPath)
+	if err != nil {
+		// Item is unusable (probably deleted), remove it from history.
+		if _, ok := f.Folders[dirPath]; ok {
+			f.Debugf("Folder: Removing Tracked Item: %v", dirPath)
+			delete(f.Folders, dirPath)
+			f.Remove(dirPath)
+		}
+
+		f.Debugf("Folder: Ignored File Event (%s) '%s' (unreadable): %v", event.Op, event.File, err)
+
+		return
+	}
+
+	if !stat.IsDir() && !xtractr.IsArchiveFile(event.Name) {
+		f.Debugf("Folder: Ignored File Event (%s) '%s' (not archive or dir): %v", event.Op, event.File, err)
+		return
+	}
+
+	f.saveEvent(event, dirPath, now)
+}
+
+func (f *Folders) saveEvent(event *Event, dirPath string, now time.Time) {
+	if _, ok := f.Folders[dirPath]; ok {
+		f.Folders[dirPath].Updated = now
+		return
+	}
+
+	if err := f.Add(dirPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			f.Errorf("Folder: Tracking New Item: %v (event: %s): %v ", dirPath, event.Op, err)
+		}
+
+		return
+	}
+
+	f.Printf("[Folder] Tracking New Item: %v (event: %s)", dirPath, event.Op)
+
+	f.Folders[dirPath] = &Folder{
+		Updated: now,
+		Status:  extract.WAITING,
+		Config:  event.Config,
+	}
+}

--- a/pkg/unpackerr/aliases.go
+++ b/pkg/unpackerr/aliases.go
@@ -2,11 +2,12 @@ package unpackerr
 
 import (
 	"github.com/Unpackerr/unpackerr/pkg/extract"
+	"github.com/Unpackerr/unpackerr/pkg/folders"
 	"github.com/Unpackerr/unpackerr/pkg/hooks"
 )
 
 // Type aliases keep the daemon and tests on the historical names while the
-// types themselves live in pkg/extract and pkg/hooks.
+// types themselves live in pkg/extract, pkg/hooks, and pkg/folders.
 type (
 	ExtractStatus   = extract.Status
 	Extract         = extract.Extract
@@ -15,6 +16,11 @@ type (
 	WebhookPayload  = hooks.Payload
 	ExtractStatuses = hooks.Statuses
 	XtractPayload   = hooks.XtractPayload
+	FolderConfig    = folders.FolderConfig
+	FoldersConfig   = folders.WatchConfig
+	Folders         = folders.Folders
+	Folder          = folders.Folder
+	eventData       = folders.Event
 )
 
 // Extract Statuses.

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -84,11 +84,6 @@ type Config struct {
 	Folder        FoldersConfig    `json:"folders"            toml:"folders"        xml:"folders"        yaml:"folders"` // undocumented.
 }
 
-type FoldersConfig struct {
-	Buffer   uint          `json:"buffer"   toml:"buffer"   xml:"buffer"   yaml:"buffer"`   // undocumented.
-	Interval cnfg.Duration `json:"interval" toml:"interval" xml:"interval" yaml:"interval"` // undocumented.
-}
-
 func (u *Unpackerr) watchWorkThread() {
 	u.ensureWorkThreads(u.starrAppCount())
 }

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"github.com/Unpackerr/unpackerr/pkg/folders"
 	"github.com/Unpackerr/unpackerr/pkg/hooks"
 	"golift.io/starr/lidarr"
 	"golift.io/starr/radarr"
@@ -135,23 +136,7 @@ func cloneStarrList[T any, P starrApp[T]](src []P) []P {
 }
 
 func cloneFolderList(src []*FolderConfig) []*FolderConfig {
-	if src == nil {
-		return nil
-	}
-
-	out := make([]*FolderConfig, len(src))
-	for idx, folder := range src {
-		cloned := *folder
-		if folder.DeleteAfter != nil {
-			dur := *folder.DeleteAfter
-			cloned.DeleteAfter = &dur
-		}
-
-		cloned.ExcludePaths = append([]string(nil), folder.ExcludePaths...)
-		out[idx] = &cloned
-	}
-
-	return out
+	return folders.CloneList(src)
 }
 
 // cloneHookList copies hooks without the mutex, counters, client, or template.

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -1,118 +1,27 @@
 package unpackerr
 
-/* Folder Watching Codez */
+/* Folder extract / callback / cleanup — the watch tracker lives in pkg/folders. */
 
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
-	"github.com/fsnotify/fsnotify"
-	"github.com/radovskyb/watcher"
-	"golift.io/cnfg"
+	"github.com/Unpackerr/unpackerr/pkg/folders"
 	"golift.io/xtractr"
 )
-
-// defaultPollInterval is used if Docker is detected.
-const (
-	defaultPollInterval = time.Second
-	minimumPollInterval = 5 * time.Millisecond
-	defaultFolderDelete = 10 * time.Minute
-)
-
-// FolderConfig defines the input data for a watched folder.
-//
-//nolint:lll
-type FolderConfig struct {
-	DeleteOrig       bool           `json:"delete_original"  toml:"delete_original"   xml:"delete_original"   yaml:"delete_original"`
-	DeleteFiles      bool           `json:"delete_files"     toml:"delete_files"      xml:"delete_files"      yaml:"delete_files"`
-	DisableLog       bool           `json:"disable_log"      toml:"disable_log"       xml:"disable_log"       yaml:"disable_log"`
-	MoveBack         bool           `json:"move_back"        toml:"move_back"         xml:"move_back"         yaml:"move_back"`
-	DeleteAfter      *cnfg.Duration `json:"delete_after"     toml:"delete_after"      xml:"delete_after"      yaml:"delete_after"`
-	ExtractPath      string         `json:"extract_path"     toml:"extract_path"      xml:"extract_path"      yaml:"extract_path"`
-	ExtractISOs      bool           `json:"extract_isos"     toml:"extract_isos"      xml:"extract_isos"      yaml:"extract_isos"`
-	DisableRecursion bool           `json:"disableRecursion" toml:"disable_recursion" xml:"disable_recursion" yaml:"disableRecursion"`
-	MaxNested        int            `json:"maxNested"        toml:"max_nested"        xml:"max_nested"        yaml:"maxNested"`
-	ExtrasMaxDepth   int            `json:"extrasMaxDepth"   toml:"extras_max_depth"  xml:"extras_max_depth"  yaml:"extrasMaxDepth"`
-	AllowSymlinks    bool           `json:"allowSymlinks"    toml:"allow_symlinks"    xml:"allow_symlinks"    yaml:"allowSymlinks"`
-	MaxBytes         string         `json:"maxBytes"         toml:"max_bytes"         xml:"max_bytes"         yaml:"maxBytes"`
-	MaxFiles         int            `json:"maxFiles"         toml:"max_files"         xml:"max_files"         yaml:"maxFiles"`
-	MaxRatio         float64        `json:"maxRatio"         toml:"max_ratio"         xml:"max_ratio"         yaml:"maxRatio"`
-	// maxBytes is 0 when unset: folder watcher is uncapped.
-	maxBytes     uint64
-	ExcludePaths []string `json:"exclude_paths" toml:"exclude_paths" xml:"exclude_path" yaml:"exclude_paths"`
-	Path         string   `json:"path"          toml:"path"          xml:"path"         yaml:"path"`
-}
-
-// Folders holds all known (created) folders in all watch paths.
-type Folders struct {
-	Logs
-	Interval time.Duration
-	Config   []*FolderConfig
-	Folders  map[string]*Folder
-	Events   chan *eventData
-	Updates  chan *xtractr.Response
-	FSNotify *fsnotify.Watcher
-	Watcher  *watcher.Watcher
-}
-
-// Logs interface for folders.
-type Logs interface {
-	Printf(msg string, v ...any)
-	Errorf(msg string, v ...any)
-	Debugf(msg string, v ...any)
-}
-
-// Folder is a "new" watched folder.
-type Folder struct {
-	updated  time.Time
-	status   ExtractStatus
-	config   *FolderConfig
-	files    []string
-	retries  uint
-	archives xtractr.ArchiveList
-	// preFiles is the snapshot of each archive dest before extraction
-	// (MoveBack only). Dest folders come from FindCompressedFiles so nested
-	// archive dirs are included. Kept across retries so failed cleanups are
-	// not recaptured as download content. Nil means remnant handling is skipped.
-	preFiles map[string]os.FileInfo
-	// noRetry is set when remnant_action=off leaves a blocker.
-	noRetry bool
-}
-
-type eventData struct {
-	cnfg *FolderConfig
-	name string
-	file string
-	op   string
-}
 
 func (u *Unpackerr) validateFolders() error {
 	return validateFolderList(u.Folders)
 }
 
-func validateFolderList(folders []*FolderConfig) error {
-	for idx := range folders {
-		if folders[idx] == nil {
-			return errNilConfigEntry
-		}
-
-		if folders[idx].DeleteAfter == nil {
-			// If delete after wasn't set, then set it to 10 minutes.
-			folders[idx].DeleteAfter = &cnfg.Duration{Duration: defaultFolderDelete}
-		}
-
-		n, _, err := parseOptionalMaxBytes(folders[idx].MaxBytes)
-		if err != nil {
-			return fmt.Errorf("folder %s: %w", folders[idx].Path, err)
-		}
-
-		folders[idx].maxBytes = n
+func validateFolderList(list []*FolderConfig) error {
+	if err := folders.ValidateList(list, parseOptionalMaxBytes); err != nil {
+		return fmt.Errorf("validating folders: %w", err)
 	}
 
 	return nil
@@ -128,228 +37,81 @@ func (u *Unpackerr) PollFolders() {
 	)
 
 	if isRunningInDocker() && u.Folder.Interval.Duration == 0 {
-		u.Folder.Interval.Duration = defaultPollInterval
+		u.Folder.Interval.Duration = folders.DefaultPollInterval
 	}
 
 	// Abs-expand a clone so GET /api/config/folders/live keeps the configured
 	// path (file vs env), not the runtime filepath.Abs rewrite.
-	watched, flist := checkFolders(cloneFolderList(u.Folders), u.Logger)
+	watched, flist := folders.Check(folders.CloneList(u.Folders), u.Logger)
 
-	folders, err := u.Folder.newWatcher(watched, u.Logger)
+	tracker, err := u.Folder.NewWatcher(watched, u.Logger, updateChanBuf, suffix)
 	if err != nil {
 		u.Errorf("Watching Folders: %s", err)
 		return
 	}
 
-	u.folders = folders
+	u.folders = tracker
 	// do not close either watcher.
 
 	if len(watched) == 0 {
 		return
 	}
 
-	go u.folders.watchFSNotify()
+	go u.folders.WatchFSNotify()
 
 	u.Printf("[Folder] Watching (fsnotify): %s", strings.Join(flist, ", "))
 
 	// Setting an interval of any value less than 5 milliseconds
 	// (except zero in docker) allows disabling the poller.
-	if u.Folder.Interval.Duration < minimumPollInterval {
+	if u.Folder.Interval.Duration < folders.MinimumPollInterval {
 		return
 	}
 
 	go func() {
-		if err := u.folders.Watcher.Start(u.Folder.Interval.Duration); err != nil {
-			u.Errorf("Folder poller stopped: %v", err)
+		if err := u.folders.StartPoller(u.Folder.Interval.Duration); err != nil {
+			u.Errorf("%s", err)
 		}
 	}()
 
 	u.Printf("[Folder] Polling @ %s: %s", u.Folder.Interval.String(), strings.Join(flist, ", "))
 }
 
-// checkFolders stats all configured folders and returns only "good" ones.
-func checkFolders(folders []*FolderConfig, log Logs) ([]*FolderConfig, []string) {
-	var (
-		err         error
-		goodFolders = folders[:0]
-		goodFlist   = []string{}
-	)
-
-	for _, folder := range folders {
-		folder.Path, err = filepath.Abs(expandHomedir(folder.Path))
-		if err != nil {
-			log.Errorf("Folder '%s' (bad path): %v", folder.Path, err)
-			continue
-		}
-
-		if folder.ExtractPath != "" {
-			folder.ExtractPath, err = filepath.Abs(expandHomedir(folder.ExtractPath))
-			if err != nil {
-				log.Errorf("Folder '%s' (bad extract path): %v", folder.ExtractPath, err)
-				continue
-			}
-		}
-
-		folder.ExcludePaths = normalizeFolderExcludePaths(folder.Path, folder.ExcludePaths)
-
-		if stat, err := os.Stat(folder.Path); err != nil {
-			log.Errorf("Folder '%s' (cannot watch): %v", folder.Path, err)
-			continue
-		} else if !stat.IsDir() {
-			log.Errorf("Folder '%s' (cannot watch): not a folder", folder.Path)
-			continue
-		}
-
-		goodFolders = append(goodFolders, folder)
-		goodFlist = append(goodFlist, folder.Path)
-	}
-
-	return goodFolders, goodFlist
-}
-
-func normalizeFolderExcludePaths(basePath string, excludes []string) []string {
-	cleaned := make([]string, 0, len(excludes))
-
-	for _, exclude := range excludes {
-		exclude = strings.TrimSpace(exclude)
-		if exclude == "" {
-			continue
-		}
-
-		exclude = expandHomedir(exclude)
-		if !filepath.IsAbs(exclude) {
-			exclude = filepath.Join(basePath, exclude)
-		}
-
-		if abs, err := filepath.Abs(exclude); err == nil {
-			cleaned = append(cleaned, filepath.Clean(abs))
-		}
-	}
-
-	return cleaned
-}
-
-func (c *FolderConfig) isExcludedPath(path string) bool {
-	if len(c.ExcludePaths) == 0 || path == "" {
-		return false
-	}
-
-	path = filepath.Clean(path)
-
-	for _, exclude := range c.ExcludePaths {
-		exclude = filepath.Clean(exclude)
-		if path == exclude || strings.HasPrefix(path, exclude+string(os.PathSeparator)) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// newWatcher returns a new folder watcher.
-// You must call folders.FSNotify.Close() when you're done with it.
-func (c FoldersConfig) newWatcher(folderConfig []*FolderConfig, log Logs) (*Folders, error) {
-	folders := &Folders{
-		Interval: c.Interval.Duration,
-		Config:   folderConfig,
-		Folders:  make(map[string]*Folder),
-		Events:   make(chan *eventData, c.Buffer),
-		Updates:  make(chan *xtractr.Response, updateChanBuf),
-		Logs:     log,
-	}
-
-	if len(folderConfig) == 0 {
-		return folders, nil // do not initialize watcher
-	}
-
-	folders.Watcher = watcher.New()
-	folders.Watcher.FilterOps(watcher.Rename, watcher.Move, watcher.Write, watcher.Create)
-	folders.Watcher.IgnoreHiddenFiles(true)
-
-	fsn, err := fsnotify.NewWatcher()
-	if err != nil {
-		return folders, fmt.Errorf("fsnotify.NewWatcher: %w", err)
-	}
-
-	folders.FSNotify = fsn
-
-	for _, folder := range folderConfig {
-		if err := folders.Watcher.Add(folder.Path); err != nil {
-			log.Errorf("Folder '%s' (cannot poll): %v", folder.Path, err)
-		}
-
-		if err := fsn.Add(folder.Path); err != nil {
-			log.Errorf("Folder '%s' (cannot watch): %v", folder.Path, err)
-		}
-	}
-
-	return folders, nil
-}
-
-// Add uses either fsnotify or watcher.
-func (f *Folders) Add(folder string) error {
-	if f.Interval >= minimumPollInterval {
-		if err := f.Watcher.Add(folder); err != nil {
-			return fmt.Errorf("watcher: %w", err)
-		}
-
-		return nil
-	}
-
-	if err := f.FSNotify.Add(folder); err != nil {
-		return fmt.Errorf("fsnotify: %w", err)
-	}
-
-	return nil
-}
-
-// Remove uses either fsnotify or watcher.
-func (f *Folders) Remove(folder string) {
-	if f.Watcher != nil {
-		_ = f.Watcher.Remove(folder)
-	}
-
-	if f.FSNotify != nil {
-		_ = f.FSNotify.Remove(folder)
-	}
-}
-
 // extractTrackedItem starts an archive or folder's extraction after it hasn't been written to in a while.
 func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Time) {
 	u.folders.Remove(name) // stop the fs watcher(s).
 	// update status.
-	u.folders.Folders[name].updated = now
-	u.folders.Folders[name].status = QUEUED
+	u.folders.Folders[name].Updated = now
+	u.folders.Folders[name].Status = QUEUED
 
 	// Do not extract r00 file if rar file with same name exists.
 	if strings.HasSuffix(strings.ToLower(name), ".r00") &&
 		xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
 		u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
-		u.folders.Folders[name].status = EXTRACTEDNOTHING
+		u.folders.Folders[name].Status = EXTRACTEDNOTHING
 
 		return
 	}
 
 	// create a queue counter in the main history; add to u.Map and send webhook for a new folder.
 	u.lockHistory()
-	item := u.updateQueueStatus(&newStatus{Name: name, Status: QUEUED}, u.folders.Folders[name].updated, true)
+	item := u.updateQueueStatus(&newStatus{Name: name, Status: QUEUED}, u.folders.Folders[name].Updated, true)
 	u.unlockHistory()
 	u.updateHistory(FolderString + ": " + name)
 
-	exclude := folderExcludeSuffixes(name, folder.config)
+	exclude := folderExcludeSuffixes(name, folder.Config)
 
-	if folder.config.MoveBack {
+	if folder.Config.MoveBack {
 		found := xtractr.FindCompressedFiles(xtractr.Filter{
 			Path:          name,
 			ExcludeSuffix: exclude,
-			AllowSymlinks: folder.config.AllowSymlinks,
+			AllowSymlinks: folder.Config.AllowSymlinks,
 		})
 
-		snap, err := keepDirSnapshot(folder.preFiles, archiveSnapshotPaths(name, found)...)
+		snap, err := keepDirSnapshot(folder.PreFiles, archiveSnapshotPaths(name, found)...)
 		if err != nil {
 			u.Errorf("[Folder] Snapshot dests for remnant check: %v", err)
 		} else {
-			folder.preFiles = snap
+			folder.PreFiles = snap
 		}
 	}
 
@@ -360,20 +122,20 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 		Name:             name,
 		Path:             name,
 		ExcludeSuffix:    exclude,
-		AllowSymlinks:    folder.config.AllowSymlinks,
-		MaxBytes:         folder.config.maxBytes,
-		MaxFiles:         folder.config.MaxFiles,
-		MaxRatio:         folder.config.MaxRatio,
-		MaxNested:        folder.config.MaxNested,
-		ExtrasMaxDepth:   folder.config.ExtrasMaxDepth,
-		TempFolder:       !folder.config.MoveBack,
-		ExtractTo:        folder.config.ExtractPath,
+		AllowSymlinks:    folder.Config.AllowSymlinks,
+		MaxBytes:         folder.Config.ResolvedMaxBytes,
+		MaxFiles:         folder.Config.MaxFiles,
+		MaxRatio:         folder.Config.MaxRatio,
+		MaxNested:        folder.Config.MaxNested,
+		ExtrasMaxDepth:   folder.Config.ExtrasMaxDepth,
+		TempFolder:       !folder.Config.MoveBack,
+		ExtractTo:        folder.Config.ExtractPath,
 		DeleteOrig:       false,
 		CBChannel:        u.folders.Updates,
 		CBFunction:       nil,
 		Progress:         u.progressUpdateCallback(item),
-		LogFile:          !folder.config.DisableLog,
-		DisableRecursion: folder.config.DisableRecursion,
+		LogFile:          !folder.Config.DisableLog,
+		DisableRecursion: folder.Config.DisableRecursion,
 	})
 	if err != nil {
 		u.Errorf("[ERROR] %v", err)
@@ -442,28 +204,28 @@ func (u *Unpackerr) folderXtractrCallback(resp *xtractr.Response) {
 
 	if !resp.Done {
 		item.XProg.Archives = resp.Archives.Count() + resp.Extras.Count()
-		folder.status = EXTRACTING
-		u.Printf("[Folder] Extraction Started: %s, retries: %d, items in queue: %d", resp.X.Name, folder.retries, resp.Queued)
-		folder.updated = now
-		u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.status}, folder.updated, true)
+		folder.Status = EXTRACTING
+		u.Printf("[Folder] Extraction Started: %s, retries: %d, items in queue: %d", resp.X.Name, folder.Retries, resp.Queued)
+		folder.Updated = now
+		u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.Status}, folder.Updated, true)
 		u.unlockHistory()
 
 		return
 	}
 
 	if errors.Is(resp.Error, xtractr.ErrNoCompressedFiles) {
-		folder.status = EXTRACTEDNOTHING
-		u.Printf("[Folder] %s: %s: %v", folder.status.Desc(), resp.X.Name, resp.Error)
-		folder.updated = now
-		u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.status}, folder.updated, true)
+		folder.Status = EXTRACTEDNOTHING
+		u.Printf("[Folder] %s: %s: %v", folder.Status.Desc(), resp.X.Name, resp.Error)
+		folder.Updated = now
+		u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.Status}, folder.Updated, true)
 		u.unlockHistory()
 
 		return
 	}
 
-	preFiles := folder.preFiles
-	retries := folder.retries
-	configPath := folder.config.Path
+	preFiles := folder.PreFiles
+	retries := folder.Retries
+	configPath := folder.Config.Path
 
 	u.unlockHistory()
 
@@ -478,8 +240,8 @@ func (u *Unpackerr) folderXtractrCallback(resp *xtractr.Response) {
 	}
 
 	u.commitFolderExtract(folder, resp, remnantStatus, remnants)
-	folder.updated = now
-	u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.status}, folder.updated, true)
+	folder.Updated = now
+	u.updateQueueStatus(&newStatus{Name: resp.X.Name, Resp: resp, Status: folder.Status}, folder.Updated, true)
 }
 
 // finishFolderExtractWork logs, records metrics, and classifies remnants without
@@ -508,7 +270,7 @@ func (u *Unpackerr) finishFolderExtractWork(
 // remnant_action=off sets noRetry so checkFolderStats will not restart.
 func (u *Unpackerr) commitFolderExtract(folder *Folder, resp *xtractr.Response, status ExtractStatus, remnants bool) {
 	if resp.Error != nil {
-		folder.archives = resp.Archives
+		folder.Archives = resp.Archives
 	}
 
 	if remnants {
@@ -517,212 +279,93 @@ func (u *Unpackerr) commitFolderExtract(folder *Folder, resp *xtractr.Response, 
 	}
 
 	if resp.Error != nil {
-		folder.status = EXTRACTFAILED
+		folder.Status = EXTRACTFAILED
 		return
 	}
 
-	folder.archives = resp.Archives
-	folder.status = EXTRACTED
-	folder.files = resp.NewFiles
+	folder.Archives = resp.Archives
+	folder.Status = EXTRACTED
+	folder.Files = resp.NewFiles
 }
 
 func (u *Unpackerr) finishFolderRemnants(folder *Folder, resp *xtractr.Response, status ExtractStatus) {
 	if status == WAITING {
 		u.Printf("[Folder] Cleared interrupted-extraction remnant(s), restarting extraction: %s", resp.X.Name)
 
-		folder.status = EXTRACTFAILED
+		folder.Status = EXTRACTFAILED
 
 		return
 	}
 
 	if remnantAction(u.RemnantAction) == "off" {
-		folder.noRetry = true
+		folder.NoRetry = true
 	}
 
 	u.Errorf("[Folder] Extraction blocked by interrupted-extraction remnant(s): %s", resp.X.Name)
 
-	folder.status = EXTRACTFAILED
-}
-
-// watchFSNotify reads file system events from a channel and processes them.
-// This runs in its own go routine, and eventually sends the event back into the main routine.
-func (f *Folders) watchFSNotify() {
-	defer log.Println("Folder watcher routine exited. No longer watching any folders.")
-
-	for {
-		select {
-		case err := <-f.Watcher.Error:
-			f.Errorf("watcher: %v", err)
-		case err := <-f.FSNotify.Errors:
-			f.Errorf("fsnotify: %v", err)
-		case event, ok := <-f.FSNotify.Events:
-			if !ok {
-				return
-			}
-
-			f.handleFileEvent(event.Name, "f "+event.Op.String())
-		case event := <-f.Watcher.Event:
-			f.handleFileEvent(event.Path, "w "+event.Op.String())
-		case <-f.Watcher.Closed:
-			return
-		}
-	}
-}
-
-// handleFileEvent takes formatted events from fsnotify or fswatcher, does minimal
-// (thread safe) validation before sending the re-formatted event to the main go routine.
-func (f *Folders) handleFileEvent(name, operation string) {
-	if strings.HasSuffix(name, suffix) {
-		return
-	}
-
-	// Send this event to processEvent().
-	for _, cnfg := range f.Config {
-		// Do not handle events on the watched folder itself.
-		if name == cnfg.Path {
-			return
-		}
-
-		// cnfg.Path: "/Users/Documents/watched_folder"
-		// event.Name: "/Users/Documents/watched_folder/new_folder/file.rar"
-		// eventData.name: "new_folder"
-		if !strings.HasPrefix(name, cnfg.Path) {
-			continue // Not the configured folder for the event we just got.
-		}
-
-		if cnfg.isExcludedPath(name) {
-			f.Debugf("Folder: Ignored event from excluded path: %v", name)
-			continue
-		}
-
-		// processEvent (below) handles events sent to f.Events.
-		if dir := filepath.Dir(name); dir == cnfg.Path {
-			f.Events <- &eventData{name: filepath.Base(name), cnfg: cnfg, file: name, op: operation}
-		} else {
-			f.Events <- &eventData{name: filepath.Base(dir), cnfg: cnfg, file: name, op: operation}
-		}
-
-		return
-	}
-
-	f.Debugf("Folder: Ignored event from non-configured path: %v", name)
+	folder.Status = EXTRACTFAILED
 }
 
 // processEvent is here to process the event in the `*Unpackerr` scope before sending it back to the `*Folders` scope.
 func (u *Unpackerr) processEvent(event *eventData, now time.Time) {
 	// Do not watch our own log file.
-	if event.file == u.LogFile || event.file == u.Webserver.LogFile {
+	if event.File == u.LogFile || event.File == u.Webserver.LogFile {
 		return
 	}
 
-	u.folders.processEvent(event, now)
-}
-
-// processEvent processes the event that was received.
-func (f *Folders) processEvent(event *eventData, now time.Time) {
-	dirPath := filepath.Join(event.cnfg.Path, event.name)
-
-	if event.cnfg.isExcludedPath(event.file) || event.cnfg.isExcludedPath(dirPath) {
-		f.Debugf("Folder: Ignored File Event (%s) '%s' (excluded path)", event.op, event.file)
-		return
-	}
-
-	stat, err := os.Stat(dirPath)
-	if err != nil {
-		// Item is unusable (probably deleted), remove it from history.
-		if _, ok := f.Folders[dirPath]; ok {
-			f.Debugf("Folder: Removing Tracked Item: %v", dirPath)
-			delete(f.Folders, dirPath)
-			f.Remove(dirPath)
-		}
-
-		f.Debugf("Folder: Ignored File Event (%s) '%s' (unreadable): %v", event.op, event.file, err)
-
-		return
-	}
-
-	if !stat.IsDir() && !xtractr.IsArchiveFile(event.name) {
-		f.Debugf("Folder: Ignored File Event (%s) '%s' (not archive or dir): %v", event.op, event.file, err)
-		return
-	}
-
-	f.saveEvent(event, dirPath, now)
-}
-
-func (f *Folders) saveEvent(event *eventData, dirPath string, now time.Time) {
-	if _, ok := f.Folders[dirPath]; ok {
-		// f.Debugf("Item Updated: %v", event.file)
-		f.Folders[dirPath].updated = now
-		return
-	}
-
-	if err := f.Add(dirPath); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			f.Errorf("Folder: Tracking New Item: %v (event: %s): %v ", dirPath, event.op, err)
-		}
-
-		return
-	}
-
-	f.Printf("[Folder] Tracking New Item: %v (event: %s)", dirPath, event.op)
-
-	f.Folders[dirPath] = &Folder{
-		updated: now,
-		status:  WAITING,
-		config:  event.cnfg,
-	}
+	u.folders.ProcessEvent(event, now)
 }
 
 // checkFolderStats runs at an interval to see if any folders need work done on them.
 // This runs on an interval ticker in the main go routine.
 func (u *Unpackerr) checkFolderStats(now time.Time) {
 	for name, folder := range u.folders.Folders {
-		switch elapsed := now.Sub(folder.updated); {
-		case WAITING == folder.status && elapsed >= u.StartDelay.Duration:
+		switch elapsed := now.Sub(folder.Updated); {
+		case WAITING == folder.Status && elapsed >= u.StartDelay.Duration:
 			// The folder hasn't been written to in a while, extract it.
 			u.extractTrackedItem(name, folder, now)
-		case EXTRACTEDNOTHING == folder.status:
+		case EXTRACTEDNOTHING == folder.Status:
 			// Wait until this item hasn't been touched for a while, so it doesn't re-queue.
-			if now.Sub(folder.updated) > u.StartDelay.Duration {
+			if now.Sub(folder.Updated) > u.StartDelay.Duration {
 				// Ignore "no compressed files" errors for folders.
 				u.lockHistory()
 				delete(u.Map, name)
 				u.unlockHistory()
 				delete(u.folders.Folders, name)
 			}
-		case EXTRACTFAILED == folder.status && folder.noRetry:
+		case EXTRACTFAILED == folder.Status && folder.NoRetry:
 			u.lockHistory()
 			u.updateQueueStatus(&newStatus{Name: name, Status: DELETED, Resp: nil}, now, true)
 			u.unlockHistory()
 			delete(u.folders.Folders, name)
 			u.Printf("[Folder] Remnant left in place (remnant_action=off), giving up: %s", name)
-		case EXTRACTFAILED == folder.status && elapsed >= u.RetryDelay.Duration &&
-			folder.retries < u.maxRetries():
+		case EXTRACTFAILED == folder.Status && elapsed >= u.RetryDelay.Duration &&
+			folder.Retries < u.maxRetries():
 			u.lockHistory()
 			u.Retries++
 			u.unlockHistory()
 
-			folder.retries++
-			folder.updated = now
-			folder.status = WAITING
+			folder.Retries++
+			folder.Updated = now
+			folder.Status = WAITING
 			u.Printf("[Folder] Re-starting Failed Extraction: %s (%d/%d, failed %v ago)",
-				folder.config.Path, folder.retries, u.maxRetries(), elapsed.Round(time.Second))
-		case EXTRACTFAILED == folder.status && folder.retries < u.maxRetries():
+				folder.Config.Path, folder.Retries, u.maxRetries(), elapsed.Round(time.Second))
+		case EXTRACTFAILED == folder.Status && folder.Retries < u.maxRetries():
 			// This empty block is to avoid deleting an item that needs more retries.
-		case EXTRACTFAILED == folder.status && folder.retries >= u.maxRetries():
+		case EXTRACTFAILED == folder.Status && folder.Retries >= u.maxRetries():
 			// Retries exhausted — clean up to prevent the item from staying in the map forever.
 			u.lockHistory()
 			u.updateQueueStatus(&newStatus{Name: name, Status: DELETED, Resp: nil}, now, true)
 			u.unlockHistory()
 			delete(u.folders.Folders, name)
-			u.Printf("[Folder] Retries exhausted (%d/%d), giving up: %s", folder.retries, u.maxRetries(), name)
-		case EXTRACTED == folder.status && folder.config.DeleteAfter.Duration <= 0:
+			u.Printf("[Folder] Retries exhausted (%d/%d), giving up: %s", folder.Retries, u.maxRetries(), name)
+		case EXTRACTED == folder.Status && folder.Config.DeleteAfter.Duration <= 0:
 			// if DeleteAfter is 0 we don't delete anything. we are done.
 			u.lockHistory()
 			u.updateQueueStatus(&newStatus{Name: name, Status: DELETED, Resp: nil}, now, false)
 			u.unlockHistory()
 			delete(u.folders.Folders, name)
-		case EXTRACTED == folder.status && elapsed >= folder.config.DeleteAfter.Duration:
+		case EXTRACTED == folder.Status && elapsed >= folder.Config.DeleteAfter.Duration:
 			u.deleteAfterReached(name, now, folder)
 		}
 	}
@@ -732,19 +375,19 @@ func (u *Unpackerr) checkFolderStats(now time.Time) {
 func (u *Unpackerr) deleteAfterReached(name string, now time.Time, folder *Folder) {
 	var webhook bool
 	// Folder reached delete delay (after extraction), nuke it.
-	if folder.config.DeleteFiles && !folder.config.MoveBack {
+	if folder.Config.DeleteFiles && !folder.Config.MoveBack {
 		u.queueDelete(&fileDeleteReq{Paths: []string{strings.TrimRight(name, `/\`) + suffix}})
 		webhook = true
-	} else if folder.config.DeleteFiles && len(folder.files) > 0 {
-		u.queueDelete(&fileDeleteReq{Paths: folder.files})
+	} else if folder.Config.DeleteFiles && len(folder.Files) > 0 {
+		u.queueDelete(&fileDeleteReq{Paths: folder.Files})
 		webhook = true
 	}
 
-	if folder.config.DeleteOrig && !folder.config.MoveBack {
+	if folder.Config.DeleteOrig && !folder.Config.MoveBack {
 		u.queueDelete(&fileDeleteReq{Paths: []string{name}})
 		webhook = true
-	} else if folder.config.DeleteOrig && len(folder.archives) > 0 {
-		u.queueDelete(&fileDeleteReq{Paths: folder.archives.List()})
+	} else if folder.Config.DeleteOrig && len(folder.Archives) > 0 {
+		u.queueDelete(&fileDeleteReq{Paths: folder.Archives.List()})
 		webhook = true
 	}
 

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -152,10 +152,10 @@ func (u *Unpackerr) retryFolderLocked(itemID string, item *Extract, now time.Tim
 		return errQueueNotFound
 	}
 
-	folder.status = WAITING
-	folder.noRetry = false
-	folder.retries = 0
-	folder.updated = now
+	folder.Status = WAITING
+	folder.NoRetry = false
+	folder.Retries = 0
+	folder.Updated = now
 	item.NoRetry = false
 	item.Status = WAITING
 	item.Updated = now

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -73,7 +73,7 @@ func TestQueueRetryFolder(t *testing.T) {
 		Retries: 3,
 	}
 	unpack.folders = &Folders{Folders: map[string]*Folder{
-		"/watch/fail": {status: EXTRACTFAILED, noRetry: true, retries: 99, updated: time.Now()},
+		"/watch/fail": {Status: EXTRACTFAILED, NoRetry: true, Retries: 99, Updated: time.Now()},
 	}}
 
 	withKey := func(req *http.Request) {
@@ -91,7 +91,7 @@ func TestQueueRetryFolder(t *testing.T) {
 	}
 
 	folder := unpack.folders.Folders["/watch/fail"]
-	if folder == nil || folder.status != WAITING || folder.noRetry || folder.retries != 0 {
+	if folder == nil || folder.Status != WAITING || folder.NoRetry || folder.Retries != 0 {
 		t.Fatalf("folder retry %+v", folder)
 	}
 }
@@ -102,7 +102,7 @@ func TestQueueForgetFolder(t *testing.T) {
 	unpack := testAuthUnpackerr(t)
 	unpack.Map["/watch/gone"] = &Extract{App: FolderString, Path: "/watch/gone", Status: EXTRACTFAILED}
 	unpack.folders = &Folders{Folders: map[string]*Folder{
-		"/watch/gone": {status: EXTRACTFAILED},
+		"/watch/gone": {Status: EXTRACTFAILED},
 	}}
 
 	withKey := func(req *http.Request) {

--- a/pkg/unpackerr/restart.go
+++ b/pkg/unpackerr/restart.go
@@ -59,7 +59,7 @@ func (u *Unpackerr) idle() bool {
 	}
 
 	for _, folder := range u.folders.Folders {
-		if folder.status == QUEUED || folder.status == EXTRACTING {
+		if folder.Status == QUEUED || folder.Status == EXTRACTING {
 			return false
 		}
 	}

--- a/pkg/unpackerr/restart_test.go
+++ b/pkg/unpackerr/restart_test.go
@@ -26,13 +26,13 @@ func TestIdleBlocksOnInFlightWork(t *testing.T) {
 	}
 
 	delete(unpack.Map, "/dl/busy")
-	unpack.folders.Folders["/watch/x"] = &Folder{status: EXTRACTING}
+	unpack.folders.Folders["/watch/x"] = &Folder{Status: EXTRACTING}
 
 	if unpack.idle() {
 		t.Fatal("an extracting folder must block a restart")
 	}
 
-	unpack.folders.Folders["/watch/x"].status = WAITING
+	unpack.folders.Folders["/watch/x"].Status = WAITING
 	unpack.queueDelete(&fileDeleteReq{})
 
 	if unpack.idle() {

--- a/pkg/unpackerr/start_test.go
+++ b/pkg/unpackerr/start_test.go
@@ -248,7 +248,7 @@ func TestValidateFoldersExtrasDefaults(t *testing.T) {
 		unpack.Folders[0].ExtrasMaxDepth != 0 ||
 		unpack.Folders[0].MaxFiles != 0 ||
 		unpack.Folders[0].MaxRatio != 0 ||
-		unpack.Folders[0].maxBytes != 0 {
+		unpack.Folders[0].ResolvedMaxBytes != 0 {
 		t.Fatalf("unset must stay unlimited: %+v", unpack.Folders[0])
 	}
 


### PR DESCRIPTION
## Summary
- Extract fsnotify/poll watching, path exclude checks, and folder config validate/clone into `pkg/folders`.
- Keep daemon names (`FolderConfig`, `FoldersConfig`, `Folders`, `Folder`) as aliases; extract and hook callbacks stay in unpackerr.
- Folder list JSON tags stay `json:"folder"`; undocumented watcher settings stay `json:"folders"`.

## Test plan
- [x] `gofmt` + `golangci-lint run ./...` (v2.13.2, 0 issues)
- [x] `go test ./...`
- [ ] Confirm a watched folder still extracts after a file lands
- [ ] Confirm Docker still polls at 1s when interval is unset


Made with [Cursor](https://cursor.com)