### PR TITLE
Do not panic when a Starr HTTP client is nil

### DIFF
--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -21,6 +21,10 @@ type LidarrConfig struct {
 }
 
 func (l *LidarrConfig) pollQueue() (int, int, error) {
+	if l.Lidarr == nil {
+		l.connect()
+	}
+
 	queue, err := l.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting queue: %w", err)

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -14,6 +14,10 @@ type RadarrConfig struct {
 }
 
 func (r *RadarrConfig) pollQueue() (int, int, error) {
+	if r.Radarr == nil {
+		r.connect()
+	}
+
 	queue, err := r.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting queue: %w", err)

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -14,6 +14,10 @@ type ReadarrConfig struct {
 }
 
 func (r *ReadarrConfig) pollQueue() (int, int, error) {
+	if r.Readarr == nil {
+		r.connect()
+	}
+
 	queue, err := r.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting queue: %w", err)

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -14,6 +14,10 @@ type SonarrConfig struct {
 }
 
 func (s *SonarrConfig) pollQueue() (int, int, error) {
+	if s.Sonarr == nil {
+		s.connect()
+	}
+
 	queue, err := s.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting queue: %w", err)

--- a/pkg/unpackerr/starrpoll_nilclient_test.go
+++ b/pkg/unpackerr/starrpoll_nilclient_test.go
@@ -1,0 +1,21 @@
+package unpackerr
+
+import "testing"
+
+func TestPollQueueNilClientDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("panic: %v", rec)
+		}
+	}()
+
+	app := &ReadarrConfig{}
+	app.URL = "http://127.0.0.1:1"
+	app.APIKey = "k"
+
+	if _, _, err := app.pollQueue(); err == nil {
+		t.Fatal("expected a queue request error")
+	}
+}


### PR DESCRIPTION
## Summary
- Call `connect()` in Sonarr/Radarr/Lidarr/Readarr `pollQueue` when the embedded client is nil so a stripped clone cannot SIGSEGV on the next poll.

## Test plan
- [x] `TestPollQueueNilClientDoesNotPanic` (`go test ./pkg/unpackerr/ -run TestPollQueueNilClientDoesNotPanic`).
- [x] After a config PUT that rebuilds Starr apps, the next interval poll should error or succeed, not crash.


Made with [Cursor](https://cursor.com)