### PR TITLE
Fix folder watcher dest re-extract and waiting queue

### DIFF
--- a/pkg/folders/folder_test.go
+++ b/pkg/folders/folder_test.go
@@ -256,6 +256,38 @@ func TestFoldersIgnoreExtractDestSiblingArchive(t *testing.T) {
 	}
 }
 
+func TestFoldersUntrackExtractDestAfterSiblingAppears(t *testing.T) {
+	t.Parallel()
+
+	watchPath := t.TempDir()
+	cfg := &FolderConfig{Path: watchPath}
+	tracker := newTestFolders(t, cfg)
+	tracker.IgnoreSuffix = "_unpackerred"
+
+	dest := filepath.Join(watchPath, "Win10")
+	if err := os.Mkdir(dest, 0o700); err != nil {
+		t.Fatalf("creating dest: %v", err)
+	}
+
+	now := time.Now()
+	tracker.ProcessEvent(&Event{Config: cfg, Name: "Win10", File: dest, Op: "test"}, now)
+
+	if _, ok := tracker.Folders[dest]; !ok {
+		t.Fatalf("expected dest to be tracked before sibling archive: %s", dest)
+	}
+
+	iso := filepath.Join(watchPath, "Win10.iso")
+	if err := os.WriteFile(iso, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating sibling iso: %v", err)
+	}
+
+	tracker.ProcessEvent(&Event{Config: cfg, Name: "Win10", File: dest, Op: "write"}, now.Add(time.Second))
+
+	if _, ok := tracker.Folders[dest]; ok {
+		t.Fatalf("expected dest to be untracked after sibling archive appeared: %s", dest)
+	}
+}
+
 func TestFoldersHandleFileEventIgnoreExtractSuffixNested(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/folders/folder_test.go
+++ b/pkg/folders/folder_test.go
@@ -180,6 +180,121 @@ func TestFoldersHandleFileEventExcludedPath(t *testing.T) {
 	}
 }
 
+func TestFoldersIgnoreExtractDestLogFile(t *testing.T) {
+	t.Parallel()
+
+	watchPath := t.TempDir()
+	cfg := &FolderConfig{Path: watchPath}
+	tracker := newTestFolders(t, cfg)
+	tracker.IgnoreSuffix = "_unpackerred"
+
+	dest := filepath.Join(watchPath, "Win10")
+	if err := os.Mkdir(dest, 0o700); err != nil {
+		t.Fatalf("creating extract dest: %v", err)
+	}
+
+	logName := filepath.Join(dest, "_unpackerred.Win10.iso.txt")
+	if err := os.WriteFile(logName, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating extract log: %v", err)
+	}
+
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   "Win10",
+		File:   dest,
+		Op:     "test",
+	}, time.Now())
+
+	if _, ok := tracker.Folders[dest]; ok {
+		t.Fatalf("did not expect extract dest to be tracked: %s", dest)
+	}
+}
+
+func TestFoldersIgnoreExtractDestSiblingArchive(t *testing.T) {
+	t.Parallel()
+
+	watchPath := t.TempDir()
+	cfg := &FolderConfig{Path: watchPath}
+	tracker := newTestFolders(t, cfg)
+	tracker.IgnoreSuffix = "_unpackerred"
+
+	iso := filepath.Join(watchPath, "Win10.iso")
+	if err := os.WriteFile(iso, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating sibling iso: %v", err)
+	}
+
+	dest := filepath.Join(watchPath, "Win10")
+	if err := os.Mkdir(dest, 0o700); err != nil {
+		t.Fatalf("creating extract dest: %v", err)
+	}
+
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   "Win10",
+		File:   dest,
+		Op:     "test",
+	}, time.Now())
+
+	if _, ok := tracker.Folders[dest]; ok {
+		t.Fatalf("did not expect sibling-of-archive dest to be tracked: %s", dest)
+	}
+
+	incoming := filepath.Join(watchPath, "incoming")
+	if err := os.Mkdir(incoming, 0o700); err != nil {
+		t.Fatalf("creating incoming dir: %v", err)
+	}
+
+	tracker.ProcessEvent(&Event{
+		Config: cfg,
+		Name:   "incoming",
+		File:   incoming,
+		Op:     "test",
+	}, time.Now())
+
+	if _, ok := tracker.Folders[incoming]; !ok {
+		t.Fatalf("expected unrelated folder to be tracked: %s", incoming)
+	}
+}
+
+func TestFoldersHandleFileEventIgnoreExtractSuffixNested(t *testing.T) {
+	t.Parallel()
+
+	watchPath := t.TempDir()
+	tracker := &Folders{
+		Config:       []*FolderConfig{{Path: watchPath}},
+		Events:       make(chan *Event, 1),
+		Logs:         noopLogger{},
+		IgnoreSuffix: "_unpackerred",
+	}
+
+	nested := filepath.Join(watchPath, "Win10.iso_unpackerred", "autorun.inf")
+	tracker.handleFileEvent(nested, "test")
+
+	select {
+	case event := <-tracker.Events:
+		t.Fatalf("did not expect event for nested extract path: %+v", event)
+	default:
+	}
+}
+
+func TestArchiveStem(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"Win10.iso":    "Win10",
+		"movie.tar.gz": "movie",
+		"show.7z":      "show",
+		"plain":        "plain",
+		"archive.ZIP":  "archive",
+	}
+
+	for name, want := range tests {
+		if got := archiveStem(name); got != want {
+			t.Fatalf("archiveStem(%q)=%q want %q", name, got, want)
+		}
+	}
+}
+
 func newTestFolders(t *testing.T, cfg *FolderConfig) *Folders {
 	t.Helper()
 

--- a/pkg/folders/watch.go
+++ b/pkg/folders/watch.go
@@ -124,7 +124,7 @@ func (f *Folders) WatchFSNotify() {
 }
 
 func (f *Folders) handleFileEvent(name, operation string) {
-	if f.IgnoreSuffix != "" && strings.HasSuffix(name, f.IgnoreSuffix) {
+	if f.ignoredExtractName(name) {
 		return
 	}
 
@@ -183,6 +183,16 @@ func (f *Folders) ProcessEvent(event *Event, now time.Time) {
 		return
 	}
 
+	if f.ignoredExtractName(dirPath) || f.ignoredExtractName(event.File) {
+		f.Debugf("Folder: Ignored File Event (%s) '%s' (extract path)", event.Op, event.File)
+		return
+	}
+
+	if stat.IsDir() && f.isExtractDest(dirPath) {
+		f.Debugf("Folder: Ignored File Event (%s) '%s' (extract output)", event.Op, event.File)
+		return
+	}
+
 	f.saveEvent(event, dirPath, now)
 }
 
@@ -207,4 +217,107 @@ func (f *Folders) saveEvent(event *Event, dirPath string, now time.Time) {
 		Status:  extract.WAITING,
 		Config:  event.Config,
 	}
+}
+
+// ignoredExtractName is true when a path component is the temp extract folder
+// (ends with IgnoreSuffix) or the extract log (_unpackerred.<archive>.txt).
+func (f *Folders) ignoredExtractName(path string) bool {
+	if f == nil || f.IgnoreSuffix == "" || path == "" {
+		return false
+	}
+
+	for {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, f.IgnoreSuffix) || strings.HasPrefix(base, f.IgnoreSuffix+".") {
+			return true
+		}
+
+		next := filepath.Dir(path)
+		if next == path {
+			return false
+		}
+
+		path = next
+	}
+}
+
+// isExtractDest reports whether dir is xtractr output: it has the extract log,
+// or it sits next to an archive whose stem matches the directory name
+// (movie.iso → movie/ after the temp _unpackerred folder is renamed).
+func (f *Folders) isExtractDest(dirPath string) bool {
+	if hasExtractLog(dirPath, f.IgnoreSuffix) {
+		return true
+	}
+
+	return hasSiblingArchiveStem(dirPath)
+}
+
+func hasExtractLog(dirPath, suffix string) bool {
+	if suffix == "" {
+		return false
+	}
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return false
+	}
+
+	prefix := suffix + "."
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if strings.HasPrefix(name, prefix) && strings.HasSuffix(strings.ToLower(name), ".txt") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasSiblingArchiveStem(dirPath string) bool {
+	base := filepath.Base(dirPath)
+	parent := filepath.Dir(dirPath)
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if xtractr.IsArchiveFile(name) && archiveStem(name) == base {
+			return true
+		}
+	}
+
+	return false
+}
+
+// archiveStem strips archive extensions the same way xtractr names the final
+// extract folder (twice, for tar.gz and friends).
+func archiveStem(name string) string {
+	stem := name
+
+	for range 2 {
+		if !xtractr.IsArchiveFile(stem) {
+			break
+		}
+
+		next := strings.TrimSuffix(stem, filepath.Ext(stem))
+		if next == stem {
+			break
+		}
+
+		stem = next
+	}
+
+	return stem
 }

--- a/pkg/folders/watch.go
+++ b/pkg/folders/watch.go
@@ -38,7 +38,7 @@ func (c WatchConfig) NewWatcher(
 	}
 
 	folders.Watcher = watcher.New()
-	folders.Watcher.FilterOps(watcher.Rename, watcher.Move, watcher.Write, watcher.Create)
+	folders.Watcher.FilterOps(watcher.Rename, watcher.Move, watcher.Write, watcher.Create, watcher.Remove)
 	folders.Watcher.IgnoreHiddenFiles(true)
 
 	fsn, err := fsnotify.NewWatcher()
@@ -190,6 +190,13 @@ func (f *Folders) ProcessEvent(event *Event, now time.Time) {
 
 	if stat.IsDir() && f.isExtractDest(dirPath) {
 		f.Debugf("Folder: Ignored File Event (%s) '%s' (extract output)", event.Op, event.File)
+
+		if _, ok := f.Folders[dirPath]; ok {
+			f.Debugf("Folder: Removing Tracked Item: %v", dirPath)
+			delete(f.Folders, dirPath)
+			f.Remove(dirPath)
+		}
+
 		return
 	}
 

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -83,15 +83,7 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	u.folders.Folders[name].Updated = now
 	u.folders.Folders[name].Status = QUEUED
 
-	// Do not extract r00 file if rar file with same name exists.
-	if strings.HasSuffix(strings.ToLower(name), ".r00") &&
-		xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
-		u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
-		u.folders.Folders[name].Status = EXTRACTEDNOTHING
-		u.lockHistory()
-		u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTEDNOTHING}, now, false)
-		u.unlockHistory()
-
+	if u.skipR00Extraction(name, now) {
 		return
 	}
 
@@ -146,6 +138,22 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 	}
 
 	u.Printf("[Folder] Queued: %s, queue size: %d", name, queueSize)
+}
+
+// skipR00Extraction drops a tracked .r00 when a sibling .rar exists (xtractr would extract the rar).
+func (u *Unpackerr) skipR00Extraction(name string, now time.Time) bool {
+	if !strings.HasSuffix(strings.ToLower(name), ".r00") ||
+		!xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
+		return false
+	}
+
+	u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
+	u.folders.Folders[name].Status = EXTRACTEDNOTHING
+	u.lockHistory()
+	u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTEDNOTHING}, now, false)
+	u.unlockHistory()
+
+	return true
 }
 
 // folderExcludeSuffixes returns archive suffixes to ignore when scanning for items to extract.
@@ -356,14 +364,27 @@ func (u *Unpackerr) syncFolderQueue(dirPath string) {
 	item.Updated = folder.Updated
 }
 
+func (u *Unpackerr) checkWaitingFolder(name string, folder *Folder, now time.Time) {
+	if _, err := os.Stat(name); err != nil {
+		delete(u.folders.Folders, name)
+		u.folders.Remove(name)
+		u.syncFolderQueue(name)
+
+		return
+	}
+
+	if now.Sub(folder.Updated) >= u.StartDelay.Duration {
+		u.extractTrackedItem(name, folder, now)
+	}
+}
+
 // checkFolderStats runs at an interval to see if any folders need work done on them.
 // This runs on an interval ticker in the main go routine.
 func (u *Unpackerr) checkFolderStats(now time.Time) {
 	for name, folder := range u.folders.Folders {
 		switch elapsed := now.Sub(folder.Updated); {
-		case WAITING == folder.Status && elapsed >= u.StartDelay.Duration:
-			// The folder hasn't been written to in a while, extract it.
-			u.extractTrackedItem(name, folder, now)
+		case WAITING == folder.Status:
+			u.checkWaitingFolder(name, folder, now)
 		case EXTRACTEDNOTHING == folder.Status:
 			// Wait until this item hasn't been touched for a while, so it doesn't re-queue.
 			if now.Sub(folder.Updated) > u.StartDelay.Duration {

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -88,6 +88,9 @@ func (u *Unpackerr) extractTrackedItem(name string, folder *Folder, now time.Tim
 		xtractr.CheckR00ForRarFile(getFileList(filepath.Dir(name)), filepath.Base(name)) {
 		u.Printf("[Folder] Removing tracked item without extraction: %v (rar file exists)", name)
 		u.folders.Folders[name].Status = EXTRACTEDNOTHING
+		u.lockHistory()
+		u.updateQueueStatus(&newStatus{Name: name, Status: EXTRACTEDNOTHING}, now, false)
+		u.unlockHistory()
 
 		return
 	}
@@ -308,12 +311,49 @@ func (u *Unpackerr) finishFolderRemnants(folder *Folder, resp *xtractr.Response,
 
 // processEvent is here to process the event in the `*Unpackerr` scope before sending it back to the `*Folders` scope.
 func (u *Unpackerr) processEvent(event *eventData, now time.Time) {
+	if event == nil || event.Config == nil {
+		return
+	}
+
 	// Do not watch our own log file.
 	if event.File == u.LogFile || event.File == u.Webserver.LogFile {
 		return
 	}
 
 	u.folders.ProcessEvent(event, now)
+	u.syncFolderQueue(filepath.Join(event.Config.Path, event.Name))
+}
+
+// syncFolderQueue mirrors a watched folder into the overview queue while it is
+// still tracking writes (before start_delay queues extraction).
+func (u *Unpackerr) syncFolderQueue(dirPath string) {
+	u.lockHistory()
+	defer u.unlockHistory()
+
+	folder, ok := u.folders.Folders[dirPath]
+	if !ok {
+		if item := u.Map[dirPath]; item != nil && item.App == FolderString && item.Status == WAITING {
+			delete(u.Map, dirPath)
+		}
+
+		return
+	}
+
+	if folder.Status != WAITING {
+		return
+	}
+
+	if _, exists := u.Map[dirPath]; !exists {
+		u.updateQueueStatus(&newStatus{Name: dirPath, Status: WAITING}, folder.Updated, false)
+		return
+	}
+
+	item := u.Map[dirPath]
+	if item.Status != WAITING {
+		return
+	}
+
+	item.Updated = folder.Updated
 }
 
 // checkFolderStats runs at an interval to see if any folders need work done on them.
@@ -409,12 +449,12 @@ type newStatus struct {
 // This is used by apps and Folders in a few other places as well.
 func (u *Unpackerr) updateQueueStatus(data *newStatus, now time.Time, sendHook bool) *Extract {
 	if _, ok := u.Map[data.Name]; !ok {
-		// This is a new Folder being queued for extraction.
-		// Arr apps do not land here. They create their own queued items in u.Map.
+		// This is a new Folder item. Arr apps do not land here.
+		// They create their own queued items in u.Map.
 		u.Map[data.Name] = &Extract{
 			Path:    data.Name,
 			App:     FolderString,
-			Status:  QUEUED,
+			Status:  data.Status,
 			Updated: now,
 			IDs:     map[string]any{"title": data.Name}, // required or webhook may break.
 		}

--- a/pkg/unpackerr/folder_track_test.go
+++ b/pkg/unpackerr/folder_track_test.go
@@ -67,3 +67,54 @@ func TestFolderWaitingShowsInQueue(t *testing.T) {
 		t.Fatal("waiting item still in queue after delete")
 	}
 }
+
+func TestCheckFolderStatsDropsMissingWaiting(t *testing.T) {
+	t.Parallel()
+
+	watch := t.TempDir()
+	cfg := &FolderConfig{Path: watch}
+	unpack := New()
+	unpack.Folder.Buffer = 32
+
+	tracker, err := unpack.Folder.NewWatcher([]*FolderConfig{cfg}, unpack.Logger, updateChanBuf, suffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if tracker.Watcher != nil {
+			tracker.Watcher.Close()
+		}
+
+		if tracker.FSNotify != nil {
+			_ = tracker.FSNotify.Close()
+		}
+	})
+
+	unpack.folders = tracker
+
+	archive := filepath.Join(watch, "movie.rar")
+	if err := os.WriteFile(archive, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.processEvent(&eventData{Config: cfg, Name: "movie.rar", File: archive, Op: "test"}, time.Now())
+
+	if unpack.Map[archive] == nil {
+		t.Fatal("expected waiting queue item")
+	}
+
+	if err := os.Remove(archive); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.checkFolderStats(time.Now())
+
+	if unpack.Map[archive] != nil {
+		t.Fatal("waiting item still in queue after checkFolderStats")
+	}
+
+	if _, ok := unpack.folders.Folders[archive]; ok {
+		t.Fatal("folder still tracked after checkFolderStats")
+	}
+}

--- a/pkg/unpackerr/folder_track_test.go
+++ b/pkg/unpackerr/folder_track_test.go
@@ -1,0 +1,69 @@
+package unpackerr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFolderWaitingShowsInQueue(t *testing.T) {
+	t.Parallel()
+
+	watch := t.TempDir()
+	cfg := &FolderConfig{Path: watch}
+	unpack := New()
+
+	unpack.Folder.Buffer = 32
+
+	tracker, err := unpack.Folder.NewWatcher([]*FolderConfig{cfg}, unpack.Logger, updateChanBuf, suffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if tracker.Watcher != nil {
+			tracker.Watcher.Close()
+		}
+
+		if tracker.FSNotify != nil {
+			_ = tracker.FSNotify.Close()
+		}
+	})
+
+	unpack.folders = tracker
+
+	archive := filepath.Join(watch, "movie.rar")
+	if err := os.WriteFile(archive, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first := time.Now().Add(-time.Minute)
+	unpack.processEvent(&eventData{Config: cfg, Name: "movie.rar", File: archive, Op: "test"}, first)
+
+	item := unpack.Map[archive]
+	if item == nil || item.Status != WAITING || item.App != FolderString {
+		t.Fatalf("queue item %+v", item)
+	}
+
+	if got := queueFromExtract(archive, item); got.Progress != "last write" {
+		t.Fatalf("progress %q", got.Progress)
+	}
+
+	later := first.Add(30 * time.Second)
+	unpack.processEvent(&eventData{Config: cfg, Name: "movie.rar", File: archive, Op: "write"}, later)
+
+	if !unpack.Map[archive].Updated.Equal(unpack.folders.Folders[archive].Updated) {
+		t.Fatalf("last write %v folder %v", unpack.Map[archive].Updated, unpack.folders.Folders[archive].Updated)
+	}
+
+	if err := os.Remove(archive); err != nil {
+		t.Fatal(err)
+	}
+
+	unpack.processEvent(&eventData{Config: cfg, Name: "movie.rar", File: archive, Op: "remove"}, later.Add(time.Second))
+
+	if unpack.Map[archive] != nil {
+		t.Fatal("waiting item still in queue after delete")
+	}
+}

--- a/pkg/unpackerr/historyfile.go
+++ b/pkg/unpackerr/historyfile.go
@@ -343,6 +343,10 @@ func queueFromExtract(id string, item *Extract) QueueItem {
 		Updated:    item.Updated,
 	}
 
+	if item.Status == WAITING && item.App == FolderString {
+		queue.Progress = "last write"
+	}
+
 	if item.XProg != nil {
 		if prog := item.XProg.String(); prog != "no progress yet" {
 			queue.Progress = prog


### PR DESCRIPTION
## Summary
- Ignore extract output after xtractr renames `*_unpackerred` to a clean sibling folder (log file and same-stem archive), so copying an ISO does not extract the dest tree as a new drop.
- Mirror watched folders into the queue as `WAITING` until `start_delay`, with progress `last write`, and drop them if the item disappears before extract.

## Test plan
- [ ] Copy an ISO into a watched folder; confirm the renamed dest is not tracked or extracted again.
- [ ] Confirm a normal incoming folder (no extract log, no sibling archive of the same stem) is still tracked.
- [ ] Confirm a watched archive appears in the queue as waiting while it is still being written, then queues after start_delay.
- [ ] `go test ./pkg/folders ./pkg/unpackerr`


Made with [Cursor](https://cursor.com)