### PR TITLE
Expose Starr queue snapshots on GET /api/stats

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,9 @@ in mind; the items below have been raised and rejected before.
 - Live `Config` fields are read and written only on the main loop. Do not ask for a
   mutex around `u.StartDelay`, `u.Passwords`, `u.Sonarr`, and similar. If a new reader
   runs on another goroutine, route it through `onMainLoop` instead.
+  Exception: `GET /api/stats` / Prometheus `Collect` read Starr/folder slice headers
+  under `configMu` and the last poll snapshot under `History.mu`. Poll workers publish
+  `Queue` and `last*` after `GetQueue` returns. Do not hop that path onto `onMainLoop`.
 - `retrieveAppQueues` does not need to snapshot the app lists. A config PUT applies on
   the same goroutine, which is parked in `wait.Wait()` until every poll returns.
 - `syncFileUIPassword` is not a lock-order inversion. `uiPassword()` releases

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -41,7 +41,7 @@ Unpackerr is **one process**. One goroutine — `(*Unpackerr).Run()` in `pkg/unp
 
 HTTP handlers **must not** mutate those on the HTTP goroutine. They validate the body, then call `onMainLoop`. Queue retry/forget use the same handoff. Config GET of the **file** snapshot does **not** need the main loop (it is under `configMu`). Config GET of **live** general/starr/folders **does**, because live `Config` is main-loop memory.
 
-If a new reader of live `u.Sonarr` / `u.Passwords` / `u.StartDelay` runs off the main loop, do not add a mutex. Route it through `onMainLoop`.
+`GET /api/stats` (and Prometheus `Collect`) is the exception that reads live Starr/folder slice headers off-loop. That path takes `configMu` for the slice headers (same as hook counts) and `History.mu` for `Queue` / `lastQueued` / `lastRetrieved` / `lastPollErr`. Poll workers publish those fields under the history write lock **after** `GetQueue` returns. Do not hop stats onto `onMainLoop`; that would stall scrapes behind Starr HTTP. Other new readers of live `u.Sonarr` / `u.Passwords` / `u.StartDelay` still go through `onMainLoop`.
 
 ---
 
@@ -105,7 +105,7 @@ What the daemon *runs*: Starr HTTP clients, expanded secrets, hashed UI password
 **HTTP readers that are allowed off-loop:**
 
 - `uiPassMu` covers live webserver **auth** fields HTTP hits every request: `UIPassword`, `APIKeys`, `Roles`, `keyPerms`, `Upstreams`, `allow`. PUT applies those under that lock via `applyLiveWebserverAuth`.
-- Stats/queue/history have their own locks (`History.mu`, `histMu`, `configMu` for hook *counts*).
+- Stats/queue/history have their own locks (`History.mu`, `histMu`, `configMu` for hook/Starr/folder *counts* and the last Starr poll snapshot).
 
 Everything else live is main-loop only.
 
@@ -336,12 +336,14 @@ This file is **ours**. Do not add line-length caps, atomic rename, or `.bak` “
 | Lock | Guards |
 | --- | --- |
 | (none — main loop) | live `Config` minus webserver auth, `Map`, folders, tickers, `pendingRestart` |
-| `configMu` | `fileConfig` + hook slices `/api/stats` counts |
+| `configMu` | `fileConfig` + hook/Starr/folder slices `/api/stats` counts |
 | `uiPassMu` | live webserver auth fields HTTP reads |
 | `histMu` | history records + JSONL |
-| `History.mu` | extract map for HTTP queue GET |
+| `History.mu` | extract map; Starr poll snapshot (`Queue`, `lastQueued`, `lastRetrieved`, `lastPollErr`) |
 
 `syncFileUIPassword` takes `uiPassword()` (uiPassMu) **then** `configMu`. That order is intentional.
+
+`GET /api/stats` takes `History.mu` **then** `configMu`. `commitConfig` holds `configMu` and must not take `History.mu`.
 
 The tray reads live `Config` in `readyTray` **before** `go u.Run()`. A PUT cannot apply until the loop exists and drains `taskChan`. That is not a race.
 

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -28,6 +28,7 @@ func (s *SonarrConfig) conf() *StarrConfig { return &s.StarrConfig }
 func (s *SonarrConfig) connect()           { s.Sonarr = sonarr.New(&s.Config) }
 func (s *SonarrConfig) takeQueue(o *SonarrConfig) {
 	s.Queue = o.Queue
+	s.takePoll(&o.StarrConfig)
 }
 func (s *SonarrConfig) stripRuntime() { s.Queue, s.Sonarr = nil, nil }
 
@@ -35,6 +36,7 @@ func (r *RadarrConfig) conf() *StarrConfig { return &r.StarrConfig }
 func (r *RadarrConfig) connect()           { r.Radarr = radarr.New(&r.Config) }
 func (r *RadarrConfig) takeQueue(o *RadarrConfig) {
 	r.Queue = o.Queue
+	r.takePoll(&o.StarrConfig)
 }
 func (r *RadarrConfig) stripRuntime() { r.Queue, r.Radarr = nil, nil }
 
@@ -42,6 +44,7 @@ func (l *LidarrConfig) conf() *StarrConfig { return &l.StarrConfig }
 func (l *LidarrConfig) connect()           { l.Lidarr = lidarr.New(&l.Config) }
 func (l *LidarrConfig) takeQueue(o *LidarrConfig) {
 	l.Queue = o.Queue
+	l.takePoll(&o.StarrConfig)
 }
 func (l *LidarrConfig) stripRuntime() { l.Queue, l.Lidarr = nil, nil }
 
@@ -49,6 +52,7 @@ func (r *ReadarrConfig) conf() *StarrConfig { return &r.StarrConfig }
 func (r *ReadarrConfig) connect()           { r.Readarr = readarr.New(&r.Config) }
 func (r *ReadarrConfig) takeQueue(o *ReadarrConfig) {
 	r.Queue = o.Queue
+	r.takePoll(&o.StarrConfig)
 }
 func (r *ReadarrConfig) stripRuntime() { r.Queue, r.Readarr = nil, nil }
 

--- a/pkg/unpackerr/configclone.go
+++ b/pkg/unpackerr/configclone.go
@@ -17,7 +17,9 @@ type starrApp[T any] interface {
 	connect()         // build the API client from conf.
 	takeQueue(old *T) // keep the last polled queue from a matching old entry.
 	stripRuntime()    // nil the queue and client on a file-shaped clone.
-	pollQueue() (total, retrieved int, err error)
+	// pollQueue fetches without publishing. The returned bind assigns Queue and
+	// must run under History.mu with lastQueued/lastRetrieved/lastPollErr.
+	pollQueue() (bind func(), total, retrieved int, err error)
 	queueViews() []queueView
 	hasQueueTitle(name string) bool
 	tweakExtract(item *Extract, rec queueView)

--- a/pkg/unpackerr/configput.go
+++ b/pkg/unpackerr/configput.go
@@ -312,7 +312,7 @@ func walkMapStrings(val reflect.Value, visit func(string) error) error {
 
 // commitConfig stages the change onto a clone of fileConfig, writes the TOML,
 // then publishes live. A failed write changes nothing. Runs on the main loop;
-// configMu covers fileConfig and the hook slices that /api/stats reads.
+// configMu covers fileConfig and the hook/Starr/folder slices that /api/stats reads.
 func (u *Unpackerr) commitConfig(mutateFile func(*Config), applyLive func()) error {
 	u.configMu.Lock()
 	defer u.configMu.Unlock()

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -419,11 +419,6 @@ func (u *Unpackerr) getDownloadPath(outputPath, label, title string, paths []str
 	return filepath.Join(paths[0], title) // useless, but return something. :(
 }
 
-// isComplete is run so many times in different places that it became a method.
-func (u *Unpackerr) isComplete(status string, protocol starr.Protocol, protos string) bool {
-	return isComplete(status, protocol, protos)
-}
-
 // added for https://github.com/Unpackerr/unpackerr/issues/235
 func (u *Unpackerr) hasSyncThingFile(dirPath string) string {
 	files, _ := u.GetFileList(dirPath)

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -29,6 +29,20 @@ type StarrConfig struct {
 	// Empty uses that default. `0` or `0B` is unlimited.
 	MaxBytes string `json:"maxBytes" toml:"max_bytes" xml:"max_bytes" yaml:"maxBytes"`
 	maxBytes uint64
+	// Last poll snapshot for GET /api/stats starrQueues.
+	lastQueued    int
+	lastRetrieved int
+	lastPollErr   string
+}
+
+func (c *StarrConfig) takePoll(old *StarrConfig) {
+	if c == nil || old == nil {
+		return
+	}
+
+	c.lastQueued = old.lastQueued
+	c.lastRetrieved = old.lastRetrieved
+	c.lastPollErr = old.lastPollErr
 }
 
 // Label is the human-facing instance name, or app when Name is empty.
@@ -407,13 +421,7 @@ func (u *Unpackerr) getDownloadPath(outputPath, label, title string, paths []str
 
 // isComplete is run so many times in different places that it became a method.
 func (u *Unpackerr) isComplete(status string, protocol starr.Protocol, protos string) bool {
-	for s := range strings.FieldsSeq(strings.ReplaceAll(protos, ",", " ")) {
-		if strings.EqualFold(string(protocol), s) {
-			return strings.EqualFold(status, "completed")
-		}
-	}
-
-	return false
+	return isComplete(status, protocol, protos)
 }
 
 // added for https://github.com/Unpackerr/unpackerr/issues/235

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -29,7 +29,7 @@ type StarrConfig struct {
 	// Empty uses that default. `0` or `0B` is unlimited.
 	MaxBytes string `json:"maxBytes" toml:"max_bytes" xml:"max_bytes" yaml:"maxBytes"`
 	maxBytes uint64
-	// Last poll snapshot for GET /api/stats starrQueues.
+	// Last poll snapshot for GET /api/stats starrQueues. Published under History.mu.
 	lastQueued    int
 	lastRetrieved int
 	lastPollErr   string

--- a/pkg/unpackerr/history.go
+++ b/pkg/unpackerr/history.go
@@ -14,9 +14,10 @@ const (
 )
 
 // History holds the history of extracted items.
-// mu guards Map, Finished, Retries, forgotten, per-item Status/Updated, and XProg
-// progress so HTTP stats, queue snapshots, and Prometheus Collect cannot race
-// the main loop. It is not reentrant; do not lock inside a caller that already holds it.
+// mu guards Map, Finished, Retries, forgotten, per-item Status/Updated, XProg
+// progress, and the Starr poll snapshot (Queue, lastQueued, lastRetrieved,
+// lastPollErr) so HTTP stats and Prometheus Collect cannot race poll workers.
+// It is not reentrant; do not lock inside a caller that already holds it.
 type History struct {
 	mu        sync.RWMutex
 	Items     []string

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -20,19 +20,17 @@ type LidarrConfig struct {
 	*lidarr.Lidarr `json:"-"          toml:"-"          xml:"-"          yaml:"-"`
 }
 
-func (l *LidarrConfig) pollQueue() (int, int, error) {
+func (l *LidarrConfig) pollQueue() (func(), int, int, error) {
 	if l.Lidarr == nil {
 		l.connect()
 	}
 
 	queue, err := l.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
-		return 0, 0, fmt.Errorf("getting queue: %w", err)
+		return nil, 0, 0, fmt.Errorf("getting queue: %w", err)
 	}
 
-	l.Queue = queue
-
-	return queue.TotalRecords, len(queue.Records), nil
+	return func() { l.Queue = queue }, queue.TotalRecords, len(queue.Records), nil
 }
 
 func (l *LidarrConfig) queueViews() []queueView {

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -44,12 +44,13 @@ func (l *LidarrConfig) queueViews() []queueView {
 
 	for _, rec := range l.Queue.Records {
 		out = append(out, queueView{
-			Title:      rec.Title,
-			Status:     rec.Status,
-			Protocol:   rec.Protocol,
-			OutputPath: rec.OutputPath,
-			Size:       rec.Size,
-			Sizeleft:   rec.Sizeleft,
+			Title:         rec.Title,
+			Status:        rec.Status,
+			TrackedStatus: rec.TrackedDownloadStatus,
+			Protocol:      rec.Protocol,
+			OutputPath:    rec.OutputPath,
+			Size:          rec.Size,
+			Sizeleft:      rec.Sizeleft,
 			IDs: map[string]any{
 				"title":      rec.Title,
 				"artistId":   rec.ArtistID,

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -57,13 +57,14 @@ func (u *Unpackerr) logCurrentQueue(now time.Time) {
 		stats.Waiting, stats.Queued, stats.Extracting, stats.Extracted, stats.Imported, stats.Failed, stats.Deleted)
 
 	u.Printf("[Unpackerr] Totals: %d retries, %d finished, %d|%d webhooks,"+
-		" %d|%d cmdhooks, stacks; event:%d, hook:%d, del:%d, up %s",
+		" %d|%d cmdhooks, stacks; fs:%d/%d, xtractr:%d/%d, folder:%d/%d, hook:%d/%d, del:%d/%d, task:%d/%d, up %s",
 		stats.Retries, stats.Finished, stats.HookOK, stats.HookFail, stats.CmdOK, stats.CmdFail,
-		len(u.folders.Events)+len(u.updates)+len(u.folders.Updates), u.hookWorker.Len(), len(u.delChan),
+		stats.StackFS.Len, stats.StackFS.Cap, stats.StackXtractr.Len, stats.StackXtractr.Cap,
+		stats.StackFolder.Len, stats.StackFolder.Cap, stats.StackHook.Len, stats.StackHook.Cap,
+		stats.StackDel.Len, stats.StackDel.Cap, stats.StackTask.Len, stats.StackTask.Cap,
 		carbon.CreateFromStdTime(version.Started).DiffAbsInString(carbon.CreateFromStdTime(now)))
 
-	u.updateTray(stats, uint(len(u.folders.Events)+len(u.updates)+
-		len(u.folders.Updates)+len(u.delChan)+u.hookWorker.Len()))
+	u.updateTray(stats, stats.stackTotal())
 }
 
 // setupLogging splits log write into a file and/or stdout.

--- a/pkg/unpackerr/metrics.go
+++ b/pkg/unpackerr/metrics.go
@@ -153,32 +153,88 @@ func (u *Unpackerr) setupMetrics() {
 
 // Stats is filled and returned when a stats request is issued.
 type Stats struct {
-	Waiting    uint `json:"waiting"`
-	Queued     uint `json:"queued"`
-	Extracting uint `json:"extracting"`
-	Failed     uint `json:"failed"`
-	Extracted  uint `json:"extracted"`
-	Imported   uint `json:"imported"`
-	Deleted    uint `json:"deleted"`
-	HookOK     uint `json:"hookOK"`
-	HookFail   uint `json:"hookFail"`
-	CmdOK      uint `json:"cmdOK"`
-	CmdFail    uint `json:"cmdFail"`
-	Retries    uint `json:"retries"`
-	Finished   uint `json:"finished"`
+	Waiting      uint             `json:"waiting"`
+	Queued       uint             `json:"queued"`
+	Extracting   uint             `json:"extracting"`
+	Failed       uint             `json:"failed"`
+	Extracted    uint             `json:"extracted"`
+	Imported     uint             `json:"imported"`
+	Deleted      uint             `json:"deleted"`
+	HookOK       uint             `json:"hookOK"`
+	HookFail     uint             `json:"hookFail"`
+	CmdOK        uint             `json:"cmdOK"`
+	CmdFail      uint             `json:"cmdFail"`
+	Retries      uint             `json:"retries"`
+	Finished     uint             `json:"finished"`
+	Starrs       uint             `json:"starrs"`
+	Folders      uint             `json:"folders"`
+	Webhooks     uint             `json:"webhooks"`
+	Cmdhooks     uint             `json:"cmdhooks"`
+	StackFS      BufferStat       `json:"stackFS"`
+	StackXtractr BufferStat       `json:"stackXtractr"`
+	StackFolder  BufferStat       `json:"stackFolder"`
+	StackHook    BufferStat       `json:"stackHook"`
+	StackDel     BufferStat       `json:"stackDel"`
+	StackTask    BufferStat       `json:"stackTask"`
+	StarrQueues  []StarrQueueStat `json:"starrQueues,omitempty"`
+}
+
+// BufferStat is occupancy and capacity of one internal channel.
+type BufferStat struct {
+	Len uint `json:"len"`
+	Cap uint `json:"cap"`
+}
+
+func (s *Stats) stackTotal() uint {
+	if s == nil {
+		return 0
+	}
+
+	return s.StackFS.Len + s.StackXtractr.Len + s.StackFolder.Len +
+		s.StackHook.Len + s.StackDel.Len + s.StackTask.Len
+}
+
+func chanStat[T any](ch <-chan T) BufferStat {
+	return BufferStat{Len: uint(len(ch)), Cap: uint(cap(ch))}
+}
+
+// StarrQueueStat is one Starr instance's last activity-queue poll.
+type StarrQueueStat struct {
+	App         string `json:"app"`
+	Name        string `json:"name"`
+	URL         string `json:"url,omitempty"`
+	Queued      int    `json:"queued"`
+	Retrieved   int    `json:"retrieved"`
+	Complete    int    `json:"complete"`
+	Match       int    `json:"match"`
+	Issues      int    `json:"issues"`
+	Downloading int    `json:"downloading"`
+	Error       string `json:"error,omitempty"`
 }
 
 // stats compiles and builds the statistics for the app.
 func (u *Unpackerr) stats() *Stats {
 	stats := &Stats{}
-	stats.HookOK, stats.HookFail = u.WebhookCounts()
-	stats.CmdOK, stats.CmdFail = u.CmdhookCounts()
 
 	u.rLockHistory()
 	defer u.rUnlockHistory()
 
+	u.fillQueueStats(stats)
+
+	return stats
+}
+
+func (u *Unpackerr) fillQueueStats(stats *Stats) {
 	stats.Retries = u.Retries
 	stats.Finished = u.Finished
+	stats.Starrs = uint(u.starrAppCount())
+	stats.Folders = uint(len(u.Folders))
+	stats.Webhooks = uint(len(u.hookList()))
+	stats.Cmdhooks = uint(len(u.cmdhookList()))
+	stats.HookOK, stats.HookFail = u.WebhookCounts()
+	stats.CmdOK, stats.CmdFail = u.CmdhookCounts()
+	u.fillStackDepths(stats)
+	stats.StarrQueues = u.starrQueueStats()
 
 	for name := range u.Map {
 		switch u.Map[name].Status {
@@ -198,6 +254,20 @@ func (u *Unpackerr) stats() *Stats {
 			stats.Imported++
 		}
 	}
+}
 
-	return stats
+// fillStackDepths is channel occupancy for the totals log and /api/stats stacks.
+func (u *Unpackerr) fillStackDepths(stats *Stats) {
+	stats.StackXtractr = chanStat(u.updates)
+	stats.StackDel = chanStat(u.delChan)
+	stats.StackTask = chanStat(u.taskChan)
+
+	if u.folders != nil {
+		stats.StackFS = chanStat(u.folders.Events)
+		stats.StackFolder = chanStat(u.folders.Updates)
+	}
+
+	if u.hookWorker != nil {
+		stats.StackHook = BufferStat{Len: uint(u.hookWorker.Len()), Cap: uint(u.hookWorker.Cap())}
+	}
 }

--- a/pkg/unpackerr/metrics.go
+++ b/pkg/unpackerr/metrics.go
@@ -227,14 +227,16 @@ func (u *Unpackerr) stats() *Stats {
 func (u *Unpackerr) fillQueueStats(stats *Stats) {
 	stats.Retries = u.Retries
 	stats.Finished = u.Finished
+	u.configMu.RLock()
 	stats.Starrs = uint(u.starrAppCount())
 	stats.Folders = uint(len(u.Folders))
+	stats.StarrQueues = u.starrQueueStats()
+	u.configMu.RUnlock()
 	stats.Webhooks = uint(len(u.hookList()))
 	stats.Cmdhooks = uint(len(u.cmdhookList()))
 	stats.HookOK, stats.HookFail = u.WebhookCounts()
 	stats.CmdOK, stats.CmdFail = u.CmdhookCounts()
 	u.fillStackDepths(stats)
-	stats.StarrQueues = u.starrQueueStats()
 
 	for name := range u.Map {
 		switch u.Map[name].Status {

--- a/pkg/unpackerr/openapi.json
+++ b/pkg/unpackerr/openapi.json
@@ -90,7 +90,43 @@
           "cmdOK": {"type": "integer"},
           "cmdFail": {"type": "integer"},
           "retries": {"type": "integer"},
-          "finished": {"type": "integer"}
+          "finished": {"type": "integer"},
+          "starrs": {"type": "integer", "description": "Configured Sonarr+Radarr+Lidarr+Readarr instance count"},
+          "folders": {"type": "integer", "description": "Configured watch-folder count"},
+          "webhooks": {"type": "integer", "description": "Configured webhook count"},
+          "cmdhooks": {"type": "integer", "description": "Configured command-hook count"},
+          "stackFS": {"$ref": "#/components/schemas/BufferStat", "description": "Folder-watch filesystem event channel"},
+          "stackXtractr": {"$ref": "#/components/schemas/BufferStat", "description": "Starr extract callback channel"},
+          "stackFolder": {"$ref": "#/components/schemas/BufferStat", "description": "Folder-watch extract callback channel"},
+          "stackHook": {"$ref": "#/components/schemas/BufferStat", "description": "Webhook and command-hook delivery channel"},
+          "stackDel": {"$ref": "#/components/schemas/BufferStat", "description": "File-delete job channel"},
+          "stackTask": {"$ref": "#/components/schemas/BufferStat", "description": "Config apply and queue-action channel"},
+          "starrQueues": {
+            "type": "array",
+            "description": "Last activity-queue poll per configured Starr app",
+            "items": {
+              "type": "object",
+              "properties": {
+                "app": {"type": "string"},
+                "name": {"type": "string"},
+                "url": {"type": "string"},
+                "queued": {"type": "integer", "description": "Starr TotalRecords"},
+                "retrieved": {"type": "integer", "description": "Records returned this poll"},
+                "complete": {"type": "integer", "description": "Retrieved items with Status completed"},
+                "match": {"type": "integer", "description": "Completed items whose protocol is in this instance's protocol list"},
+                "issues": {"type": "integer", "description": "Retrieved items that failed, warned, or have a tracked-download error/warning"},
+                "downloading": {"type": "integer", "description": "Retrieved items with Status downloading"},
+                "error": {"type": "string"}
+              }
+            }
+          }
+        }
+      },
+      "BufferStat": {
+        "type": "object",
+        "properties": {
+          "len": {"type": "integer", "description": "Items currently queued"},
+          "cap": {"type": "integer", "description": "Channel capacity"}
         }
       },
       "SystemInfo": {

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -13,19 +13,17 @@ type RadarrConfig struct {
 	*radarr.Radarr `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
-func (r *RadarrConfig) pollQueue() (int, int, error) {
+func (r *RadarrConfig) pollQueue() (func(), int, int, error) {
 	if r.Radarr == nil {
 		r.connect()
 	}
 
 	queue, err := r.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
-		return 0, 0, fmt.Errorf("getting queue: %w", err)
+		return nil, 0, 0, fmt.Errorf("getting queue: %w", err)
 	}
 
-	r.Queue = queue
-
-	return queue.TotalRecords, len(queue.Records), nil
+	return func() { r.Queue = queue }, queue.TotalRecords, len(queue.Records), nil
 }
 
 func (r *RadarrConfig) queueViews() []queueView {

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -37,12 +37,14 @@ func (r *RadarrConfig) queueViews() []queueView {
 
 	for _, rec := range r.Queue.Records {
 		out = append(out, queueView{
-			Title:      rec.Title,
-			Status:     rec.Status,
-			Protocol:   rec.Protocol,
-			OutputPath: rec.OutputPath,
-			Size:       rec.Size,
-			Sizeleft:   rec.Sizeleft,
+			Title:         rec.Title,
+			Status:        rec.Status,
+			TrackedStatus: rec.TrackedDownloadStatus,
+			TrackedState:  rec.TrackedDownloadState,
+			Protocol:      rec.Protocol,
+			OutputPath:    rec.OutputPath,
+			Size:          rec.Size,
+			Sizeleft:      rec.Sizeleft,
 			IDs: map[string]any{
 				"downloadId": rec.DownloadID,
 				"title":      rec.Title,

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -37,12 +37,14 @@ func (r *ReadarrConfig) queueViews() []queueView {
 
 	for _, rec := range r.Queue.Records {
 		out = append(out, queueView{
-			Title:      rec.Title,
-			Status:     rec.Status,
-			Protocol:   rec.Protocol,
-			OutputPath: rec.OutputPath,
-			Size:       rec.Size,
-			Sizeleft:   rec.Sizeleft,
+			Title:         rec.Title,
+			Status:        rec.Status,
+			TrackedStatus: rec.TrackedDownloadStatus,
+			TrackedState:  rec.TrackedDownloadState,
+			Protocol:      rec.Protocol,
+			OutputPath:    rec.OutputPath,
+			Size:          rec.Size,
+			Sizeleft:      rec.Sizeleft,
 			IDs: map[string]any{
 				"title":      rec.Title,
 				"authorId":   rec.AuthorID,

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -13,19 +13,17 @@ type ReadarrConfig struct {
 	*readarr.Readarr `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
-func (r *ReadarrConfig) pollQueue() (int, int, error) {
+func (r *ReadarrConfig) pollQueue() (func(), int, int, error) {
 	if r.Readarr == nil {
 		r.connect()
 	}
 
 	queue, err := r.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
-		return 0, 0, fmt.Errorf("getting queue: %w", err)
+		return nil, 0, 0, fmt.Errorf("getting queue: %w", err)
 	}
 
-	r.Queue = queue
-
-	return queue.TotalRecords, len(queue.Records), nil
+	return func() { r.Queue = queue }, queue.TotalRecords, len(queue.Records), nil
 }
 
 func (r *ReadarrConfig) queueViews() []queueView {

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -37,13 +37,15 @@ func (s *SonarrConfig) queueViews() []queueView {
 
 	for _, rec := range s.Queue.Records {
 		out = append(out, queueView{
-			Title:      rec.Title,
-			Status:     rec.Status,
-			Protocol:   rec.Protocol,
-			OutputPath: rec.OutputPath,
-			Size:       rec.Size,
-			Sizeleft:   rec.Sizeleft,
-			DebugExtra: fmt.Sprintf(" (Ep: %v)", rec.EpisodeID),
+			Title:         rec.Title,
+			Status:        rec.Status,
+			TrackedStatus: rec.TrackedDownloadStatus,
+			TrackedState:  rec.TrackedDownloadState,
+			Protocol:      rec.Protocol,
+			OutputPath:    rec.OutputPath,
+			Size:          rec.Size,
+			Sizeleft:      rec.Sizeleft,
+			DebugExtra:    fmt.Sprintf(" (Ep: %v)", rec.EpisodeID),
 			IDs: map[string]any{
 				"title":      rec.Title,
 				"downloadId": rec.DownloadID,

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -13,19 +13,17 @@ type SonarrConfig struct {
 	*sonarr.Sonarr `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
-func (s *SonarrConfig) pollQueue() (int, int, error) {
+func (s *SonarrConfig) pollQueue() (func(), int, int, error) {
 	if s.Sonarr == nil {
 		s.connect()
 	}
 
 	queue, err := s.GetQueue(DefaultQueuePageSize, 1)
 	if err != nil {
-		return 0, 0, fmt.Errorf("getting queue: %w", err)
+		return nil, 0, 0, fmt.Errorf("getting queue: %w", err)
 	}
 
-	s.Queue = queue
-
-	return queue.TotalRecords, len(queue.Records), nil
+	return func() { s.Queue = queue }, queue.TotalRecords, len(queue.Records), nil
 }
 
 func (s *SonarrConfig) queueViews() []queueView {

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -11,11 +11,12 @@ import (
 
 // queueView is the subset of a Starr queue record Unpackerr needs to start an extract.
 type queueView struct {
-	Title, Status, OutputPath string
-	Protocol                  starr.Protocol
-	Size, Sizeleft            float64
-	IDs                       map[string]any
-	DebugExtra                string
+	Title, Status, OutputPath   string
+	TrackedStatus, TrackedState string
+	Protocol                    starr.Protocol
+	Size, Sizeleft              float64
+	IDs                         map[string]any
+	DebugExtra                  string
 }
 
 func validateStarrList[T any, P starrApp[T]](unpack *Unpackerr, list *[]P, app starr.App) error {
@@ -81,10 +82,15 @@ func (u *Unpackerr) getStarrQueue[T any, P starrApp[T]](server P, app starr.App,
 
 	total, retrieved, err := server.pollQueue()
 	if err != nil {
+		cfg.lastPollErr = err.Error()
 		u.saveQueueMetrics(0, start, app, cfg.URL, label, err)
+
 		return
 	}
 
+	cfg.lastQueued = total
+	cfg.lastRetrieved = retrieved
+	cfg.lastPollErr = ""
 	u.saveQueueMetrics(total, start, app, cfg.URL, label, nil)
 
 	if !u.Activity || total > 0 {
@@ -140,6 +146,88 @@ func haveStarrQitem[T any, P starrApp[T]](list []P, name string) bool {
 	for _, server := range list {
 		if server.hasQueueTitle(name) {
 			return true
+		}
+	}
+
+	return false
+}
+
+func (u *Unpackerr) starrQueueStats() []StarrQueueStat {
+	n := u.starrAppCount()
+	if n == 0 {
+		return nil
+	}
+
+	out := make([]StarrQueueStat, 0, n)
+	out = append(out, starrQueueRows(u.Lidarr, starr.Lidarr)...)
+	out = append(out, starrQueueRows(u.Radarr, starr.Radarr)...)
+	out = append(out, starrQueueRows(u.Readarr, starr.Readarr)...)
+	out = append(out, starrQueueRows(u.Sonarr, starr.Sonarr)...)
+
+	return out
+}
+
+func starrQueueRows[T any, P starrApp[T]](list []P, app starr.App) []StarrQueueStat {
+	out := make([]StarrQueueStat, 0, len(list))
+
+	for _, server := range list {
+		cfg := server.conf()
+		counts := tallyQueueViews(server.queueViews(), cfg.Protocols)
+		out = append(out, StarrQueueStat{
+			App:         string(app),
+			Name:        cfg.Label(app),
+			URL:         cfg.URL,
+			Queued:      cfg.lastQueued,
+			Retrieved:   cfg.lastRetrieved,
+			Complete:    counts.complete,
+			Match:       counts.match,
+			Issues:      counts.issues,
+			Downloading: counts.downloading,
+			Error:       cfg.lastPollErr,
+		})
+	}
+
+	return out
+}
+
+type queueStatusCounts struct {
+	complete, match, issues, downloading int
+}
+
+func tallyQueueViews(views []queueView, protocols string) queueStatusCounts {
+	var counts queueStatusCounts
+
+	for _, rec := range views {
+		status := strings.ToLower(rec.Status)
+		tracked := strings.ToLower(rec.TrackedStatus)
+		state := strings.ToLower(rec.TrackedState)
+
+		if status == "completed" {
+			counts.complete++
+		}
+
+		if isComplete(rec.Status, rec.Protocol, protocols) {
+			counts.match++
+		}
+
+		if status == "failed" || status == "warning" ||
+			tracked == "error" || tracked == "warning" ||
+			strings.Contains(state, "fail") {
+			counts.issues++
+		}
+
+		if status == "downloading" {
+			counts.downloading++
+		}
+	}
+
+	return counts
+}
+
+func isComplete(status string, protocol starr.Protocol, protos string) bool {
+	for s := range strings.FieldsSeq(strings.ReplaceAll(protos, ",", " ")) {
+		if strings.EqualFold(string(protocol), s) {
+			return strings.EqualFold(status, "completed")
 		}
 	}
 

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -80,22 +80,40 @@ func (u *Unpackerr) getStarrQueue[T any, P starrApp[T]](server P, app starr.App,
 		return
 	}
 
-	total, retrieved, err := server.pollQueue()
+	bind, total, retrieved, err := server.pollQueue()
+	u.publishStarrPoll(cfg, bind, total, retrieved, err)
+
 	if err != nil {
-		cfg.lastPollErr = err.Error()
 		u.saveQueueMetrics(0, start, app, cfg.URL, label, err)
 
 		return
 	}
 
-	cfg.lastQueued = total
-	cfg.lastRetrieved = retrieved
-	cfg.lastPollErr = ""
 	u.saveQueueMetrics(total, start, app, cfg.URL, label, nil)
 
 	if !u.Activity || total > 0 {
 		u.Printf("[%s] Updated (%s): %d Items Queued, %d Retrieved", label, cfg.URL, total, retrieved)
 	}
+}
+
+// publishStarrPoll stores the last poll snapshot under History.mu so HTTP
+// stats() and Prometheus Collect cannot race the pointer swap or lastPollErr.
+// GetQueue stays outside this lock.
+func (u *Unpackerr) publishStarrPoll(cfg *StarrConfig, bind func(), total, retrieved int, err error) {
+	u.lockHistory()
+	defer u.unlockHistory()
+
+	if err != nil {
+		cfg.lastPollErr = err.Error()
+
+		return
+	}
+
+	bind()
+
+	cfg.lastQueued = total
+	cfg.lastRetrieved = retrieved
+	cfg.lastPollErr = ""
 }
 
 func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app starr.App, now time.Time) {

--- a/pkg/unpackerr/starrpoll.go
+++ b/pkg/unpackerr/starrpoll.go
@@ -130,9 +130,9 @@ func checkStarrQueue[T any, P starrApp[T]](unpack *Unpackerr, list []P, app star
 			}
 
 			switch {
-			case found && item.Status == EXTRACTED && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols):
+			case found && item.Status == EXTRACTED && isComplete(rec.Status, rec.Protocol, cfg.Protocols):
 				unpack.Debugf("%s (%s): Item Waiting for Import (%s): %v", cfg.Label(app), cfg.URL, rec.Protocol, rec.Title)
-			case !found && unpack.isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
+			case !found && isComplete(rec.Status, rec.Protocol, cfg.Protocols) && !unpack.isForgotten(rec.Title):
 				waiting := &Extract{
 					App:         app,
 					Name:        cfg.Name,

--- a/pkg/unpackerr/starrpoll_nilclient_test.go
+++ b/pkg/unpackerr/starrpoll_nilclient_test.go
@@ -15,7 +15,7 @@ func TestPollQueueNilClientDoesNotPanic(t *testing.T) {
 	app.URL = "http://127.0.0.1:1"
 	app.APIKey = "k"
 
-	if _, _, err := app.pollQueue(); err == nil {
+	if _, _, _, err := app.pollQueue(); err == nil {
 		t.Fatal("expected a queue request error")
 	}
 }

--- a/pkg/unpackerr/starrpoll_test.go
+++ b/pkg/unpackerr/starrpoll_test.go
@@ -11,6 +11,7 @@ import (
 	"golift.io/starr/radarr"
 	"golift.io/starr/readarr"
 	"golift.io/starr/sonarr"
+	"golift.io/xtractr"
 )
 
 func TestQueueViewsIDs(t *testing.T) {
@@ -196,5 +197,152 @@ func TestStarrConfigLabel(t *testing.T) {
 	cfg := &StarrConfig{Name: "  Sportarr "}
 	if got := cfg.Label(starr.Sonarr); got != "Sportarr" {
 		t.Fatalf("named Label: %q", got)
+	}
+}
+
+func TestTallyQueueViews(t *testing.T) {
+	t.Parallel()
+
+	got := tallyQueueViews([]queueView{
+		{Status: "completed", Protocol: "torrent"},
+		{Status: "Completed", Protocol: "usenet", TrackedStatus: "error"},
+		{Status: "failed"},
+		{Status: "downloading"},
+		{Status: "paused", TrackedState: "downloadFailed"},
+		{Status: "queued"},
+		{Status: "warning"},
+		{Status: "completed", TrackedStatus: "warning"},
+	}, "torrent")
+	if got.complete != 3 || got.match != 1 || got.issues != 5 || got.downloading != 1 {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestStarrQueueStatsCountsRecords(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{
+		Name: "Sportarr", Protocols: "torrent", lastQueued: 6, lastRetrieved: 4,
+		Queue: &sonarr.Queue{Records: []*sonarr.QueueRecord{
+			{Status: "completed", Protocol: "torrent"},
+			{Status: "completed", Protocol: "usenet", TrackedDownloadStatus: "error"},
+			{Status: "failed"},
+			{Status: "downloading"},
+			{Status: "warning"},
+		}},
+	}}
+
+	stats := &Stats{}
+	unpack.fillQueueStats(stats)
+
+	got := stats.StarrQueues[0]
+	if got.Queued != 6 || got.Retrieved != 4 || got.Complete != 2 || got.Match != 1 ||
+		got.Issues != 3 || got.Downloading != 1 {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestFillQueueStatsConfigCounts(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{}, {}}
+	unpack.Radarr = []*RadarrConfig{{}}
+	unpack.Folders = []*FolderConfig{{Path: "/watch"}, {Path: "/other"}}
+	unpack.Finished = 9
+	unpack.Map["live"] = &Extract{Status: IMPORTED, Updated: time.Now()}
+	unpack.Map["out"] = &Extract{Status: EXTRACTED, Updated: time.Now()}
+
+	stats := &Stats{}
+	unpack.fillQueueStats(stats)
+
+	if stats.Starrs != 3 {
+		t.Fatalf("starrs %d", stats.Starrs)
+	}
+
+	if stats.Folders != 2 {
+		t.Fatalf("folders %d", stats.Folders)
+	}
+
+	unpack.Webhook = []*WebhookConfig{{}}
+
+	stats = &Stats{}
+	unpack.fillQueueStats(stats)
+
+	if stats.Webhooks != 1 || stats.Cmdhooks != 0 {
+		t.Fatalf("hooks configured webhook:%d cmd:%d", stats.Webhooks, stats.Cmdhooks)
+	}
+
+	if stats.Imported != 1 {
+		t.Fatalf("live imported %d", stats.Imported)
+	}
+
+	if stats.Extracted != 1 || stats.Finished != 9 {
+		t.Fatalf("extracted %d finished %d", stats.Extracted, stats.Finished)
+	}
+
+	if len(stats.StarrQueues) != 3 {
+		t.Fatalf("starr queues %d", len(stats.StarrQueues))
+	}
+}
+
+func TestFillStackDepthsSplitsChannels(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.folders.Events = make(chan *eventData, 8)
+
+	unpack.folders.Updates = make(chan *xtractr.Response, 8)
+	unpack.folders.Events <- &eventData{}
+
+	unpack.folders.Events <- &eventData{}
+
+	unpack.folders.Updates <- &xtractr.Response{}
+
+	unpack.updates <- &xtractr.Response{}
+
+	unpack.delChan <- &fileDeleteReq{}
+
+	unpack.taskChan <- nil
+
+	stats := &Stats{}
+	unpack.fillStackDepths(stats)
+
+	if stats.StackFS != (BufferStat{Len: 2, Cap: 8}) ||
+		stats.StackFolder != (BufferStat{Len: 1, Cap: 8}) ||
+		stats.StackXtractr != (BufferStat{Len: 1, Cap: updateChanBuf}) ||
+		stats.StackDel != (BufferStat{Len: 1, Cap: updateChanBuf}) ||
+		stats.StackTask != (BufferStat{Len: 1, Cap: updateChanBuf}) ||
+		stats.StackHook != (BufferStat{Len: 0, Cap: updateChanBuf}) {
+		t.Fatalf("%+v", stats)
+	}
+
+	if stats.stackTotal() != 6 {
+		t.Fatalf("stack total %d", stats.stackTotal())
+	}
+}
+
+func TestStarrQueueStatsShowsPollCounts(t *testing.T) {
+	t.Parallel()
+
+	unpack := New()
+	unpack.Sonarr = []*SonarrConfig{{}}
+	unpack.Sonarr[0].Name = "Sportarr"
+	unpack.Sonarr[0].URL = "http://127.0.0.1:8989"
+	unpack.Sonarr[0].lastQueued = 12
+	unpack.Sonarr[0].lastRetrieved = 8
+	unpack.Sonarr[0].lastPollErr = "timeout"
+
+	stats := &Stats{}
+	unpack.fillQueueStats(stats)
+
+	if len(stats.StarrQueues) != 1 {
+		t.Fatalf("starr queues %d", len(stats.StarrQueues))
+	}
+
+	got := stats.StarrQueues[0]
+	if got.Name != "Sportarr" || got.Queued != 12 || got.Retrieved != 8 || got.Error != "timeout" {
+		t.Fatalf("%+v", got)
 	}
 }

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -82,7 +82,7 @@ type Unpackerr struct {
 	menu     map[string]ui.MenuItem
 	// Live Config is owned by the main goroutine in Run(). fileConfig is the
 	// on-disk shape (filepath: values kept) and is also written by the tray,
-	// so it and the hook slices that /api/stats counts sit under configMu.
+	// so it and the hook/Starr/folder slices that /api/stats counts sit under configMu.
 	fileConfig       *Config
 	envUsed          map[string]string // UN_* suffixes that ParseENV wrote; immutable after startup
 	livePasswords    StringSlice       // post-env, pre-expansion; GET /live uses this


### PR DESCRIPTION
## Summary
- Persist each Starr poll (`queued`/`retrieved`/`error`) and tally retrieved records (complete, protocol match, issues, downloading) onto `GET /api/stats` as `starrQueues`.
- Add configured Starr/folder/hook counts plus per-channel stack occupancy (`stackFS`, `stackXtractr`, `stackFolder`, `stackHook`, `stackDel`, `stackTask`) and print those `len/cap` pairs in the totals log.
- Carry poll snapshot fields across config clone so a PUT does not wipe the last poll.

## Test plan
- [ ] `GET /api/stats` after a Starr poll includes `starrQueues` with queued/retrieved and status tallies
- [ ] Totals log shows `fs:0/N, xtractr:0/N, folder:0/N, hook:0/N, del:0/N, task:0/N`
- [ ] PUT that keeps the same Starr URL still reports the previous poll counts until the next interval


Made with [Cursor](https://cursor.com)