### PR TITLE
Add optional Starr instance names for logs, hooks, and the dashboard

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -183,4 +183,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 11 SEP 2026 03:33 UTC
+## => Content Auto Generated, 11 SEP 2026 03:53 UTC

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     - UN_FOLDERS_INTERVAL=1s
     - UN_FOLDERS_BUFFER=20000
     ## Sonarr Settings
-    - UN_SONARR_0_NAME=Sportarr
+    - UN_SONARR_0_NAME=
     - UN_SONARR_0_URL=http://sonarr:8989
     - UN_SONARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_SONARR_0_HTTP_USER=
@@ -74,7 +74,7 @@ services:
     - UN_SONARR_0_VALID_SSL=false
     - UN_SONARR_0_MAX_BYTES=
     ## Radarr Settings
-    - UN_RADARR_0_NAME=Sportarr
+    - UN_RADARR_0_NAME=
     - UN_RADARR_0_URL=http://radarr:7878
     - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_RADARR_0_HTTP_USER=
@@ -90,7 +90,7 @@ services:
     - UN_RADARR_0_VALID_SSL=false
     - UN_RADARR_0_MAX_BYTES=
     ## Lidarr Settings
-    - UN_LIDARR_0_NAME=Sportarr
+    - UN_LIDARR_0_NAME=
     - UN_LIDARR_0_URL=http://lidarr:8686
     - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_LIDARR_0_HTTP_USER=
@@ -107,7 +107,7 @@ services:
     - UN_LIDARR_0_MAX_BYTES=
     - UN_LIDARR_0_SPLIT_FLAC=false
     ## Readarr Settings
-    - UN_READARR_0_NAME=Sportarr
+    - UN_READARR_0_NAME=
     - UN_READARR_0_URL=http://readarr:8787
     - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_READARR_0_HTTP_USER=
@@ -123,7 +123,7 @@ services:
     - UN_READARR_0_VALID_SSL=false
     - UN_READARR_0_MAX_BYTES=
     ## Whisparr Settings
-    - UN_WHISPARR_0_NAME=Sportarr
+    - UN_WHISPARR_0_NAME=
     - UN_WHISPARR_0_URL=http://whisparr:6969
     - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_WHISPARR_0_HTTP_USER=
@@ -183,4 +183,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 11 SEP 2026 03:06 UTC
+## => Content Auto Generated, 11 SEP 2026 03:33 UTC

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     - UN_FOLDERS_INTERVAL=1s
     - UN_FOLDERS_BUFFER=20000
     ## Sonarr Settings
+    - UN_SONARR_0_NAME=Sportarr
     - UN_SONARR_0_URL=http://sonarr:8989
     - UN_SONARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_SONARR_0_HTTP_USER=
@@ -73,6 +74,7 @@ services:
     - UN_SONARR_0_VALID_SSL=false
     - UN_SONARR_0_MAX_BYTES=
     ## Radarr Settings
+    - UN_RADARR_0_NAME=Sportarr
     - UN_RADARR_0_URL=http://radarr:7878
     - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_RADARR_0_HTTP_USER=
@@ -88,6 +90,7 @@ services:
     - UN_RADARR_0_VALID_SSL=false
     - UN_RADARR_0_MAX_BYTES=
     ## Lidarr Settings
+    - UN_LIDARR_0_NAME=Sportarr
     - UN_LIDARR_0_URL=http://lidarr:8686
     - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_LIDARR_0_HTTP_USER=
@@ -104,6 +107,7 @@ services:
     - UN_LIDARR_0_MAX_BYTES=
     - UN_LIDARR_0_SPLIT_FLAC=false
     ## Readarr Settings
+    - UN_READARR_0_NAME=Sportarr
     - UN_READARR_0_URL=http://readarr:8787
     - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_READARR_0_HTTP_USER=
@@ -119,6 +123,7 @@ services:
     - UN_READARR_0_VALID_SSL=false
     - UN_READARR_0_MAX_BYTES=
     ## Whisparr Settings
+    - UN_WHISPARR_0_NAME=Sportarr
     - UN_WHISPARR_0_URL=http://whisparr:6969
     - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
     - UN_WHISPARR_0_HTTP_USER=
@@ -178,4 +183,4 @@ services:
     - UN_CMDHOOK_0_EXCLUDE_1=lidarr
     - UN_CMDHOOK_0_TIMEOUT=10s
 
-## => Content Auto Generated, 10 SEP 2026 04:55 UTC
+## => Content Auto Generated, 11 SEP 2026 03:06 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -177,6 +177,10 @@ passwords = []
 ## Leaving the [[sonarr]] header uncommented (no leading hash #) without also
 ## uncommenting the api_key (remove the hash #) will produce a startup warning.
 [[sonarr]]
+## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+## Sonarr-compatible app such as Sportarr so logs and Discord are not
+## tagged Sonarr. Hook exclude matches this name or the app dialect.
+# name = "Sportarr"
 # url = "http://127.0.0.1:8989"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -218,6 +222,10 @@ passwords = []
 ## Leaving the [[radarr]] header uncommented (no leading hash #) without also
 ## uncommenting the api_key (remove the hash #) will produce a startup warning.
 [[radarr]]
+## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+## Sonarr-compatible app such as Sportarr so logs and Discord are not
+## tagged Sonarr. Hook exclude matches this name or the app dialect.
+# name = "Sportarr"
 # url = "http://127.0.0.1:7878"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -257,6 +265,10 @@ passwords = []
 # max_bytes = ""
 
 #[[lidarr]]
+## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+## Sonarr-compatible app such as Sportarr so logs and Discord are not
+## tagged Sonarr. Hook exclude matches this name or the app dialect.
+# name = "Sportarr"
 # url = "http://127.0.0.1:8686"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -299,6 +311,10 @@ passwords = []
 # split_flac = false
 
 #[[readarr]]
+## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+## Sonarr-compatible app such as Sportarr so logs and Discord are not
+## tagged Sonarr. Hook exclude matches this name or the app dialect.
+# name = "Sportarr"
 # url = "http://127.0.0.1:8787"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -338,6 +354,10 @@ passwords = []
 # max_bytes = ""
 
 #[[whisparr]]
+## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+## Sonarr-compatible app such as Sportarr so logs and Discord are not
+## tagged Sonarr. Hook exclude matches this name or the app dialect.
+# name = "Sportarr"
 # url = "http://127.0.0.1:6969"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -450,7 +470,7 @@ passwords = []
 # channel = ""
 ## Passed into webhook templates. Used by Discord, Telegram, and Slack.
 # token = ""
-## List of apps to exclude. None by default. This is an example:
+## Dialect tokens skip every instance of that API. Any other value matches an instance name. None by default. This is an example:
 # exclude = ["readarr", "lidarr"]
 ## Override internal webhook template for discord.com or other hooks.
 # template_path = ''
@@ -482,9 +502,9 @@ passwords = []
 ## The default is [0] and this is an example:
 # events = [1, 4, 7]
 ## ===> Optional Command Hook Configuration <===
-## List of apps to exclude. None by default. This is an example:
+## Dialect tokens skip every instance of that API. Any other value matches an instance name. None by default. This is an example:
 # exclude = ["readarr", "lidarr"]
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 10 SEP 2026 07:22 UTC
+## => Content Auto Generated, 11 SEP 2026 03:06 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -180,6 +180,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
+## Names must be printable and cannot contain quotes, braces, or angle brackets.
 # name = ""
 # url = "http://127.0.0.1:8989"
 # api_key = "0123456789abcdef0123456789abcdef"
@@ -225,6 +226,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
+## Names must be printable and cannot contain quotes, braces, or angle brackets.
 # name = ""
 # url = "http://127.0.0.1:7878"
 # api_key = "0123456789abcdef0123456789abcdef"
@@ -268,6 +270,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
+## Names must be printable and cannot contain quotes, braces, or angle brackets.
 # name = ""
 # url = "http://127.0.0.1:8686"
 # api_key = "0123456789abcdef0123456789abcdef"
@@ -314,6 +317,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
+## Names must be printable and cannot contain quotes, braces, or angle brackets.
 # name = ""
 # url = "http://127.0.0.1:8787"
 # api_key = "0123456789abcdef0123456789abcdef"
@@ -357,6 +361,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
+## Names must be printable and cannot contain quotes, braces, or angle brackets.
 # name = ""
 # url = "http://127.0.0.1:6969"
 # api_key = "0123456789abcdef0123456789abcdef"
@@ -507,4 +512,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 11 SEP 2026 03:33 UTC
+## => Content Auto Generated, 11 SEP 2026 03:53 UTC

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -180,7 +180,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
-# name = "Sportarr"
+# name = ""
 # url = "http://127.0.0.1:8989"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -225,7 +225,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
-# name = "Sportarr"
+# name = ""
 # url = "http://127.0.0.1:7878"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -268,7 +268,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
-# name = "Sportarr"
+# name = ""
 # url = "http://127.0.0.1:8686"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -314,7 +314,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
-# name = "Sportarr"
+# name = ""
 # url = "http://127.0.0.1:8787"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -357,7 +357,7 @@ passwords = []
 ## Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
 ## Sonarr-compatible app such as Sportarr so logs and Discord are not
 ## tagged Sonarr. Hook exclude matches this name or the app dialect.
-# name = "Sportarr"
+# name = ""
 # url = "http://127.0.0.1:6969"
 # api_key = "0123456789abcdef0123456789abcdef"
 ## Username for HTTP basic authentication on the Starr app, if enabled.
@@ -507,4 +507,4 @@ passwords = []
 ## You can adjust how long to wait for the command to run.
 # timeout = "10s"
 
-## => Content Auto Generated, 11 SEP 2026 03:06 UTC
+## => Content Auto Generated, 11 SEP 2026 03:33 UTC

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -580,6 +580,15 @@ sections:
   starr:
     kind: list
     params:
+      - name: name
+        envvar: NAME
+        default: ''
+        example: Sportarr
+        short: Optional label for logs, webhooks, and the dashboard.
+        desc: |
+          Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
+          Sonarr-compatible app such as Sportarr so logs and Discord are not
+          tagged Sonarr. Hook exclude matches this name or the app dialect.
       - name: url
         envvar: URL
         short: URL where this starr app can be accessed.
@@ -985,8 +994,8 @@ sections:
         example: ['readarr', 'lidarr']
         recommend: *APPS
         kind: list
-        short: 'List of apps to exclude: radarr, sonarr, folders, etc.'
-        desc: 'List of apps to exclude. None by default. This is an example:'
+        short: 'Apps or instance names to skip: sonarr, Sportarr, folder, etc.'
+        desc: 'Dialect tokens skip every instance of that API. Any other value matches an instance name. None by default. This is an example:'
       - name: template_path
         envvar: TEMPLATE_PATH
         default: ''
@@ -1128,10 +1137,10 @@ sections:
         example: ['readarr', 'lidarr']
         recommend: *APPS
         kind: list
-        short: 'List of apps to exclude: radarr, sonarr, folders, etc.'
+        short: 'Apps or instance names to skip: sonarr, Sportarr, folder, etc.'
         desc: |
           ===> Optional Command Hook Configuration <===
-          List of apps to exclude. None by default. This is an example:
+          Dialect tokens skip every instance of that API. Any other value matches an instance name. None by default. This is an example:
       - name: timeout
         envvar: TIMEOUT
         default: 10s

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -588,6 +588,7 @@ sections:
           Empty uses the app name (Sonarr, Radarr, and so on). Set this for a
           Sonarr-compatible app such as Sportarr so logs and Discord are not
           tagged Sonarr. Hook exclude matches this name or the app dialect.
+          Names must be printable and cannot contain quotes, braces, or angle brackets.
       - name: url
         envvar: URL
         short: URL where this starr app can be accessed.

--- a/pkg/configdef/definitions.yml
+++ b/pkg/configdef/definitions.yml
@@ -583,7 +583,6 @@ sections:
       - name: name
         envvar: NAME
         default: ''
-        example: Sportarr
         short: Optional label for logs, webhooks, and the dashboard.
         desc: |
           Empty uses the app name (Sonarr, Radarr, and so on). Set this for a

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -2,6 +2,7 @@ package extract
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"golift.io/starr"
@@ -10,12 +11,15 @@ import (
 
 // Extract holds data for files being extracted.
 type Extract struct {
-	Syncthing   bool
-	SplitFlac   bool
-	Retries     uint
-	Path        string // Local path (resolved for extraction on this host).
-	OutputPath  string // Original path from Starr app (may be UNC/remote — used for ManualImport).
-	App         starr.App
+	Syncthing  bool
+	SplitFlac  bool
+	Retries    uint
+	Path       string // Local path (resolved for extraction on this host).
+	OutputPath string // Original path from Starr app (may be UNC/remote — used for ManualImport).
+	App        starr.App
+	// Name is an optional Starr instance label for logs, hooks, and the dashboard.
+	// Empty uses App (Sonarr, Radarr, Folder, …). App stays the dialect for logic.
+	Name        string
 	URL         string
 	Updated     time.Time
 	DeleteDelay time.Duration
@@ -36,4 +40,17 @@ type Extract struct {
 	NoRetry bool
 	// MaxBytes is the resolved byte cap for this Starr item (0 = unlimited).
 	MaxBytes uint64
+}
+
+// Label is the human-facing instance name, or the dialect when Name is empty.
+func (e *Extract) Label() string {
+	if e == nil {
+		return ""
+	}
+
+	if name := strings.TrimSpace(e.Name); name != "" {
+		return name
+	}
+
+	return string(e.App)
 }

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -1,0 +1,32 @@
+package extract
+
+import (
+	"testing"
+
+	"golift.io/starr"
+)
+
+func TestExtractLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item *Extract
+		want string
+	}{
+		{name: "nil", item: nil, want: ""},
+		{name: "dialect", item: &Extract{App: starr.Sonarr}, want: string(starr.Sonarr)},
+		{name: "named", item: &Extract{App: starr.Sonarr, Name: "Sportarr"}, want: "Sportarr"},
+		{name: "spaces", item: &Extract{App: starr.Radarr, Name: "  "}, want: string(starr.Radarr)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := test.item.Label(); got != test.want {
+				t.Fatalf("Label() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/hooks/config.go
+++ b/pkg/hooks/config.go
@@ -136,10 +136,16 @@ func (w *Config) ensureClient() {
 	}
 }
 
-// Excluded returns true if an app is in the Exclude slice.
-func (w *Config) Excluded(app starr.App) bool {
+// Excluded returns true if the dialect or instance name is in the Exclude slice.
+// Dialect tokens (sonarr, radarr, …) skip every instance of that API.
+// Any other value matches an instance name, case-insensitive.
+func (w *Config) Excluded(app starr.App, name string) bool {
 	for _, exclude := range w.Exclude {
 		if strings.EqualFold(exclude, string(app)) {
+			return true
+		}
+
+		if name != "" && strings.EqualFold(exclude, name) {
 			return true
 		}
 	}

--- a/pkg/hooks/config_test.go
+++ b/pkg/hooks/config_test.go
@@ -1,0 +1,37 @@
+package hooks
+
+import (
+	"testing"
+
+	"golift.io/starr"
+)
+
+func TestExcludedDialectOrName(t *testing.T) {
+	t.Parallel()
+
+	hook := &Config{Exclude: []string{"sonarr", "Sportarr"}}
+
+	tests := []struct {
+		name     string
+		app      starr.App
+		inst     string
+		excluded bool
+	}{
+		{name: "dialect", app: starr.Sonarr, inst: "", excluded: true},
+		{name: "named dialect still matches", app: starr.Sonarr, inst: "TV", excluded: true},
+		{name: "instance name", app: starr.Radarr, inst: "Sportarr", excluded: true},
+		{name: "name case", app: starr.Radarr, inst: "sportarr", excluded: true},
+		{name: "other app", app: starr.Lidarr, inst: "Music", excluded: false},
+		{name: "empty exclude name", app: starr.Radarr, inst: "", excluded: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := hook.Excluded(test.app, test.inst); got != test.excluded {
+				t.Fatalf("Excluded(%s, %q) = %v, want %v", test.app, test.inst, got, test.excluded)
+			}
+		})
+	}
+}

--- a/pkg/hooks/templates.go
+++ b/pkg/hooks/templates.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/url"
 	"os"
 	"strings"
@@ -51,7 +52,7 @@ type XtractPayload struct {
 // when not using discord.com (below), or a custom template file.
 const WebhookTemplateNotifiarr = `{
   "path": {{encode .Path}},
-  "app": "{{.App}}",
+  "app": {{encode .App}},
   "ids": {
     {{$s := separator ",\n"}}{{range $key, $value := .IDs}}{{call $s}}"{{$key}}": {{encode $value}}{{end}}
   },
@@ -82,7 +83,7 @@ const WebhookTemplateTelegram = `{
   "disable_web_page_preview": true,
   "text": "<b><a href=\"https://github.com/Unpackerr/unpackerr/releases\">Unpackerr</a></b>: {{.Event.Desc -}}
     \n<b>Title</b>: {{rawencode (index .IDs "title") -}}
-    \n<b>App</b>: {{.App -}}
+    \n<b>App</b>: {{htmlencode .App -}}
     \n\n<b>Path</b>: <code>{{rawencode .Path}}</code>
   {{- if .Data }}\n
     {{- if .Data.Elapsed.Duration}}\n <b>Elapsed</b>: {{.Data.Elapsed}}{{end -}}
@@ -99,7 +100,8 @@ const WebhookTemplateTelegram = `{
 
 const WebhookTemplateGotify = `{
   "title": "{{if nickname}}{{nickname}}{{else}}Unpackerr{{end}}: {{.Event.Desc}}",
-  "message": "**App**: {{.App}}  \n**Name**: {{rawencode (index .IDs "title")}}  \n**Path**: {{rawencode .Path -}}
+  "message": "**App**: {{rawencode .App}}  \n` +
+	`**Name**: {{rawencode (index .IDs "title")}}  \n**Path**: {{rawencode .Path -}}
     {{ if .Data.Elapsed.Duration }}  \n**Elapsed**: {{.Data.Elapsed}}{{end -}}
     {{ if .Data.Archives }}  \n**RARs**: {{len .Data.Archives}}{{end -}}
     {{ if .Data.Files }}  \n**Files**: {{len .Data.Files}}{{end -}}
@@ -140,7 +142,7 @@ const WebhookTemplateDiscord = `{
             {{- else}}16711695{{end}},
     "fields": [
      {"name": "Path", "value": {{encode .Path}}, "inline": false},
-     {"name": "App", "value": "{{.App}}", "inline": true}{{ if .Data }}
+     {"name": "App", "value": {{encode .App}}, "inline": true}{{ if .Data }}
      {{ if .Data.Archives}},{"name": "Archives", "value": "{{len .Data.Archives}}", "inline": true}
      {{end -}}
      {{ if .Data.Elapsed.Duration}},{"name": "Elapsed", "value": "{{.Data.Elapsed}}", "inline": true}
@@ -163,7 +165,7 @@ const WebhookTemplateDiscord = `{
 `
 
 const WebhookTemplatePushover = `token={{token}}&user={{channel}}&html=1&title={{formencode .Event.Desc}}&` +
-	`{{if nickname}}device={{nickname}}&{{end}}message=<pre><b>App</b>: {{.App}}
+	`{{if nickname}}device={{nickname}}&{{end}}message=<pre><b>App</b>: {{formencode (htmlencode .App)}}
 <b>Name</b>: {{formencode (index .IDs "title")}}
 <b>Path</b>: {{formencode .Path}}
 {{ if .Data -}}
@@ -217,7 +219,7 @@ const WebhookTemplateSlack = `
         },
         {
           "type": "mrkdwn",
-          "text": "*App*\n{{.App}}"
+          "text": {{encode (print "*App*\n" .App)}}
         }{{ if .Data }}
         {{ if .Data.Bytes }},{
           "type": "mrkdwn",
@@ -258,7 +260,8 @@ func (w *Config) Template() (*template.Template, error) {
 	template := template.New("webhook").Funcs(template.FuncMap{
 		"encode":     func(v any) string { b, _ := json.Marshal(v); return string(b) },
 		"rawencode":  func(v any) string { b, _ := json.Marshal(v); return strings.Trim(string(b), `"`) }, // yuck
-		"formencode": url.QueryEscape,
+		"formencode": func(v any) string { return url.QueryEscape(fmt.Sprint(v)) },
+		"htmlencode": func(v any) string { return html.EscapeString(fmt.Sprint(v)) },
 		"separator":  separator,
 		"humanbytes": humanbytes,
 		"nickname":   func() string { return w.Nickname },

--- a/pkg/hooks/templates_test.go
+++ b/pkg/hooks/templates_test.go
@@ -1,0 +1,108 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Unpackerr/unpackerr/pkg/extract"
+	"golift.io/starr"
+)
+
+func TestBuiltinTemplatesEncodeApp(t *testing.T) {
+	t.Parallel()
+
+	const app = "Sports & News+"
+
+	payload := &Payload{
+		Path:  "/dl/show",
+		App:   starr.App(app),
+		IDs:   map[string]any{"title": "Episode"},
+		Event: extract.EXTRACTED,
+		Time:  time.Unix(0, 0).UTC(),
+		Data:  &XtractPayload{},
+	}
+
+	for _, name := range []string{"notifiarr", "discord", "telegram", "slack", "pushover", "gotify"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			body := renderHookTemplate(t, name, payload)
+
+			switch name {
+			case "pushover":
+				assertPushoverApp(t, body, app)
+			case "telegram":
+				if strings.Contains(body, app) {
+					t.Fatalf("telegram HTML left %q unescaped", app)
+				}
+
+				if !strings.Contains(body, "Sports &amp; News+") {
+					t.Fatalf("telegram missing html-escaped app:\n%s", body)
+				}
+			default:
+				assertJSONApp(t, name, body, app)
+			}
+		})
+	}
+}
+
+func renderHookTemplate(t *testing.T, name string, payload *Payload) string {
+	t.Helper()
+
+	tmpl, err := (&Config{
+		TempName: name,
+		Nickname: "bot",
+		Token:    "tok",
+		Channel:  "chan",
+	}).Template()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, payload); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.String()
+}
+
+func assertPushoverApp(t *testing.T, body, app string) {
+	t.Helper()
+
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := values.Get("message")
+	if msg == "" {
+		t.Fatalf("pushover message empty; keys=%v body=%q", values, body)
+	}
+
+	if strings.Contains(msg, app) {
+		t.Fatalf("pushover HTML left %q unescaped: %q", app, msg)
+	}
+
+	if !strings.Contains(msg, "Sports &amp; News+") {
+		t.Fatalf("pushover missing html-escaped app: %q", msg)
+	}
+}
+
+func assertJSONApp(t *testing.T, name, body, app string) {
+	t.Helper()
+
+	var parsed any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("%s invalid json: %v\n%s", name, err, body)
+	}
+
+	if !strings.Contains(fmt.Sprint(parsed), app) {
+		t.Fatalf("%s missing app %q:\n%s", name, app, body)
+	}
+}

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -151,6 +151,13 @@ func (u *Unpackerr) validateApps() error {
 		}
 	}
 
+	seen := make(map[string]string)
+	warnDuplicateStarrNames(u, seen, starr.Lidarr, u.Lidarr)
+	warnDuplicateStarrNames(u, seen, starr.Radarr, u.Radarr)
+	warnDuplicateStarrNames(u, seen, starr.Readarr, u.Readarr)
+	warnDuplicateStarrNames(u, seen, starr.Sonarr, u.Sonarr)
+	warnDuplicateStarrNames(u, seen, starr.Whisparr, u.Whisparr)
+
 	for _, validate := range []func() error{
 		u.validateCmdhook,
 		u.validateWebhook,

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"golift.io/cnfg"
 	"golift.io/starr"
@@ -27,6 +28,8 @@ const (
 	// always processed regardless of which Starr app version is in use.
 	defaultProtocol = "torrent,TorrentDownloadProtocol"
 	apiKeyMinLength = 32
+	// Quotes, braces, and similar break unescaped {{.App}} in webhook JSON templates.
+	starrNameMeta = "\"'`\\{}<>"
 )
 
 // These are the names used to identify each app.
@@ -36,9 +39,20 @@ const (
 
 // Application validation errors.
 var (
-	ErrInvalidURL = errors.New("provided application URL is invalid")
-	ErrInvalidKey = fmt.Errorf("provided application API Key is invalid, must be at least %d characters", apiKeyMinLength)
+	ErrInvalidURL  = errors.New("provided application URL is invalid")
+	ErrInvalidKey  = fmt.Errorf("provided application API Key is invalid, must be at least %d characters", apiKeyMinLength)
+	ErrInvalidName = errors.New("instance name must be printable and cannot contain quotes, braces, or angle brackets")
 )
+
+func checkStarrName(name string) error {
+	for _, r := range name {
+		if !unicode.IsPrint(r) || strings.ContainsRune(starrNameMeta, r) {
+			return ErrInvalidName
+		}
+	}
+
+	return nil
+}
 
 // skipInvalidApp reports whether a Starr instance should be dropped at
 // startup (missing/short URL or API key) rather than aborting the process.

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -453,26 +453,14 @@ func expandHomedir(filePath string) string {
 func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 	conf.Name = strings.TrimSpace(conf.Name)
 
-	if conf.URL == "" {
-		u.Errorf("Missing %s URL in one of your configurations, skipped and ignored.", app)
-		return ErrInvalidURL // this error is not printed.
+	if err := checkStarrName(conf.Name); err != nil {
+		return fmt.Errorf("%s name %q: %w", app, conf.Name, err)
 	}
 
-	if conf.APIKey == "" {
-		u.Errorf("Missing %s API Key in one of your configurations, skipped and ignored.", app)
-		return ErrInvalidKey // this error is not printed at startup; PUT returns it.
-	}
+	label := conf.Label(app)
 
-	if !strings.HasPrefix(conf.URL, "http://") && !strings.HasPrefix(conf.URL, "https://") {
-		return fmt.Errorf("%w: (%s) %s", ErrInvalidURL, app, conf.URL)
-	}
-
-	if len(conf.APIKey) < apiKeyMinLength {
-		u.Errorf("%s (%s) API Key is too short (%d < %d), skipped and ignored.",
-			app, conf.URL, len(conf.APIKey), apiKeyMinLength)
-
-		return fmt.Errorf("%s (%s) %w, your key length: %d",
-			app, conf.URL, ErrInvalidKey, len(conf.APIKey))
+	if err := u.requireStarrAccess(conf, label); err != nil {
+		return err
 	}
 
 	if conf.Timeout.Duration == 0 {
@@ -500,7 +488,7 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 	}
 
 	if err := conf.applyMaxBytes(app); err != nil {
-		return fmt.Errorf("%s (%s) %w", app, conf.URL, err)
+		return fmt.Errorf("%s (%s) %w", label, conf.URL, err)
 	}
 
 	conf.Client = &http.Client{
@@ -508,6 +496,32 @@ func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !conf.ValidSSL}, //nolint:gosec
 		},
+	}
+
+	return nil
+}
+
+func (u *Unpackerr) requireStarrAccess(conf *StarrConfig, label string) error {
+	if conf.URL == "" {
+		u.Errorf("Missing %s URL in one of your configurations, skipped and ignored.", label)
+		return ErrInvalidURL // this error is not printed.
+	}
+
+	if conf.APIKey == "" {
+		u.Errorf("Missing %s API Key in one of your configurations, skipped and ignored.", label)
+		return ErrInvalidKey // this error is not printed at startup; PUT returns it.
+	}
+
+	if !strings.HasPrefix(conf.URL, "http://") && !strings.HasPrefix(conf.URL, "https://") {
+		return fmt.Errorf("%w: (%s) %s", ErrInvalidURL, label, conf.URL)
+	}
+
+	if len(conf.APIKey) < apiKeyMinLength {
+		u.Errorf("%s (%s) API Key is too short (%d < %d), skipped and ignored.",
+			label, conf.URL, len(conf.APIKey), apiKeyMinLength)
+
+		return fmt.Errorf("%s (%s) %w, your key length: %d",
+			label, conf.URL, ErrInvalidKey, len(conf.APIKey))
 	}
 
 	return nil

--- a/pkg/unpackerr/cnfgfile.go
+++ b/pkg/unpackerr/cnfgfile.go
@@ -451,6 +451,8 @@ func expandHomedir(filePath string) string {
 }
 
 func (u *Unpackerr) validateApp(conf *StarrConfig, app starr.App) error {
+	conf.Name = strings.TrimSpace(conf.Name)
+
 	if conf.URL == "" {
 		u.Errorf("Missing %s URL in one of your configurations, skipped and ignored.", app)
 		return ErrInvalidURL // this error is not printed.

--- a/pkg/unpackerr/cnfgfile_test.go
+++ b/pkg/unpackerr/cnfgfile_test.go
@@ -2,6 +2,7 @@ package unpackerr
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -674,5 +675,83 @@ func TestValidateSonarrSkipsShortAPIKey(t *testing.T) {
 
 	if len(unpack.Sonarr) != 0 {
 		t.Fatalf("short key must skip, got %d", len(unpack.Sonarr))
+	}
+}
+
+func TestCheckStarrName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", "Sportarr", "Sonarr 4K", "Fightarr-2"} {
+		if err := checkStarrName(name); err != nil {
+			t.Fatalf("%q: %v", name, err)
+		}
+	}
+
+	for _, name := range []string{
+		`Sport"arr`,
+		"Sport'arr",
+		"Sport`arr",
+		`Sport\arr`,
+		"Sport{arr}",
+		"Sport<arr>",
+		"Sport\narr",
+	} {
+		if err := checkStarrName(name); !errors.Is(err, ErrInvalidName) {
+			t.Fatalf("%q: got %v want ErrInvalidName", name, err)
+		}
+	}
+}
+
+func TestValidateAppUsesInstanceLabel(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	key := strings.Repeat("a", apiKeyMinLength)
+
+	conf := &StarrConfig{Name: "Sportarr"}
+	conf.URL = "ftp://127.0.0.1:8989"
+	conf.APIKey = key
+
+	err := unpack.validateApp(conf, starr.Sonarr)
+	if err == nil || !strings.Contains(err.Error(), "Sportarr") {
+		t.Fatalf("invalid URL: %v", err)
+	}
+
+	conf = &StarrConfig{Name: "Sportarr"}
+	conf.URL = "http://127.0.0.1:8989"
+	conf.APIKey = "short"
+
+	err = unpack.validateApp(conf, starr.Sonarr)
+	if err == nil || !strings.Contains(err.Error(), "Sportarr") {
+		t.Fatalf("short key: %v", err)
+	}
+
+	conf = &StarrConfig{Name: "Sportarr", MaxBytes: "nope"}
+	conf.URL = "http://127.0.0.1:8989"
+	conf.APIKey = key
+
+	err = unpack.validateApp(conf, starr.Sonarr)
+	if err == nil || !strings.Contains(err.Error(), "Sportarr") {
+		t.Fatalf("max bytes: %v", err)
+	}
+}
+
+func TestValidateStarrListRejectsBadName(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{
+		Name:   `Sport"arr`,
+		URL:    "http://127.0.0.1:8989",
+		APIKey: strings.Repeat("a", apiKeyMinLength),
+	}}
+
+	err := validateStarrList(unpack, &unpack.Sonarr, starr.Sonarr)
+	if !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("got %v want ErrInvalidName", err)
+	}
+
+	if len(unpack.Sonarr) != 1 {
+		t.Fatalf("bad name must not skip the instance, got %d", len(unpack.Sonarr))
 	}
 }

--- a/pkg/unpackerr/configdump.go
+++ b/pkg/unpackerr/configdump.go
@@ -130,8 +130,8 @@ func logStarr[T any, P starrApp[T]](printf configLine, app starr.App, list []P) 
 	if count == 1 {
 		item := list[0]
 		c := item.conf()
-		printf(" => %s Config: 1 server: "+starrLogLine+"%s",
-			app, c.URL, c.APIKey != "", c.Timeout.String(),
+		printf(" => %s Config: 1 server: %s"+starrLogLine+"%s",
+			app, starrNamePrefix(c.Name), c.URL, c.APIKey != "", c.Timeout.String(),
 			c.ValidSSL, c.Protocols, c.Syncthing,
 			c.DeleteOrig, c.DeleteDelay.String(),
 			logMaxBytes(c.MaxBytes, defaultAppMaxBytes(app)), c.Paths, item.logExtra())
@@ -143,11 +143,20 @@ func logStarr[T any, P starrApp[T]](printf configLine, app starr.App, list []P) 
 
 	for _, item := range list {
 		c := item.conf()
-		printf(starrLogPfx+starrLogLine+"%s",
+		printf(starrLogPfx+"%s"+starrLogLine+"%s",
+			starrNamePrefix(c.Name),
 			c.URL, c.APIKey != "", c.Timeout.String(), c.ValidSSL, c.Protocols,
 			c.Syncthing, c.DeleteOrig, c.DeleteDelay.String(),
 			logMaxBytes(c.MaxBytes, defaultAppMaxBytes(app)), c.Paths, item.logExtra())
 	}
+}
+
+func starrNamePrefix(name string) string {
+	if name = strings.TrimSpace(name); name == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("name:%q, ", name)
 }
 
 // logMaxBytes prints the configured size, or fallback when the setting is empty.

--- a/pkg/unpackerr/configdump_test.go
+++ b/pkg/unpackerr/configdump_test.go
@@ -55,7 +55,8 @@ func TestRunningDumpPrintsPerAppMaxBytes(t *testing.T) {
 
 	unpack := testAuthUnpackerr(t)
 	unpack.Sonarr = []*SonarrConfig{{
-		URL: "http://sonarr.test",
+		URL:  "http://sonarr.test",
+		Name: "Sportarr",
 	}}
 	unpack.Radarr = []*RadarrConfig{{
 		URL:      "http://radarr.test",
@@ -101,6 +102,11 @@ func TestRunningDumpPrintsPerAppMaxBytes(t *testing.T) {
 		if !strings.Contains(line, maxBytes) {
 			t.Errorf("%q: want %q in %q", needle, maxBytes, line)
 		}
+	}
+
+	sonarrLine := dumpLineContaining(got, "http://sonarr.test")
+	if !strings.Contains(sonarrLine, `name:"Sportarr"`) {
+		t.Errorf("named instance missing from dump: %q", sonarrLine)
 	}
 }
 

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -16,6 +16,7 @@ import (
 // StarrConfig is the shared config items for all starr apps.
 type StarrConfig struct {
 	starr.Config
+	Name        string        `json:"name"         toml:"name"         xml:"name"         yaml:"name"`
 	Path        string        `json:"path"         toml:"path"         xml:"path"         yaml:"path"`
 	Paths       StringSlice   `json:"paths"        toml:"paths"        xml:"paths"        yaml:"paths"`
 	Protocols   string        `json:"protocols"    toml:"protocols"    xml:"protocols"    yaml:"protocols"`
@@ -28,6 +29,17 @@ type StarrConfig struct {
 	// Empty uses that default. `0` or `0B` is unlimited.
 	MaxBytes string `json:"maxBytes" toml:"max_bytes" xml:"max_bytes" yaml:"maxBytes"`
 	maxBytes uint64
+}
+
+// Label is the human-facing instance name, or app when Name is empty.
+func (c *StarrConfig) Label(app starr.App) string {
+	if c != nil {
+		if name := strings.TrimSpace(c.Name); name != "" {
+			return name
+		}
+	}
+
+	return string(app)
 }
 
 // checkQueueChanges checks each item for state changes from the app queues.
@@ -45,28 +57,28 @@ func (u *Unpackerr) checkQueueChanges(now time.Time) {
 			case data.Status == WAITING:
 				// A waiting item just fell out of the queue. We never extracted it. Remove it and move on.
 				delete(u.Map, name)
-				u.Printf("[%v] Imported: %v (not extracted, removing from history)", data.App, name)
+				u.Printf("[%v] Imported: %v (not extracted, removing from history)", data.Label(), name)
 			case data.Status > IMPORTED:
 				u.Debugf("Already imported? %s", name)
 			case data.Status == IMPORTED:
 				u.Debugf("%v: Awaiting Delete Delay (%v remains): %v",
-					data.App, data.DeleteDelay-elapsed.Round(time.Second), name)
+					data.Label(), data.DeleteDelay-elapsed.Round(time.Second), name)
 			default:
 				u.updateQueueStatus(&newStatus{Name: name, Status: IMPORTED, Resp: data.Resp}, now, true)
-				u.Printf("[%v] Imported: %v (delete in %v)", data.App, name, data.DeleteDelay)
+				u.Printf("[%v] Imported: %v (delete in %v)", data.Label(), name, data.DeleteDelay)
 			}
 		case data.Status == IMPORTED:
 			// The item fell out of the app queue and came back. Reset it.
-			u.Printf("%s: Extraction Not Imported: %s - De-queued and returned.", data.App, name)
+			u.Printf("%s: Extraction Not Imported: %s - De-queued and returned.", data.Label(), name)
 			data.Status = EXTRACTED
 		case data.Status > IMPORTED:
 			// The item fell out of the app queue and came back. Reset it.
-			u.Printf("%s: Extraction Restarting: %s - Deleted Item De-queued and returned.", data.App, name)
+			u.Printf("%s: Extraction Restarting: %s - Deleted Item De-queued and returned.", data.Label(), name)
 			data.Status = WAITING
 			data.Updated = now
 		}
 
-		u.Printf("[%s] Status: %s (%v, elapsed: %v) %s", data.App, name, data.Status.Desc(),
+		u.Printf("[%s] Status: %s (%v, elapsed: %v) %s", data.Label(), name, data.Status.Desc(),
 			now.Sub(data.Updated).Round(time.Second), data.XProg)
 	}
 }
@@ -100,7 +112,7 @@ func (u *Unpackerr) extractCompletedDownloads(now time.Time) {
 // This is called by extractCompletedDownloads() via the main routine in start.go.
 func (u *Unpackerr) extractCompletedDownload(name string, now time.Time, item *Extract) {
 	if d := u.StartDelay.Duration - now.Sub(item.Updated); d > time.Second { // wiggle room.
-		u.Printf("[%s] Waiting for Start Delay: %v (%v remains)", item.App, name, d.Round(time.Second))
+		u.Printf("[%s] Waiting for Start Delay: %v (%v remains)", item.Label(), name, d.Round(time.Second))
 		return
 	}
 
@@ -108,10 +120,10 @@ func (u *Unpackerr) extractCompletedDownload(name string, now time.Time, item *E
 	if len(files) == 0 {
 		if _, err := os.Stat(item.Path); err != nil {
 			u.Printf("[%s] Completed item still waiting: %s, no extractable files found at: %s (stat err: %v)",
-				item.App, name, item.Path, err)
+				item.Label(), name, item.Path, err)
 		} else {
 			u.Printf("[%s] Completed item still waiting: %s, no extractable files found at: %s (%s Activity Queue status: %v)",
-				item.App, name, item.Path, item.App, item.IDs["reason"])
+				item.Label(), name, item.Path, item.Label(), item.IDs["reason"])
 		}
 
 		return
@@ -119,7 +131,7 @@ func (u *Unpackerr) extractCompletedDownload(name string, now time.Time, item *E
 
 	if item.Syncthing {
 		if tmpFile := u.hasSyncThingFile(item.Path); tmpFile != "" {
-			u.Printf("[%s] Completed item still syncing: %s, found Syncthing .tmp file: %s", item.App, name, tmpFile)
+			u.Printf("[%s] Completed item still syncing: %s, found Syncthing .tmp file: %s", item.Label(), name, tmpFile)
 			return
 		}
 	}
@@ -160,7 +172,7 @@ func (u *Unpackerr) markItemQueued(item *Extract, snap map[string]os.FileInfo, s
 	defer u.unlockHistory()
 
 	if snapErr != nil {
-		u.Errorf("[%s] Snapshot dests for remnant check: %v", item.App, snapErr)
+		u.Errorf("[%s] Snapshot dests for remnant check: %v", item.Label(), snapErr)
 	} else {
 		item.PreFiles = snap
 	}
@@ -176,8 +188,8 @@ func (u *Unpackerr) logQueuedDownload(queueSize int, item *Extract, files xtract
 	}
 
 	u.Printf("[%s] Extraction Queued: %s, retries: %d, %s, delete orig: %v, queue size: %d",
-		item.App, item.Path, item.Retries, count, item.DeleteOrig, queueSize)
-	u.updateHistory(string(item.App) + ": " + item.Path)
+		item.Label(), item.Path, item.Retries, count, item.DeleteOrig, queueSize)
+	u.updateHistory(item.Label() + ": " + item.Path)
 }
 
 func (u *Unpackerr) getPasswordFromPath(path string) string {
@@ -207,7 +219,7 @@ func (u *Unpackerr) checkExtractDone(now time.Time) {
 			// Remove the item from history some time after it's deleted.
 			u.Finished++
 			delete(u.Map, name)
-			u.Printf("[%s] Finished, Removed History: %v", item.App, name)
+			u.Printf("[%s] Finished, Removed History: %v", item.Label(), name)
 		case item.App == FolderString:
 			continue // folders are handled in folder.go.
 		case item.Status == EXTRACTFAILED && item.NoRetry:
@@ -220,21 +232,21 @@ func (u *Unpackerr) checkExtractDone(now time.Time) {
 			item.Status = WAITING
 			item.Updated = now
 			u.Printf("[%s] Extract failed %v ago, triggering restart (%d/%d): %v",
-				item.App, elapsed.Round(time.Second), item.Retries, u.maxRetries(), name)
+				item.Label(), elapsed.Round(time.Second), item.Retries, u.maxRetries(), name)
 		case item.Status == EXTRACTFAILED && item.Retries >= u.maxRetries():
 			// Stay EXTRACTFAILED. DELETED is > IMPORTED, so checkQueueChanges
 			// would bounce a still-completed Starr item back to WAITING.
 			item.NoRetry = true
 			u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTFAILED, Resp: item.Resp}, now, true)
 			u.Printf("[%s] Retries exhausted (%d/%d), giving up: %v",
-				item.App, item.Retries, u.maxRetries(), name)
+				item.Label(), item.Retries, u.maxRetries(), name)
 		case (item.Status == EXTRACTED || item.Status == EXTRACTING || item.Status == QUEUED) &&
 			elapsed >= staleItemTimeout:
 			// Safety net: items stuck at intermediate states for too long are cleaned up
 			// to prevent unbounded map growth (e.g. Starr app never imports the item).
 			u.updateQueueStatus(&newStatus{Name: name, Status: DELETED, Resp: item.Resp}, now, true)
 			u.Printf("[%s] Stale item removed after %v at status %s: %v",
-				item.App, elapsed.Round(time.Second), item.Status.Desc(), name)
+				item.Label(), elapsed.Round(time.Second), item.Status.Desc(), name)
 		case item.Status == IMPORTED && elapsed >= item.DeleteDelay:
 			var webhook bool
 
@@ -310,7 +322,7 @@ func (u *Unpackerr) handleXtractrCallback(resp *xtractr.Response) { //nolint:fun
 		// This case wins over resp.Error, so log a password/corrupt-archive
 		// error here the way the folder callback logs before remnant cleanup.
 		if resp.Error != nil {
-			u.Errorf("[%s] Extraction Failed: %s: %v", item.App, resp.X.Name, resp.Error)
+			u.Errorf("[%s] Extraction Failed: %s: %v", item.Label(), resp.X.Name, resp.Error)
 		}
 
 		u.Retries++
@@ -318,13 +330,13 @@ func (u *Unpackerr) handleXtractrCallback(resp *xtractr.Response) { //nolint:fun
 		item.Status = WAITING
 		item.Updated = now
 		item.Resp = resp
-		u.Printf("[%s] Cleared interrupted-extraction remnant(s), restarting extraction: %s", item.App, resp.X.Name)
+		u.Printf("[%s] Cleared interrupted-extraction remnant(s), restarting extraction: %s", item.Label(), resp.X.Name)
 	case remnants:
 		if remnantAction(u.RemnantAction) == "off" {
 			item.NoRetry = true
 		}
 
-		u.Errorf("[%s] Extraction blocked by interrupted-extraction remnant(s): %s", item.App, resp.X.Name)
+		u.Errorf("[%s] Extraction blocked by interrupted-extraction remnant(s): %s", item.Label(), resp.X.Name)
 		u.updateQueueStatus(&newStatus{Name: resp.X.Name, Status: EXTRACTFAILED, Resp: resp}, now, true)
 	case resp.Error != nil:
 		if xtractr.IsLimitError(resp.Error) {

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -360,7 +360,7 @@ func (u *Unpackerr) handleXtractrCallback(resp *xtractr.Response) { //nolint:fun
 
 // Looking for a message that looks like:
 // "No files found are eligible for import in /downloads/Downloading/Space.Warriors.S99E88.GrOuP.1080p.WEB.x264".
-func (u *Unpackerr) getDownloadPath(outputPath string, app starr.App, title string, paths []string) string {
+func (u *Unpackerr) getDownloadPath(outputPath, label, title string, paths []string) string {
 	var errs []error
 
 	// Try all the user provided paths.
@@ -376,7 +376,7 @@ func (u *Unpackerr) getDownloadPath(outputPath string, app starr.App, title stri
 	}
 
 	// Print the errors for each user-provided path.
-	u.Debugf("%s: Errors encountered looking for %s path: %q", app, title, errs)
+	u.Debugf("%s: Errors encountered looking for %s path: %q", label, title, errs)
 
 	// The title often differs from the actual folder name (e.g. torrent names include genre tags).
 	// Try the folder name from outputPath against configured paths — the folder name is the real
@@ -389,18 +389,18 @@ func (u *Unpackerr) getDownloadPath(outputPath string, app starr.App, title stri
 				candidate := filepath.Join(path, outputFolder)
 
 				if _, err := os.Stat(candidate); err == nil {
-					u.Debugf("%s: Resolved via outputPath folder name: %s -> %s", app, outputPath, candidate)
+					u.Debugf("%s: Resolved via outputPath folder name: %s -> %s", label, outputPath, candidate)
 					return candidate
 				}
 			}
 		}
 
-		u.Debugf("%s: Configured paths do not exist; trying 'outputPath': %s", app, outputPath)
+		u.Debugf("%s: Configured paths do not exist; trying 'outputPath': %s", label, outputPath)
 
 		return outputPath
 	}
 
-	u.Debugf("%s: Configured paths do not exist and 'outputPath' is empty for: %s", app, title)
+	u.Debugf("%s: Configured paths do not exist and 'outputPath' is empty for: %s", label, title)
 
 	return filepath.Join(paths[0], title) // useless, but return something. :(
 }

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -197,7 +197,7 @@ func historyFromExtract(itemID string, item *Extract) HistoryRecord {
 
 	rec := HistoryRecord{
 		ID:         itemID,
-		App:        string(item.App),
+		App:        item.Label(),
 		URL:        item.URL,
 		Path:       item.Path,
 		OutputPath: item.OutputPath,
@@ -334,7 +334,7 @@ func (u *Unpackerr) queueSnapshot() []QueueItem {
 func queueFromExtract(id string, item *Extract) QueueItem {
 	queue := QueueItem{
 		ID:         id,
-		App:        string(item.App),
+		App:        item.Label(),
 		URL:        item.URL,
 		Path:       item.Path,
 		OutputPath: item.OutputPath,

--- a/pkg/unpackerr/metrics.go
+++ b/pkg/unpackerr/metrics.go
@@ -78,9 +78,14 @@ func (u *Unpackerr) updateMetrics(resp *xtractr.Response, app starr.App, url str
 }
 
 // saveQueueMetrics observes metrics for each starr app queue request.
-func (u *Unpackerr) saveQueueMetrics(size int, start time.Time, app starr.App, url string, err error) {
+// app is the dialect for Prometheus labels; label is the human instance name for logs.
+func (u *Unpackerr) saveQueueMetrics(size int, start time.Time, app starr.App, url, label string, err error) {
 	if err != nil {
-		u.Errorf("%s (%s): %v", app, url, err)
+		if label == "" {
+			label = string(app)
+		}
+
+		u.Errorf("%s (%s): %v", label, url, err)
 	}
 
 	if u.metrics == nil {

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -127,7 +127,7 @@
         "type": "object",
         "properties": {
           "id": {"type": "string"},
-          "app": {"type": "string"},
+          "app": {"type": "string", "description": "Instance name when set, otherwise the Starr dialect (Sonarr, Radarr, Folder, …)."},
           "url": {"type": "string"},
           "path": {"type": "string"},
           "outputPath": {"type": "string"},
@@ -142,7 +142,7 @@
         "type": "object",
         "properties": {
           "id": {"type": "string"},
-          "app": {"type": "string"},
+          "app": {"type": "string", "description": "Instance name when set, otherwise the Starr dialect (Sonarr, Radarr, Folder, …)."},
           "url": {"type": "string"},
           "path": {"type": "string"},
           "outputPath": {"type": "string"},

--- a/pkg/unpackerr/progress.go
+++ b/pkg/unpackerr/progress.go
@@ -45,7 +45,7 @@ func (u *Unpackerr) printProgress(now time.Time) {
 		}
 
 		if prog := data.XProg.String(); prog != "no progress yet" {
-			u.Printf("[%s] Status: %s (%v, elapsed: %v) %s", data.App, name, data.Status.Desc(),
+			u.Printf("[%s] Status: %s (%v, elapsed: %v) %s", data.Label(), name, data.Status.Desc(),
 				now.Sub(data.Updated).Round(time.Second), prog)
 		}
 	}

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -72,21 +72,23 @@ func enqueueStarrPoll[T any, P starrApp[T]](
 
 func (u *Unpackerr) getStarrQueue[T any, P starrApp[T]](server P, app starr.App, start time.Time) {
 	cfg := server.conf()
+	label := cfg.Label(app)
+
 	if cfg.APIKey == "" {
-		u.Debugf("%s (%s): skipped, no API key", app, cfg.URL)
+		u.Debugf("%s (%s): skipped, no API key", label, cfg.URL)
 		return
 	}
 
 	total, retrieved, err := server.pollQueue()
 	if err != nil {
-		u.saveQueueMetrics(0, start, app, cfg.URL, err)
+		u.saveQueueMetrics(0, start, app, cfg.URL, label, err)
 		return
 	}
 
-	u.saveQueueMetrics(total, start, app, cfg.URL, nil)
+	u.saveQueueMetrics(total, start, app, cfg.URL, label, nil)
 
 	if !u.Activity || total > 0 {
-		u.Printf("[%s] Updated (%s): %d Items Queued, %d Retrieved", cfg.Label(app), cfg.URL, total, retrieved)
+		u.Printf("[%s] Updated (%s): %d Items Queued, %d Retrieved", label, cfg.URL, total, retrieved)
 	}
 }
 
@@ -99,7 +101,7 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 
 		for _, rec := range server.queueViews() {
 			item, found := unpack.Map[rec.Title]
-			if found {
+			if found && item.App == app && item.URL == cfg.URL {
 				item.Name = cfg.Name
 			}
 
@@ -117,7 +119,7 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 					DeleteDelay: cfg.DeleteDelay.Duration,
 					Syncthing:   cfg.Syncthing,
 					MaxBytes:    cfg.maxBytes,
-					Path:        unpack.getDownloadPath(rec.OutputPath, app, rec.Title, cfg.Paths),
+					Path:        unpack.getDownloadPath(rec.OutputPath, cfg.Label(app), rec.Title, cfg.Paths),
 					IDs:         rec.IDs,
 				}
 				waiting.XProg = &ExtractProgress{Extract: waiting}

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -1,6 +1,8 @@
 package unpackerr
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,6 +39,27 @@ func validateStarrList[T any, P starrApp[T]](unpack *Unpackerr, list *[]P, app s
 	return nil
 }
 
+func warnDuplicateStarrNames[T any, P starrApp[T]](unpack *Unpackerr, seen map[string]string, app starr.App, list []P) {
+	for _, item := range list {
+		c := item.conf()
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			continue
+		}
+
+		key := strings.ToLower(name)
+		loc := fmt.Sprintf("%s (%s)", app, c.URL)
+
+		if prev, ok := seen[key]; ok {
+			unpack.Errorf("Config Warning: duplicate Starr instance name %q on %s and %s; hook exclude cannot tell them apart",
+				name, prev, loc)
+			continue
+		}
+
+		seen[key] = loc
+	}
+}
+
 func enqueueStarrPoll[T any, P starrApp[T]](
 	unpack *Unpackerr, list []P, app starr.App, start time.Time, wait *sync.WaitGroup,
 ) {
@@ -61,7 +84,7 @@ func (u *Unpackerr) getStarrQueue[T any, P starrApp[T]](server P, app starr.App,
 	u.saveQueueMetrics(total, start, app, cfg.URL, nil)
 
 	if !u.Activity || total > 0 {
-		u.Printf("[%s] Updated (%s): %d Items Queued, %d Retrieved", app, cfg.URL, total, retrieved)
+		u.Printf("[%s] Updated (%s): %d Items Queued, %d Retrieved", cfg.Label(app), cfg.URL, total, retrieved)
 	}
 }
 
@@ -73,12 +96,18 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 		cfg := server.conf()
 
 		for _, rec := range server.queueViews() {
-			switch item, ok := unpack.Map[rec.Title]; {
+			item, ok := unpack.Map[rec.Title]
+			if ok {
+				item.Name = cfg.Name
+			}
+
+			switch {
 			case ok && item.Status == EXTRACTED && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols):
-				unpack.Debugf("%s (%s): Item Waiting for Import (%s): %v", app, cfg.URL, rec.Protocol, rec.Title)
+				unpack.Debugf("%s (%s): Item Waiting for Import (%s): %v", cfg.Label(app), cfg.URL, rec.Protocol, rec.Title)
 			case !ok && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
 				waiting := &Extract{
 					App:         app,
+					Name:        cfg.Name,
 					URL:         cfg.URL,
 					Updated:     now,
 					Status:      WAITING,
@@ -96,7 +125,7 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 				fallthrough
 			default:
 				unpack.Debugf("%s (%s): %s (%s:%d%%): %v%s",
-					app, cfg.URL, rec.Status, rec.Protocol,
+					cfg.Label(app), cfg.URL, rec.Status, rec.Protocol,
 					percent(rec.Sizeleft, rec.Size), rec.Title, rec.DebugExtra)
 			}
 		}

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -41,18 +41,20 @@ func validateStarrList[T any, P starrApp[T]](unpack *Unpackerr, list *[]P, app s
 
 func warnDuplicateStarrNames[T any, P starrApp[T]](unpack *Unpackerr, seen map[string]string, app starr.App, list []P) {
 	for _, item := range list {
-		c := item.conf()
-		name := strings.TrimSpace(c.Name)
+		cfg := item.conf()
+		name := strings.TrimSpace(cfg.Name)
+
 		if name == "" {
 			continue
 		}
 
 		key := strings.ToLower(name)
-		loc := fmt.Sprintf("%s (%s)", app, c.URL)
+		loc := fmt.Sprintf("%s (%s)", app, cfg.URL)
 
 		if prev, ok := seen[key]; ok {
 			unpack.Errorf("Config Warning: duplicate Starr instance name %q on %s and %s; hook exclude cannot tell them apart",
 				name, prev, loc)
+
 			continue
 		}
 
@@ -96,15 +98,15 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 		cfg := server.conf()
 
 		for _, rec := range server.queueViews() {
-			item, ok := unpack.Map[rec.Title]
-			if ok {
+			item, found := unpack.Map[rec.Title]
+			if found {
 				item.Name = cfg.Name
 			}
 
 			switch {
-			case ok && item.Status == EXTRACTED && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols):
+			case found && item.Status == EXTRACTED && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols):
 				unpack.Debugf("%s (%s): Item Waiting for Import (%s): %v", cfg.Label(app), cfg.URL, rec.Protocol, rec.Title)
-			case !ok && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
+			case !found && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
 				waiting := &Extract{
 					App:         app,
 					Name:        cfg.Name,

--- a/pkg/unpackerr/starrpoll_test.go
+++ b/pkg/unpackerr/starrpoll_test.go
@@ -120,11 +120,9 @@ func TestCheckStarrQueueSetsName(t *testing.T) {
 
 	unpack := New()
 	unpack.Sonarr = []*SonarrConfig{{
-		StarrConfig: StarrConfig{
-			Name:      "Sportarr",
-			Protocols: defaultProtocol,
-			Paths:     StringSlice{mappedRoot},
-		},
+		Name:      "Sportarr",
+		Protocols: defaultProtocol,
+		Paths:     StringSlice{mappedRoot},
 		Queue: &sonarr.Queue{Records: []*sonarr.QueueRecord{{
 			Title:    title,
 			Status:   "completed",

--- a/pkg/unpackerr/starrpoll_test.go
+++ b/pkg/unpackerr/starrpoll_test.go
@@ -105,3 +105,69 @@ func TestCheckStarrQueueLidarrTweak(t *testing.T) {
 		t.Fatalf("Path: got %q want mapped %q", item.Path, mappedPath)
 	}
 }
+
+func TestCheckStarrQueueSetsName(t *testing.T) {
+	t.Parallel()
+
+	const title = "Show"
+
+	mappedRoot := t.TempDir()
+	mappedPath := filepath.Join(mappedRoot, title)
+
+	if err := os.Mkdir(mappedPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{
+		StarrConfig: StarrConfig{
+			Name:      "Sportarr",
+			Protocols: defaultProtocol,
+			Paths:     StringSlice{mappedRoot},
+		},
+		Queue: &sonarr.Queue{Records: []*sonarr.QueueRecord{{
+			Title:    title,
+			Status:   "completed",
+			Protocol: starr.Protocol("torrent"),
+		}}},
+	}}
+
+	checkStarrQueue(unpack, unpack.Sonarr, starr.Sonarr, time.Now())
+
+	item, ok := unpack.Map[title]
+	if !ok {
+		t.Fatal("expected Sonarr queue item in extract map")
+	}
+
+	if item.App != starr.Sonarr {
+		t.Fatalf("App: got %q want %s", item.App, starr.Sonarr)
+	}
+
+	if item.Name != "Sportarr" {
+		t.Fatalf("Name: got %q want Sportarr", item.Name)
+	}
+
+	if item.Label() != "Sportarr" {
+		t.Fatalf("Label: got %q want Sportarr", item.Label())
+	}
+
+	unpack.Sonarr[0].Name = "Fightarr"
+	checkStarrQueue(unpack, unpack.Sonarr, starr.Sonarr, time.Now())
+
+	if unpack.Map[title].Name != "Fightarr" {
+		t.Fatalf("Name after rename: got %q want Fightarr", unpack.Map[title].Name)
+	}
+}
+
+func TestStarrConfigLabel(t *testing.T) {
+	t.Parallel()
+
+	if got := (*StarrConfig)(nil).Label(starr.Sonarr); got != string(starr.Sonarr) {
+		t.Fatalf("nil Label: %q", got)
+	}
+
+	cfg := &StarrConfig{Name: "  Sportarr "}
+	if got := cfg.Label(starr.Sonarr); got != "Sportarr" {
+		t.Fatalf("named Label: %q", got)
+	}
+}

--- a/pkg/unpackerr/starrpoll_test.go
+++ b/pkg/unpackerr/starrpoll_test.go
@@ -157,6 +157,35 @@ func TestCheckStarrQueueSetsName(t *testing.T) {
 	}
 }
 
+func TestCheckStarrQueueKeepsForeignName(t *testing.T) {
+	t.Parallel()
+
+	const title = "Show"
+
+	unpack := New()
+	unpack.Map[title] = &Extract{
+		App:  starr.Radarr,
+		Name: "Movies",
+		URL:  "http://radarr:7878",
+	}
+	unpack.Sonarr = []*SonarrConfig{{
+		Name:      "Sportarr",
+		URL:       "http://sonarr:8989",
+		Protocols: defaultProtocol,
+		Queue: &sonarr.Queue{Records: []*sonarr.QueueRecord{{
+			Title:    title,
+			Status:   "downloading",
+			Protocol: starr.Protocol("torrent"),
+		}}},
+	}}
+
+	checkStarrQueue(unpack, unpack.Sonarr, starr.Sonarr, time.Now())
+
+	if unpack.Map[title].Name != "Movies" {
+		t.Fatalf("Name: got %q want Movies", unpack.Map[title].Name)
+	}
+}
+
 func TestStarrConfigLabel(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Unpackerr/unpackerr/pkg/extract"
 	"github.com/Unpackerr/unpackerr/pkg/hooks"
 	"golift.io/cnfg"
+	"golift.io/starr"
 	"golift.io/version"
 )
 
@@ -18,13 +19,13 @@ func (u *Unpackerr) runAllHooks(item *Extract) {
 	payload := hookPayload(item)
 
 	for _, hook := range u.hookList() {
-		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
+		if hook.HasEvent(item.Status) && !hook.Excluded(item.App, item.Name) {
 			u.queueHook(&hooks.Item{Config: hook, Payload: payload})
 		}
 	}
 
 	for _, hook := range u.cmdhookList() {
-		if hook.HasEvent(item.Status) && !hook.Excluded(item.App) {
+		if hook.HasEvent(item.Status) && !hook.Excluded(item.App, item.Name) {
 			u.queueHook(&hooks.Item{Config: hook, Payload: payload})
 		}
 	}
@@ -33,7 +34,7 @@ func (u *Unpackerr) runAllHooks(item *Extract) {
 func hookPayload(item *Extract) *hooks.Payload {
 	payload := &hooks.Payload{
 		Path:  item.Path,
-		App:   item.App,
+		App:   starr.App(item.Label()),
 		IDs:   item.IDs,
 		Time:  item.Updated,
 		Data:  nil,

--- a/pkg/unpackerr/webhook_test.go
+++ b/pkg/unpackerr/webhook_test.go
@@ -1,0 +1,21 @@
+package unpackerr
+
+import (
+	"testing"
+
+	"golift.io/starr"
+)
+
+func TestHookPayloadUsesLabel(t *testing.T) {
+	t.Parallel()
+
+	payload := hookPayload(&Extract{App: starr.Sonarr, Name: "Sportarr", Path: "/dl"})
+	if payload.App != "Sportarr" {
+		t.Fatalf("payload.App = %q, want Sportarr", payload.App)
+	}
+
+	plain := hookPayload(&Extract{App: starr.Sonarr, Path: "/dl"})
+	if plain.App != starr.Sonarr {
+		t.Fatalf("unnamed payload.App = %q, want %s", plain.App, starr.Sonarr)
+	}
+}


### PR DESCRIPTION
## Summary
- Optional `name` on each Starr instance so Sonarr-compatible apps (Sportarr, Fightarr, …) can keep using `[[sonarr]]` while logs, webhooks, queue/history JSON, and the dashboard show a human label instead of the dialect.
- Hook `exclude` matches the dialect **or** the instance name (case-insensitive): `sonarr` still silences every Sonarr-style instance; `Sportarr` silences only that name. Duplicate names warn at startup and do not fail.
- `Extract.App` stays the dialect for queue matching, Lidarr split-flac, max-bytes, and Prometheus. Metrics do not gain a `name` label.
- This is the alternative to adding Sportarr as a first-class app.
- Closes #647.

## Test plan
- [ ] Set `name = "Sportarr"` on a `[[sonarr]]` instance and confirm logs, webhook `app`, and queue/history JSON use `Sportarr` instead of `Sonarr`.
- [ ] Hook `exclude = ["sonarr"]` skips that named instance; `exclude = ["Sportarr"]` skips only that name and still fires for an unnamed Sonarr.
- [ ] Empty `name` keeps today’s dialect strings everywhere.
- [ ] Two instances with the same name log a config warning and still start.


Made with [Cursor](https://cursor.com)