### PR TITLE
Count forgotten deleted items and log forgotten imports

### DIFF
--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -179,6 +179,15 @@ func (u *Unpackerr) forgetQueueID(itemID string) error {
 		return errQueueNotForgettable
 	}
 
+	if item.Status == DELETED {
+		u.Finished++
+	}
+
+	if item.Status == IMPORTED {
+		u.Printf("[%s] User forgot imported item; skipping file cleanup: %s (%s)",
+			item.App, itemID, item.Path)
+	}
+
 	delete(u.Map, itemID)
 
 	if item.App != FolderString {

--- a/pkg/unpackerr/queue_actions.go
+++ b/pkg/unpackerr/queue_actions.go
@@ -185,7 +185,7 @@ func (u *Unpackerr) forgetQueueID(itemID string) error {
 
 	if item.Status == IMPORTED {
 		u.Printf("[%s] User forgot imported item; skipping file cleanup: %s (%s)",
-			item.App, itemID, item.Path)
+			item.Label(), itemID, item.Path)
 	}
 
 	delete(u.Map, itemID)

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -1,6 +1,7 @@
 package unpackerr
 
 import (
+	"bytes"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -58,6 +59,49 @@ func TestQueueRetryAndForget(t *testing.T) {
 	missing := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/nope"}`, withKey)
 	if missing.Code != http.StatusNotFound {
 		t.Fatalf("forget missing %d", missing.Code)
+	}
+}
+
+func TestQueueForgetImportedAndDeleted(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	unpack := testAuthUnpackerr(t)
+	unpack.Info.SetOutput(&logs)
+	unpack.Map["/dl/imp"] = &Extract{Path: "/dl/imp", Status: IMPORTED, App: starr.Sonarr}
+	unpack.Map["/dl/gone"] = &Extract{Path: "/dl/gone", Status: DELETED, App: starr.Sonarr}
+
+	withKey := func(req *http.Request) {
+		req.Header.Set(headerAPIKey, unpack.Webserver.adminAPIKey())
+	}
+
+	imp := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/imp"}`, withKey)
+	if imp.Code != http.StatusOK {
+		t.Fatalf("forget imported %d %s", imp.Code, imp.Body.String())
+	}
+
+	if unpack.Finished != 0 {
+		t.Fatalf("imported forget must not count finished: %d", unpack.Finished)
+	}
+
+	if _, exists := unpack.Map["/dl/imp"]; exists {
+		t.Fatal("imported item still in map")
+	}
+
+	logged := logs.String()
+	if !strings.Contains(logged, "User forgot imported item") ||
+		!strings.Contains(logged, "skipping file cleanup") ||
+		!strings.Contains(logged, "/dl/imp") {
+		t.Fatalf("imported forget log: %s", logged)
+	}
+
+	gone := doAuth(t, unpack, http.MethodPost, "/api/queue/forget", `{"id":"/dl/gone"}`, withKey)
+	if gone.Code != http.StatusOK {
+		t.Fatalf("forget deleted %d %s", gone.Code, gone.Body.String())
+	}
+
+	if unpack.Finished != 1 {
+		t.Fatalf("deleted forget should count finished, got %d", unpack.Finished)
 	}
 }
 

--- a/pkg/unpackerr/queue_actions_test.go
+++ b/pkg/unpackerr/queue_actions_test.go
@@ -66,6 +66,7 @@ func TestQueueForgetImportedAndDeleted(t *testing.T) {
 	t.Parallel()
 
 	var logs bytes.Buffer
+
 	unpack := testAuthUnpackerr(t)
 	unpack.Info.SetOutput(&logs)
 	unpack.Map["/dl/imp"] = &Extract{Path: "/dl/imp", Status: IMPORTED, App: starr.Sonarr}


### PR DESCRIPTION
## Summary
- Forgetting a `DELETED` queue item increments `Finished` so totals match a completed delete.
- Forgetting an `IMPORTED` item logs that file cleanup is skipped (the extract dest is left in place).

## Test plan
- [ ] `go test ./pkg/unpackerr/ -run TestQueueForgetImportedAndDeleted`
- [ ] Forget an imported row in the UI: item leaves the queue, files stay, log mentions skipping cleanup.
- [ ] Forget a deleted row: finished count goes up by one.


Made with [Cursor](https://cursor.com)